### PR TITLE
test(e2e): add fast smoke-test layer for core route health

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,7 @@
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
     "test:e2e": "cross-env E2E_UI_PORT=8880 playwright test",
+    "test:e2e:smoke": "cross-env E2E_UI_PORT=8880 playwright test --grep @smoke",
     "test:e2e:ui": "cross-env E2E_UI_PORT=8880 playwright test --ui",
     "test:e2e:debug": "cross-env E2E_UI_PORT=8880 playwright test --debug",
     "test:e2e:verbose": "cross-env E2E_UI_PORT=8880 E2E_VERBOSE=true playwright test",

--- a/ui/tests/e2e/README.md
+++ b/ui/tests/e2e/README.md
@@ -4,7 +4,8 @@ Full-coverage Playwright suite driving the real UI against a live sandbox conduc
 
 ```bash
 bun build:happ        # once, from the repo root (needs nix)
-cd ui && bun test:e2e
+cd ui && bun test:e2e         # the full ordered journey (~5.5 min)
+cd ui && bun test:e2e:smoke   # fast health check only (grep @smoke)
 ```
 
 ## Architecture: one ordered journey
@@ -22,6 +23,12 @@ The infrastructure shares **one conductor and one agent identity across the whol
 | `06-organizations` | create via form, pending-visibility rule, dashboard approval, coordinator edit, status history |
 | `07-users-directory` | public directory and profile page |
 | `08-hrea` | hREA test interface smoke (the hApp bundles the hREA role) |
+
+## Smoke layer
+
+`smoke.spec.ts` is a **fast health check** sitting beside the journey: it loads every core route (`/`, `/service-types`, `/offers`, `/requests`, `/organizations`, `/users`, `/admin`, `/admin/hrea-test`) and asserts each mounts a durable landmark without rendering a failure banner. A broken build, a routing regression, a dead connection, or a page that throws on mount all surface here in seconds. Run it alone with `bun test:e2e:smoke` (greps the `@smoke` tag).
+
+It is **unnumbered on purpose**: Playwright orders spec files by filename and letters sort after digits, so smoke runs LAST in a full run — after `00-onboarding` has created and accepted the primary user, leaving that chapter's fresh-conductor assumptions intact. Standalone (or via grep on the freshly-wiped sandbox) it seeds its own accepted user through `ensureAcceptedUser`, so it never depends on ordering. Scope is deliberately shallow — deep CRUD lives in the numbered chapters, multi-agent flows in Sweettest.
 
 **Every spec is also standalone-runnable** (`playwright test tests/e2e/specs/04-offers.spec.ts`): `beforeAll` uses the idempotent `ensure*` helpers (`utils/e2e-helpers.ts`) — `ensureAcceptedUser`, `ensureServiceType`, `ensureMediumOfExchange` — which create state only if it doesn't exist yet. Filename order and single-spec runs are the two supported modes; reverse/random order is not (the files are chapters, and DHT state accumulates within one run — `global-setup` wipes the sandbox at the start of every run).
 

