### PR TITLE
Feat(integrity): Add ServiceType ActionHash fields to Request/Offer structs (Issue #39)

### DIFF
--- a/dnas/requests_and_offers/zomes/integrity/offers/src/offer.rs
+++ b/dnas/requests_and_offers/zomes/integrity/offers/src/offer.rs
@@ -9,8 +9,6 @@ pub struct Offer {
   pub title: String,
   /// A detailed description of the offer
   pub description: String,
-  /// The capabilities or skills being offered
-  pub capabilities: Vec<String>,
   /// The preferred time of day for the offer
   pub time_preference: TimePreference,
   /// The time zone for the offer
@@ -21,6 +19,8 @@ pub struct Offer {
   pub interaction_type: InteractionType,
   /// Links related to the offer
   pub links: Vec<String>,
+  /// ActionHashes of ServiceType entries linked to this offer
+  pub service_type_action_hashes: Vec<ActionHash>,
 }
 
 /// Validates an offer entry
@@ -43,13 +43,6 @@ pub fn validate_offer(offer: Offer) -> ExternResult<ValidateCallbackResult> {
   if offer.description.len() > 500 {
     return Ok(ValidateCallbackResult::Invalid(
       "Offer description cannot exceed 500 characters".to_string(),
-    ));
-  }
-
-  // Validate capabilities
-  if offer.capabilities.is_empty() {
-    return Ok(ValidateCallbackResult::Invalid(
-      "Offer must have at least one capability".to_string(),
     ));
   }
 

--- a/dnas/requests_and_offers/zomes/integrity/requests/src/request.rs
+++ b/dnas/requests_and_offers/zomes/integrity/requests/src/request.rs
@@ -11,8 +11,6 @@ pub struct Request {
   pub title: String,
   /// A detailed description of the request
   pub description: String,
-  /// The requirements associated with the request (formerly skills)
-  pub requirements: Vec<String>,
   /// The contact preference for the request
   pub contact_preference: ContactPreference,
   /// The date range for the request
@@ -29,6 +27,8 @@ pub struct Request {
   pub interaction_type: InteractionType,
   /// Links related to the request
   pub links: Vec<String>,
+  /// ActionHashes of ServiceType entries linked to this request
+  pub service_type_action_hashes: Vec<ActionHash>,
 }
 
 /// Validates a request entry
@@ -51,13 +51,6 @@ pub fn validate_request(request: Request) -> ExternResult<ValidateCallbackResult
   if request.description.len() > 500 {
     return Ok(ValidateCallbackResult::Invalid(
       "Request description cannot exceed 500 characters".to_string(),
-    ));
-  }
-
-  // Validate requirements (formerly skills)
-  if request.requirements.is_empty() {
-    return Ok(ValidateCallbackResult::Invalid(
-      "Request must have at least one requirement".to_string(),
     ));
   }
 


### PR DESCRIPTION
This PR introduces the `service_type_action_hashes: Vec<ActionHash>` field to both the `Request` and `Offer` integrity structs. This is part of the work for issue #39 to transition from string-based service/skill representations to a structured `ServiceType` DHT entry system.