### PR TITLE
fix(nix): stop openssl-sys vendoring OpenSSL from source in dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,9 @@
           llvmPackages.libclang
           cmake
           pkg-config
+          # Provides a system OpenSSL so openssl-sys does not vendor/build it
+          # from source during native Sweettest builds.
+          openssl
         ]) ++ [
           inputs'.holonix-playground.packages.hc-playground
           inputs'.holonix.packages.bootstrap-srv
@@ -36,6 +39,9 @@
           export PS1='\[\033[1;34m\][holonix:\w]\$\[\033[0m\] '
           # Required by bindgen (datachannel-sys) when building Sweettest tests natively
           export LIBCLANG_PATH="${pkgs.llvmPackages.libclang.lib}/lib"
+          # Force openssl-sys to link the system OpenSSL above rather than
+          # vendoring it (the vendored build needs make and fails in-shell).
+          export OPENSSL_NO_VENDOR=1
           export BINDGEN_EXTRA_CLANG_ARGS="-isystem ${pkgs.llvmPackages.libclang.lib}/lib/clang/$(ls ${pkgs.llvmPackages.libclang.lib}/lib/clang/)/include${pkgs.lib.optionalString pkgs.stdenv.isLinux " -isystem ${pkgs.glibc.dev}/include"}"
         '';
       };


### PR DESCRIPTION
Native Sweettest builds pull openssl-sys, which tries to vendor and compile OpenSSL from source and fails on macOS with "tool make not found" (the Xcode shim message, not a missing gnumake, which is present in the shell throughout).

This adds openssl to the dev-shell packages and exports OPENSSL_NO_VENDOR=1 in the shellHook so the crate links against the Nix-provided library instead of building its own.

Verified: shell still evaluates, pkg-config --modversion openssl reports 3.6.0, and a bare nix develop now builds native tests with no hand-exported environment.

Companion to the dev-shell work in #153, both edit the flake shellHook. Kept as a separate small change so it can land independently.