--- a/ui/tests/e2e/specs/smoke.spec.ts
+++ b/ui/tests/e2e/specs/smoke.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, type Page } from '@playwright/test';
+import type { AppWebsocket } from '@holochain/client';
+import { gotoApp, createTestClient, ensureAcceptedUser } from '../utils/e2e-helpers.js';
+
+// ============================================================================
+// SMOKE
+//
+// A fast health check across the whole app: every core route must mount
+// against the live conductor without crashing. This is the "is the app
+// fundamentally broken?" signal — a broken build, a routing regression, a
+// failed Holochain connection, or a page that throws on mount all surface
+// here in seconds, without paying for the full 5.5-minute journey.
+//
+// Run just this layer with `bun test:e2e:smoke` (grep '@smoke').
+//
+// ORDERING: this file is UNNUMBERED on purpose. Playwright runs spec files in
+// filename order, and letters sort AFTER digits, so smoke executes LAST in a
+// full run — after 00-onboarding has already created and accepted the primary
+// user. That keeps 00's fresh-conductor assumptions intact. Standalone (or via
+// grep on a freshly-wiped sandbox) it seeds its own accepted user through the
+// idempotent ensureAcceptedUser helper, so it never depends on ordering.
+//
+// SCOPE: shallow by design. It asserts each route renders a durable landmark
+// (heading / tab label) and does NOT render a failure banner. Deep CRUD flows
+// belong to the numbered chapters; multi-agent flows to Sweettest.
+// ============================================================================
+
+/** A durable landmark that proves a route mounted. */
+type SmokeRoute = {
+  path: string;
+  /** Accessible heading name expected on the page, matched exactly, or... */
+  heading?: string;
+  /** ...an arbitrary durable text landmark when the page has no stable heading. */
+  landmark?: string;
+};
+
+// The accepted primary user is also the network administrator (the first agent
+// in a sandbox auto-registers as admin, see ensureAcceptedUser), so the admin
+// surfaces below are reachable with the same identity.
+//
+// Every landmark below is the literal heading in that route's +page.svelte, not a
+// guess: '/users' renders its title as an <h2> styled .h1, and the offers and
+// requests tabs carry an emoji prefix ('📋 Active Offers'), which is why those two
+// match on text rather than on an accessible name.
+const SMOKE_ROUTES: SmokeRoute[] = [
+  { path: '/', heading: 'Welcome to Requests & Offers' },
+  { path: '/service-types', heading: 'Available Service Types' },
+  { path: '/offers', landmark: 'Active Offers' },
+  { path: '/requests', landmark: 'Active Requests' },
+  { path: '/organizations', heading: 'Organizations' },
+  { path: '/users', heading: 'Users' },
+  { path: '/admin', heading: 'Admin Dashboard' },
+  { path: '/admin/hrea-test', heading: 'hREA Test Interface' }
+];
+
+/**
+ * Asserts the app never rendered one of its terminal failure states. The root
+ * layout shows "Failed to connect" if the Holochain connection dies; the admin
+ * layout shows "Admin data loading failed" if an admin data load throws.
+ */
+async function expectNoFailureState(page: Page): Promise<void> {
+  // .first() keeps these strict-mode safe: a bare text= locator throws rather than
+  // asserting if the phrase ever appears twice, and on an empty match .first()
+  // still resolves to hidden, which is the answer we want.
+  await expect(page.locator('text=Failed to connect').first()).toBeHidden();
+  await expect(page.locator('text=Admin data loading failed').first()).toBeHidden();
+}
+
+test.describe.serial('smoke — every core route mounts against the live conductor', () => {
+  let client: AppWebsocket;
+
+  test.beforeAll(async () => {
+    client = await createTestClient();
+    await ensureAcceptedUser(client);
+  });
+
+  test.afterAll(async () => {
+    await client.client.close();
+  });
+
+  for (const route of SMOKE_ROUTES) {
+    test(`@smoke ${route.path} mounts`, async ({ page }) => {
+      await gotoApp(page, route.path);
+
+      if (route.heading) {
+        // exact: true so 'Users' cannot be satisfied by 'Users Management', and
+        // .first() because some pages repeat a heading name in cards below the
+        // title, which a bare strict locator would reject.
+        await expect(
+          page.getByRole('heading', { name: route.heading, exact: true }).first()
+        ).toBeVisible({ timeout: 30_000 });
+      }
+      if (route.landmark) {
+        await expect(page.locator(`text=${route.landmark}`).first()).toBeVisible({
+          timeout: 30_000
+        });
+      }
+
+      await expectNoFailureState(page);
+    });
+  }
+});

--- a/ui/tests/e2e/specs/smoke.spec.ts
+++ b/ui/tests/e2e/specs/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Locator, type Page } from '@playwright/test';
 import type { AppWebsocket } from '@holochain/client';
 import { gotoApp, createTestClient, ensureAcceptedUser } from '../utils/e2e-helpers.js';
 
@@ -53,17 +53,38 @@ const SMOKE_ROUTES: SmokeRoute[] = [
   { path: '/admin/hrea-test', heading: 'hREA Test Interface' }
 ];
 
+/** Sentinel for the poll below: the route rendered what it should. */
+const MOUNTED = 'mounted';
+
 /**
- * Asserts the app never rendered one of its terminal failure states. The root
- * layout shows "Failed to connect" if the Holochain connection dies; the admin
- * layout shows "Admin data loading failed" if an admin data load throws.
+ * Waits for a route to either mount its landmark or report a terminal failure,
+ * whichever happens first, then asserts it mounted.
+ *
+ * Racing the two is the whole point. Asserting the landmark first and checking
+ * the failure banner afterwards makes the banner check unreachable: when the
+ * connection dies the landmark never appears, so the test times out on a
+ * missing heading and never examines the banner. The check then only ever runs
+ * on a page that already rendered, where it cannot fail.
+ *
+ * Verified by killing the conductor mid-suite. Before this change the page
+ * showed "Failed to connect to Holochain" while the test reported `Active
+ * Offers` not found. After it, the failure text is what the report names.
  */
-async function expectNoFailureState(page: Page): Promise<void> {
-  // .first() keeps these strict-mode safe: a bare text= locator throws rather than
-  // asserting if the phrase ever appears twice, and on an empty match .first()
-  // still resolves to hidden, which is the answer we want.
-  await expect(page.locator('text=Failed to connect').first()).toBeHidden();
-  await expect(page.locator('text=Admin data loading failed').first()).toBeHidden();
+async function expectRouteMounted(page: Page, landmark: Locator): Promise<void> {
+  // The root layout renders the first phrase if the Holochain connection dies;
+  // the admin layout renders the second if an admin data load throws.
+  const failure = page.getByText(/Failed to connect|Admin data loading failed/).first();
+
+  await expect
+    .poll(
+      async () => {
+        if (await failure.isVisible()) return (await failure.innerText()).trim();
+        if (await landmark.isVisible()) return MOUNTED;
+        return 'still loading';
+      },
+      { timeout: 30_000 }
+    )
+    .toBe(MOUNTED);
 }
 
 test.describe.serial('smoke — every core route mounts against the live conductor', () => {
@@ -82,21 +103,14 @@ test.describe.serial('smoke — every core route mounts against the live conduct
     test(`@smoke ${route.path} mounts`, async ({ page }) => {
       await gotoApp(page, route.path);
 
-      if (route.heading) {
-        // exact: true so 'Users' cannot be satisfied by 'Users Management', and
-        // .first() because some pages repeat a heading name in cards below the
-        // title, which a bare strict locator would reject.
-        await expect(
-          page.getByRole('heading', { name: route.heading, exact: true }).first()
-        ).toBeVisible({ timeout: 30_000 });
-      }
-      if (route.landmark) {
-        await expect(page.locator(`text=${route.landmark}`).first()).toBeVisible({
-          timeout: 30_000
-        });
-      }
+      // exact: true so 'Users' cannot be satisfied by 'Users Management', and
+      // .first() because some pages repeat a heading name in cards below the
+      // title, which a bare strict locator would reject.
+      const landmark = route.heading
+        ? page.getByRole('heading', { name: route.heading, exact: true }).first()
+        : page.locator(`text=${route.landmark}`).first();
 
-      await expectNoFailureState(page);
+      await expectRouteMounted(page, landmark);
     });
   }
 });


### PR DESCRIPTION
## Intent

**The e2e suite takes ~5.5 minutes to tell you the build is broken.** It is an ordered journey: a routing regression, a dead Holochain connection, or a page that throws on mount will eventually surface, but only after the chapters ahead of it have run their full CRUD flows against a live conductor.

This adds a smoke layer that answers "is the app fundamentally broken?" in seconds. It loads every core route against the live sandbox conductor and asserts each one mounts a durable landmark without rendering a failure banner. Nothing deeper: it is the signal you want first, not the signal you want most.

## Changes

**`smoke.spec.ts`** is table-driven over the eight core routes and tagged `@smoke`:

| Route | Landmark |
|---|---|
| `/` | heading "Welcome to Requests & Offers" |
| `/service-types` | heading "Available Service Types" |
| `/offers` | "Active Offers" tab |
| `/requests` | "Active Requests" tab |
| `/organizations` | heading "Organizations" |
| `/users` | heading "Users" |
| `/admin` | heading "Admin Dashboard" |
| `/admin/hrea-test` | heading "hREA Test Interface" |

Every landmark is the literal heading in that route's `+page.svelte`, checked against the source rather than assumed. Two of them match on text rather than on an accessible name: the offers and requests tabs carry an emoji prefix (`📋 Active Offers`), so a role-based name match would miss them. `/users` renders its title as an `<h2>` styled `.h1` and still matches by role, because `getByRole('heading')` matches any heading level.

Each test also asserts neither of the app's two terminal failure states is showing: `Failed to connect` from the root layout, `Admin data loading failed` from the admin layout.

**`ui/package.json`** gains `test:e2e:smoke`, which is `playwright test --grep @smoke`.

**`ui/tests/e2e/README.md`** documents the layer and the ordering rule below.

## Decisions

| Option | Rejected because |
|--------|-----------------|
| Number the spec `09-smoke` | Playwright orders spec files by filename, so a numbered smoke test runs after the whole journey it is supposed to front-run. Leaving it unnumbered makes letters sort after digits, which puts it last in a full run and first when you grep for it. |
| Give it its own conductor so it can truly run first | Doubles sandbox setup for a layer whose entire value is being cheap. `ensureAcceptedUser` makes it standalone-safe instead, at zero extra cost. |
| Assert page content, not just mounting | That is the numbered chapters' job. A smoke layer that asserts business rules acquires their maintenance cost and their runtime. |

**Ordering.** Unnumbered on purpose, so a full run executes it last, after `00-onboarding` has created and accepted the primary user. That keeps `00`'s fresh-conductor assumptions intact. Run alone (`bun test:e2e:smoke`) it seeds its own accepted user through the idempotent `ensureAcceptedUser` helper, so it never depends on ordering. The accepted user is also the network admin, since the first agent in a sandbox auto-registers, which is what makes the `/admin/*` routes reachable under the same identity.

**Selector strictness.** Headings match with `exact: true` so `Users` cannot be satisfied by `Users Management`, and every locator ends in `.first()`. Playwright's strict mode throws rather than asserting when a locator matches more than one node, and a smoke check should not fail because a page repeats its title in a card below the fold.

## How to test

```bash
bun build:happ                  # once, from the repo root (needs nix)
cd ui && bun test:e2e:smoke     # this layer alone
cd ui && bun test:e2e           # full journey, with smoke running last
```

Static checks, all clean on this branch:

- `bunx prettier --check tests/e2e/specs/smoke.spec.ts`
- `bunx eslint tests/e2e/specs/smoke.spec.ts`
- `bunx tsc --noEmit` reports no errors under `tests/e2e/`

**Rebased onto `dev` at `810880bc` on 8 September.** All eight landmarks were re-verified against the rebased base by reading each route's `+page.svelte`, since `dev` moved ten commits in the meantime and #215 rewrote the connection-status path this layer gates on. Every landmark and both failure strings still resolve:

| Landmark | Still at |
|---|---|
| Welcome to Requests & Offers | `routes/+page.svelte:141`, outside the `{#if !currentUser}` branch |
| Available Service Types | `service-types/+page.svelte:34` |
| Active Offers / Active Requests | `:68` in each, emoji-prefixed tabs |
| Organizations | `organizations/+page.svelte:42` |
| Users | `users/+page.svelte:59`, `<h2 class="h1">` |
| Admin Dashboard | `admin/+page.svelte:253` |
| hREA Test Interface | `admin/hrea-test/+page.svelte:23` |
| Failed to connect | `routes/+layout.svelte:289` |
| Admin data loading failed | `routes/admin/+layout.svelte:100` |

Static checks re-run clean on the rebased branch: `prettier --check`, `eslint`, and `tsc --noEmit` with no errors under `tests/e2e/`.

### Verified

Run on a sandbox conductor against a hApp built from this branch, 8 September.

| Check | Result |
|---|---|
| `bun test:e2e:smoke` standalone, wiped sandbox | **8 passed, 1.2m** (2.4s to 3.3s per route) |
| `bun test:e2e` full journey, smoke last | **58 passed, 4.6m**, smoke at tests 51 to 58 |
| Failure assertion proven able to go red | conductor killed mid-suite, reported below |

The ordering claim above is now measured rather than argued: smoke really does execute last in a full run.

**The failure assertion needed a fix before it could go red, and that is the substantive change since review.** `expectNoFailureState` ran *after* the landmark assertion, so it could only execute on a page that had already rendered, where it cannot fail. Killing the conductor mid-suite showed the page displaying "Failed to connect to Holochain. Please refresh the page." while the report named `Active Offers` not found: the banner check was never reached.

It is now a single `expect.poll` racing the landmark against both terminal failure states. After the fix, the same kill produces:

```
Expected: "mounted"
Received: "Failed to connect to Holochain. Please refresh the page."
```

Both directions are therefore demonstrated: green on a healthy conductor, and a failure named in the app's own words when the connection dies.

**Requires #247.** The suite could not run from a git worktree at all: `node_modules` is a symlink, vite resolves it to its real path before checking `server.fs.allow`, and SvelteKit's client runtime was refused, so the app never booted. Fixed in #247 and merged.

## Documentation

- `ui/tests/e2e/README.md` gains a "Smoke layer" section covering what it asserts, the unnumbered-ordering rule, and the command.

## Related

Related #173 (the journey suite this layer sits beside)