### PR TITLE
feat(messaging): cross-agent signal substrate for chat and notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4695,6 +4695,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "messaging"
+version = "0.0.1"
+dependencies = [
+ "hdk",
+ "serde",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/dnas/requests_and_offers/workdir/dna.yaml
+++ b/dnas/requests_and_offers/workdir/dna.yaml
@@ -65,3 +65,7 @@ coordinator:
       path: "../../../target/wasm32-unknown-unknown/release/mediums_of_exchange.wasm"
       dependencies:
         - name: mediums_of_exchange_integrity
+    - name: messaging
+      hash: ~
+      path: "../../../target/wasm32-unknown-unknown/release/messaging.wasm"
+      dependencies: []

--- a/dnas/requests_and_offers/zomes/coordinator/messaging/Cargo.toml
+++ b/dnas/requests_and_offers/zomes/coordinator/messaging/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "messaging"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "messaging"
+
+[dependencies]
+hdk = { workspace = true }
+serde = { workspace = true }

--- a/dnas/requests_and_offers/zomes/coordinator/messaging/src/lib.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/messaging/src/lib.rs
@@ -1,0 +1,85 @@
+use hdk::prelude::*;
+use std::collections::HashSet;
+
+/// Input from this agent's own UI: send `content` on `stream_id` to `agents`.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SendMessageInput {
+    pub stream_id: String,
+    pub content: String,
+    pub agents: Vec<AgentPubKey>,
+}
+
+/// The payload that crosses the wire to another agent via a remote signal.
+/// For the substrate proof `content` is plaintext. Under the messaging design
+/// it will carry ciphertext (see the messaging architecture note, persist-and-
+/// signal lifecycle). Serde derives are sufficient for the extern and signal
+/// boundaries on hdk 0.6; SerializedBytes is not required (cf. the misc zome).
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Message {
+    pub stream_id: String,
+    pub content: String,
+}
+
+/// Signals emitted to this agent's own UI. A received remote signal becomes a
+/// `Signal::Message`; `from` is the sender, read from call provenance.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type")]
+pub enum Signal {
+    Message {
+        stream_id: String,
+        content: String,
+        from: AgentPubKey,
+    },
+}
+
+/// Grant any agent the right to call `recv_remote_signal` on this zome, which
+/// is what makes cross-agent delivery possible. `create_cap_grant` commits it
+/// as a Private entry on this agent's own source chain (verified in hdk 0.6.0
+/// capability.rs), so it is never gossiped.
+///
+/// The grant is Unrestricted by necessity: you cannot know your correspondents
+/// in advance. Filtering unsolicited or abusive signals is an application-layer
+/// concern, not a substrate one.
+#[hdk_extern]
+pub fn init(_: ()) -> ExternResult<InitCallbackResult> {
+    // GrantedFunctions::Listed takes a HashSet<(ZomeName, FunctionName)> in
+    // 0.6.0 (not the BTreeSet older references use). Type is inferred from the
+    // Listed(..) use below, so no explicit annotation is needed.
+    let mut fns = HashSet::new();
+    fns.insert((zome_info()?.name, "recv_remote_signal".into()));
+    let functions = GrantedFunctions::Listed(fns);
+    create_cap_grant(ZomeCallCapGrant {
+        tag: "".into(),
+        access: CapAccess::Unrestricted,
+        functions,
+    })?;
+    Ok(InitCallbackResult::Pass)
+}
+
+/// Called by this agent's own UI. Pushes `content` to each recipient's node via
+/// a remote signal. Delivery is best-effort and requires the recipient to be
+/// online; durability is added later, when messages are persisted as entries.
+#[hdk_extern]
+pub fn send_message(input: SendMessageInput) -> ExternResult<()> {
+    send_remote_signal(
+        Message {
+            stream_id: input.stream_id,
+            content: input.content,
+        },
+        input.agents,
+    )
+}
+
+/// Called remotely by a sending agent, permitted by the init cap grant.
+/// Re-emits the message to this agent's own UI, tagged with the sender.
+#[hdk_extern]
+pub fn recv_remote_signal(message: Message) -> ExternResult<()> {
+    let info = call_info()?;
+    let signal = Signal::Message {
+        stream_id: message.stream_id,
+        content: message.content,
+        from: info.provenance,
+    };
+    emit_signal(signal)
+}

--- a/dnas/requests_and_offers/zomes/coordinator/messaging/src/lib.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/messaging/src/lib.rs
@@ -41,6 +41,10 @@ pub enum Signal {
 /// The grant is Unrestricted by necessity: you cannot know your correspondents
 /// in advance. Filtering unsolicited or abusive signals is an application-layer
 /// concern, not a substrate one.
+///
+/// NOTE: init runs lazily, on a cell's first zome call. A recipient must have
+/// been called at least once (e.g. `ping`) before a remote signal will be
+/// authorised, otherwise the grant does not yet exist and the signal is dropped.
 #[hdk_extern]
 pub fn init(_: ()) -> ExternResult<InitCallbackResult> {
     // GrantedFunctions::Listed takes a HashSet<(ZomeName, FunctionName)> in
@@ -55,6 +59,14 @@ pub fn init(_: ()) -> ExternResult<InitCallbackResult> {
         functions,
     })?;
     Ok(InitCallbackResult::Pass)
+}
+
+/// Trivial health-check. Also serves to force `init` to run on a freshly
+/// installed cell, committing the cap grant so this agent can receive remote
+/// signals. Callers priming a recipient should call this before a signal is sent.
+#[hdk_extern]
+pub fn ping(_: ()) -> ExternResult<String> {
+    Ok("pong".to_string())
 }
 
 /// Called by this agent's own UI. Pushes `content` to each recipient's node via

--- a/documentation/architecture/chat-system.md
+++ b/documentation/architecture/chat-system.md
@@ -3,12 +3,19 @@
 **Status:** Design of record.
 **Holochain stack:** hdk 0.6.1 / hdi 0.7.1 / conductor 0.6.1, confirmed against `Cargo.lock`.
 **R&O application version:** to be confirmed against the root `package.json` before publication.
-**Implementation status:** the cross-agent signal substrate (§7) is built and tested.
-Nothing else in this note is built.
+**Implementation status:** the cross-agent signal substrate (§7) is built and tested. The
+conversation DNA is partly built and in review as #183: the integrity membrane gate, the
+coordinator, the base-cell write refusal, the third role and membrane test coverage. The
+message and configuration entries are not built. Nothing else in this note is built.
 **Relates to:** #91 (Chat System), #51 (Global Notifications), #12 (Real-time Signals),
 #144 (Breaking-version Migration), #163 / #162 (Flagging / Moderation)
 **Supersedes:** the *Security and Privacy* section of
 `documentation/requirements/post-mvp/messaging-system.md`
+**Canonical location:** `documentation/architecture/chat-system.md` on
+`feat/messaging-substrate`. Any copy held outside the repository is a snapshot and may state
+the opposite of the current decision; verify it with
+`git show feat/messaging-substrate:documentation/architecture/chat-system.md` before relying
+on it.
 
 ---
 
@@ -20,7 +27,9 @@ Nothing else in this note is built.
   subset.
 - **No content encryption inside a clone.** Isolation is the confidentiality mechanism.
 - A conversation is created by **responding to a listing**. The response carries a random
-  network seed and a membrane proof, encrypted to the recipient.
+  network seed, the conversation id and the participant pair, encrypted to the recipient.
+  Both participants are admitted to the clone by identity, so no membrane proof is
+  transmitted (§5).
 - Seeds are **random and transmitted**, never derived from public values (§6).
 - Deletion is **leave-and-remove**, which genuinely removes local data, plus archive for
   tidiness. Crypto-shredding is not available on this platform (§8).
@@ -133,10 +142,18 @@ same way. The reference becomes one-directional: a participant can enumerate the
 conversations and see which listing each concerns, and nobody can go the other way from a
 listing to its conversations. That is a small feature loss and a privacy gain.
 
-**What it costs.** This is not a configuration change. `workdir/happ.yaml` declares two
-roles, both with `clone_limit: 0`. Isolation requires a third role backed by a new
-conversation DNA built in this repository, with its own integrity and coordinator zomes
-and a non-zero clone limit.
+**What it costs.** This is not a configuration change. `workdir/happ.yaml` now declares
+three roles: the original two at `clone_limit: 0`, and a conversation role backed by a new
+DNA built in this repository, with its own integrity and coordinator zomes and a non-zero
+clone limit.
+
+**And it costs an idle cell on every conductor.** The conversation role cannot be provisioned
+lazily. A role with no provisioned cell reaches an unimplemented arm in
+`holochain_conductor_api-0.6.1/src/app_interface.rs` at line 491 while app info is assembled,
+so the panic surfaces whenever app info is requested rather than at install. Both
+`strategy: clone_only` and `deferred: true` reach it. Every member therefore carries an empty
+base conversation cell, and that base cell must refuse writes at the integrity layer, because
+it is a real cell a client could otherwise write to.
 
 **Precedent.** Volla Messages runs this model in production on Android and desktop. Their
 `happ.yaml` declares a single role with `clone_limit: 100` and `deferred: false`. Their
@@ -146,14 +163,21 @@ progenitor: a conversation clone is admitted by a progenitor-signed proof naming
 specific conversation. Their entry types are all public with no visibility attribute, and
 their zomes contain no content encryption at all.
 
+R&O departs on one point. Volla's properties name a single progenitor and admission is by
+proof, where ours name the participant pair and admission is by identity. That is what lets
+either participant invite an administrator (§10) without being the other's gatekeeper.
+
 Volla's profiles and file storage live inside the conversation clone, so they have no
 global member directory, and their invitation mechanism is an out-of-band QR exchange.
 R&O's shared DNA is exactly what they lack, and it is what makes isolation practical here
 without QR swapping (§5).
 
 **Unmeasured.** What a conductor costs at high cell count on R&O's stack. Volla runs 100
-clones as a pure messenger; R&O carries the shared DNA and the hREA cell alongside. This
-is measurable directly and should be measured before the clone limit is chosen.
+clones as a pure messenger; R&O carries the shared DNA and the hREA cell alongside. This is
+measurable directly and should be measured before the clone limit is raised. The manifest
+therefore sets `clone_limit: 100`, matching the only figure known to run in production rather
+than a larger number that would read as a decision this note has not made. Raising it is a
+one-line manifest change once the measurement exists.
 
 ## 5. Conversation lifecycle
 
@@ -161,19 +185,22 @@ is measurable directly and should be measured before the clone limit is chosen.
 response is the invitation. This reuses an interaction R&O wants anyway rather than
 introducing a separate invitation artefact with its own metadata cost.
 
-**Invitation contents.** A random network seed, and a membrane proof admitting the
-recipient to the clone, encrypted to the recipient's agent key. The responder creates the
-clone and is its progenitor. The recipient decrypts, creates a clone with the same seed
-and their proof, and the two are in a network nobody else can locate or enter.
+**Invitation contents.** A random network seed, the conversation id, and the participant
+pair, encrypted to the recipient's agent key. The clone's properties name both participants,
+who are admitted by identity, so no membrane proof is transmitted and neither participant is
+the other's gatekeeper. The recipient decrypts, creates a clone with the same seed and the
+same properties, and the two are in a network nobody else can locate or enter.
 
 **How this differs from joining.** R&O already uses membrane proofs to admit members to
 the network, signed by a `membrane_signer` key the joining service holds, distinct from the
 DNA progenitor (`MEMBRANE_MANAGEMENT.md` and its off-DHT companion). Conversation proofs
-reuse the mechanism and invert the custody model: the signer is the conversation's
-initiator, not a service, and there is no ledger, no central key and no service in the
-loop. `genesis_self_check` validates the signature rather than the issuing method, so both
-kinds of proof are the same shape. Nothing about conversation creation should route through
-the joining service.
+reuse the mechanism and invert the custody model: where a proof is needed at all, either
+participant may sign it, and there is no ledger, no central key and no service in the loop. A
+proof is needed only to admit an agent not named in the clone's properties, which in practice
+means an invited administrator (§10); the signed data names its own signer, so the signature
+covers the claim of who issued it. `genesis_self_check` validates the signature rather than
+the issuing method, so both kinds of proof are the same shape. Nothing about conversation
+creation should route through the joining service.
 
 **Delivery, signal first.** If the recipient is online, the invitation travels as a remote
 signal and nothing is persisted anywhere, so the conversation leaves no trace on any DHT.
@@ -292,9 +319,10 @@ The substrate lives in a coordinator-only `messaging` zome:
 - a `Signal::Message` variant;
 - a `ping` health-check whose secondary job is to trigger lazy `init`.
 
-Verified against hdk 0.6.0 canon, which caught two drifts from older reference code:
+Verified against current HDK canon, which caught two drifts from older reference code:
 `GrantedFunctions::Listed` takes a `HashSet` rather than a `BTreeSet`, and the
-`SerializedBytes` derive is unnecessary on 0.6. Proven by a two-conductor Sweettest.
+`SerializedBytes` derive is unnecessary on the 0.6 line. Proven by a two-conductor Sweettest.
+The stack pin is in the front matter and is not restated here.
 
 **The grant is `Listed`, naming exactly one function.** Nothing else in the zome is
 remotely callable, which matters for anything added to it later.
@@ -345,13 +373,17 @@ Two models, because two DNAs are involved.
   listing hash and the proposal id are resolved frontend-side against the other cells;
   neither is a DHT link, and neither can be.
 - Links: conversation to messages, time-bucketed for pagination. The message update chain.
+  A path anchor to the configuration entry, without which that entry has no base and is
+  unreachable to a joining participant. Earlier revisions of this note specified no link for
+  it; that was an omission rather than a decision.
 
 Participants are the clone's membrane, not a field on an entry.
 
 **On the shared `requests_and_offers` DNA:**
 
-- The invitation entry, only when signal delivery fails (§5): a random seed and a membrane
-  proof, encrypted to the recipient, under a time-bucketed global anchor.
+- The invitation entry, only when signal delivery fails (§5): a random seed, the
+  conversation id and the participant pair, encrypted to the recipient, under a
+  time-bucketed global anchor.
 
 ## 10. Administrator access
 
@@ -376,9 +408,15 @@ is joining an ongoing room.
 (#163) remains available and discloses far less. Administrator invitation is the heavier
 instrument and should be presented as such.
 
-**Open for governance.** The exact consent wording, and whether both participants must
-agree rather than one inviting unilaterally with notice, is a governance decision rather
-than an architectural one.
+**Unilateral, with notice.** One participant may invite an administrator without the
+other's agreement. Requiring mutual consent would defeat the instrument in the case that most
+needs it, since a participant behaving badly will not consent to being observed. The notice is
+the safeguard, and it is structural rather than social: the system message is committed, so a
+modified client cannot suppress it.
+
+**Open for governance.** The exact consent wording remains a governance and copy decision
+rather than an architectural one, including how plainly it conveys that an invited
+administrator reads the whole history.
 
 ## 11. What members are told
 
@@ -402,11 +440,17 @@ The guarantee, in plain terms:
 1. **Substrate.** Cap grant and remote signal path. (DONE, §7.)
 2. **Prove it.** Two-conductor Sweettest. (DONE.)
 3. **Conversation DNA.** A new DNA in this repository with integrity and coordinator zomes,
-   the message and configuration entries, and membrane proof validation against a
-   progenitor. Registered as a third role in `workdir/happ.yaml` with a non-zero clone
-   limit and, following Volla, `deferred: false`.
+   the message and configuration entries, and membrane validation against the participant
+   pair named in the clone's properties. Registered as a third role in `workdir/happ.yaml`
+   with a non-zero clone limit and `deferred: false`, which the platform forces rather than
+   Volla merely suggesting (§4). (PARTLY DONE, #183: the DNA, the membrane gate, the
+   coordinator, the base-cell write refusal, the role and membrane test coverage. The message
+   and configuration entries remain.)
 4. **Clone lifecycle.** Create, join, disable, remove, and the frontend's conversation list
-   assembled by enumerating clones.
+   assembled by enumerating clones. This needs its own harness: #183 provisions the role
+   directly and does not exercise cloning. A freshly created or joined clone has no cap grant
+   until something calls it, and signals into it are dropped silently, so every clone needs
+   priming on both sides (§7).
 5. **Invitation.** Signal-first delivery with the persisted anchor fallback. Depends on the
    listing-response design (§5).
 6. **UI.** Conversation list, thread, inbox, and the listing entry points.
@@ -424,6 +468,8 @@ Steps 3 and 4 can proceed independently of step 5.
   the current conductor payload ceiling is unverified; the 256KB figure in circulation
   dates from a much older Holochain version.
 - Whether the `messaging` zome belongs in the conversation DNA, the shared DNA, or both.
+  This blocks the signal half of message delivery (§5), so the message entries land
+  persist-only until it is answered.
 
 **Dependencies on others:**
 
@@ -439,6 +485,11 @@ Steps 3 and 4 can proceed independently of step 5.
 - Sender identity cannot be hidden on a shared DNA (§3).
 - A clone limit is a resource guard set in the manifest, not an architectural ceiling.
   Holochain's own documentation shows `u32::MAX` as a valid value.
+- A base conversation cell on every conductor is unavoidable; lazy provisioning of the role
+  is not available on this stack (§4).
+- Sweettest cannot pass a membrane proof through any public API on 0.6.1, 0.6.3 or 0.7.0.
+  `ConductorHandle::install_app_bundle` with `RoleSettings::Provisioned` is the working
+  route (§14).
 
 ## 14. Evidence base
 
@@ -453,6 +504,12 @@ Claims in this note were established by reading source directly. The principal s
 - `hdk` 0.6.1 and `hdi` 0.7.1, `x_salsa20_poly1305.rs`: the encryption and decryption
   signatures and their opposed argument orders.
 - `lair_keystore_api` 0.6.3: absence of any deletion operation.
+- `holochain_conductor_api` 0.6.1, `app_interface.rs` line 491: the unimplemented arm for a
+  role with no provisioned cell.
+- `holochain` 0.6.1, `conductor.rs` line 1295, with `holochain_types` 0.6.1, `app.rs` lines
+  154 to 176: `install_app_bundle` and per-role `RoleSettings::Provisioned`, the only public
+  route that carries a membrane proof. Sweettest's own installers map every DNA to no proof
+  on 0.6.1, 0.6.3 and 0.7.0 alike.
 - `kitsune2_bootstrap_srv` 0.4.1, `space.rs`, `auth.rs`, `http.rs`: space read scoping and
   the optional authentication hook.
 - `HelloVolla/volla-messages`: `workdir/happ.yaml`, and the relay integrity zome's
@@ -464,4 +521,5 @@ Claims in this note were established by reading source directly. The principal s
 
 **Correction owed elsewhere:** `CellCloning.md` states that `deferred: true` is required
 for clonable roles. Two production manifests set `deferred: false` with a non-zero clone
-limit.
+limit, and on this stack `deferred: true` reaches the unimplemented arm named above. Filed as
+`Soushi888/holochain-agent-skill#2`.

--- a/documentation/architecture/chat-system.md
+++ b/documentation/architecture/chat-system.md
@@ -186,6 +186,21 @@ entry in the clone, which is durability and reaches an offline participant when 
 return, and sent as a remote signal, which is liveness. `post_commit` runs only on the
 committing agent, so the remote signal is the only cross-agent path.
 
+**What becomes public when a conversation succeeds.** An hREA Agreement names its
+provider and receiver and is public by design, because fulfilment tracking and reputation
+depend on it (#90). So the moment a conversation produces an agreement, that edge is
+visible. Isolation protects the content of every conversation and protects entirely those
+that never reach agreement, which is most of them: browsing, asking, negotiating,
+declining. It does not conceal a completed deal, and it should not, since an agreement is
+a deliberate mutual public act.
+
+Two consequences for the exchange layer. A conversation can hold the agreement id and
+resolve it frontend-side, but the reverse lookup from a public agreement to a private
+conversation cannot exist, and is not needed: only participants would want it and they are
+already inside the clone. And any conversation identifier stored on the agreement must be
+an opaque random value, never derived from the conversation's network seed, which stays
+secret (§6).
+
 **Dependency.** Where the response-to-a-listing event lives is not messaging's decision.
 The `exchanges` name is reserved in the frontend's `ZomeName` union but nothing implements
 it, and no domain store or composable exists for it. R&O runs hREA as a second DNA, and
@@ -362,6 +377,8 @@ The guarantee, in plain terms:
 - No administrator has access to any conversation unless a participant invites them, and
   that invitation is announced in the conversation. An invited administrator can read the
   conversation's whole history.
+- If a conversation leads to an agreement, the agreement itself is public, including
+  who it is between. Conversations that do not lead to an agreement leave no such record.
 - Leaving a conversation removes your copy. It cannot remove the other participant's copy.
 - Conversation data is stored unencrypted on your own device. Device-level protection is
   your own disk encryption.

--- a/documentation/architecture/chat-system.md
+++ b/documentation/architecture/chat-system.md
@@ -166,6 +166,15 @@ recipient to the clone, encrypted to the recipient's agent key. The responder cr
 clone and is its progenitor. The recipient decrypts, creates a clone with the same seed
 and their proof, and the two are in a network nobody else can locate or enter.
 
+**How this differs from joining.** R&O already uses membrane proofs to admit members to
+the network, signed by a `membrane_signer` key the joining service holds, distinct from the
+DNA progenitor (`MEMBRANE_MANAGEMENT.md` and its off-DHT companion). Conversation proofs
+reuse the mechanism and invert the custody model: the signer is the conversation's
+initiator, not a service, and there is no ledger, no central key and no service in the
+loop. `genesis_self_check` validates the signature rather than the issuing method, so both
+kinds of proof are the same shape. Nothing about conversation creation should route through
+the joining service.
+
 **Delivery, signal first.** If the recipient is online, the invitation travels as a remote
 signal and nothing is persisted anywhere, so the conversation leaves no trace on any DHT.
 Only if no acknowledgement arrives does the sender fall back to a persisted entry on the
@@ -255,9 +264,14 @@ hook server configured the server issues tokens freely and treats every request 
 successful. On a public unauthenticated bootstrap, anyone who knows a space identifier can
 enumerate its members, which for a two-agent clone is a social graph edge.
 
-Two consequences follow. R&O should **run its own bootstrap with an authentication hook**,
-for which the existing joining service is the natural candidate. And independently,
-**network seeds must be random and transmitted, never derived from public values**. A seed
+Two consequences follow. R&O should **run its own bootstrap with an authentication hook**.
+The joining service is the natural candidate: it already holds a signing key, issues signed
+single-use artefacts against a ledger, and knows which agents are members, which is exactly
+what an authentication hook needs to decide. This is an integration point rather than new
+infrastructure.
+
+Independently of that, **network seeds must be random and transmitted, never derived from
+public values**. A seed
 derived from a listing hash and an agent key would be computable by every member, handing
 the conversation graph to anyone willing to enumerate. The membrane still prevents them
 entering the clone, but membership enumeration alone is the leak this design exists to

--- a/documentation/architecture/chat-system.md
+++ b/documentation/architecture/chat-system.md
@@ -191,9 +191,11 @@ who are admitted by identity, so no membrane proof is transmitted and neither pa
 the other's gatekeeper. The recipient decrypts, creates a clone with the same seed and the
 same properties, and the two are in a network nobody else can locate or enter.
 
-**How this differs from joining.** R&O already uses membrane proofs to admit members to
-the network, signed by a `membrane_signer` key the joining service holds, distinct from the
-DNA progenitor (`MEMBRANE_MANAGEMENT.md` and its off-DHT companion). Conversation proofs
+**How this differs from joining.** R&O's joining membrane admits members by proof, verified
+against a dedicated `membrane_signer_pubkey` distinct from the DNA progenitor. Admission is
+decided pre-key in R&O's own application; the approval issues a single-use invite redeemed
+through the joining service, and the proof is signed at join (`MEMBRANE_MANAGEMENT.md` and
+its off-DHT companion). Conversation proofs
 reuse the mechanism and invert the custody model: where a proof is needed at all, either
 participant may sign it, and there is no ledger, no central key and no service in the loop. A
 proof is needed only to admit an agent not named in the clone's properties, which in practice

--- a/documentation/architecture/chat-system.md
+++ b/documentation/architecture/chat-system.md
@@ -6,7 +6,8 @@
 **Implementation status:** the cross-agent signal substrate (§7) is built and tested. The
 conversation DNA is partly built and in review as #183: the integrity membrane gate, the
 coordinator, the base-cell write refusal, the third role and membrane test coverage. The
-message and configuration entries are not built. Nothing else in this note is built.
+message entry and the context properties are not built. Nothing else in this note is
+built.
 **Relates to:** #91 (Chat System), #51 (Global Notifications), #12 (Real-time Signals),
 #144 (Breaking-version Migration), #163 / #162 (Flagging / Moderation)
 **Supersedes:** the *Security and Privacy* section of
@@ -232,12 +233,12 @@ that never reach agreement, which is most of them: browsing, asking, negotiating
 declining. It does not conceal a completed deal, and it should not, since an agreement is
 a deliberate mutual public act.
 
-Two consequences for the exchange layer. A conversation can hold the agreement id and
-resolve it frontend-side, but the reverse lookup from a public agreement to a private
-conversation cannot exist, and is not needed: only participants would want it and they are
-already inside the clone. And any conversation identifier stored on the agreement must be
-an opaque random value, never derived from the conversation's network seed, which stays
-secret (§6).
+Two consequences for the exchange layer. A conversation holds the agreement id as a
+committed system message (§9) and resolves it frontend-side, but the reverse lookup from a
+public agreement to a private conversation cannot exist, and is not needed: only
+participants would want it and they are already inside the clone. And any conversation
+identifier stored on the agreement must be an opaque random value, never derived from the
+conversation's network seed, which stays secret (§6).
 
 **Dependency.** Where the response-to-a-listing event lives is not messaging's decision.
 The `exchanges` name is reserved in the frontend's `ZomeName` union but nothing implements
@@ -367,17 +368,30 @@ Two models, because two DNAs are involved.
 
 **In the conversation clone:**
 
-- `Message { content, message_type, reply_to?, created_at }`. Content is plaintext (§6).
-  `message_type` distinguishes member messages from system messages, of which the
-  administrator-invitation notice (§10) is one.
-- Conversation metadata as a configuration entry: the listing hash this conversation
-  concerns, its type (Request, Offer, Direct), and an optional hREA proposal id. Both the
-  listing hash and the proposal id are resolved frontend-side against the other cells;
+- `Message { content, message_type, reply_to? }`. Content is plaintext (§6). The action
+  carries the authoritative timestamp, so the entry does not repeat it as a forgeable client
+  copy. `message_type` distinguishes member messages from system messages, of which the
+  administrator-invitation notice (§10) and the agreement announcement below are two.
+- Creation-time context as DNA properties, not an entry. The clone's properties carry the
+  listing hash this conversation concerns and its type (Request, Offer, Direct), alongside
+  the conversation id and participant pair they already carry (§5). Every participant's
+  clone is then self-describing from `dna_info()` with no DHT read, and the invitation
+  transmits nothing extra, since properties already travel with it. Volla carries
+  per-conversation context in properties in production. Properties being immutable means a
+  conversation cannot be re-pointed at a different listing; it never should be, so the
+  wrong state is unrepresentable rather than guarded against.
+- The hREA proposal id is not creation-time context: a conversation produces its agreement
+  mid-life (§5). When it does, the id is committed as a system message in the stream at the
+  moment the deal was struck, reusing the mechanism §10 already requires. It reaches every
+  participant through the same reads that render the messages, so retrieval costs nothing
+  the client is not already paying. An earlier revision put all three fields on a
+  configuration entry; the mid-life id would have forced an update chain onto it, where
+  this shape keeps the conversation's context append-only: properties fixed at creation,
+  the agreement announced by appended message.
+- The listing hash and the proposal id are resolved frontend-side against the other cells;
   neither is a DHT link, and neither can be.
 - Links: conversation to messages, time-bucketed for pagination. The message update chain.
-  A path anchor to the configuration entry, without which that entry has no base and is
-  unreachable to a joining participant. Earlier revisions of this note specified no link for
-  it; that was an omission rather than a decision.
+  No other entry exists to need one.
 
 Participants are the clone's membrane, not a field on an entry.
 
@@ -442,12 +456,13 @@ The guarantee, in plain terms:
 1. **Substrate.** Cap grant and remote signal path. (DONE, §7.)
 2. **Prove it.** Two-conductor Sweettest. (DONE.)
 3. **Conversation DNA.** A new DNA in this repository with integrity and coordinator zomes,
-   the message and configuration entries, and membrane validation against the participant
-   pair named in the clone's properties. Registered as a third role in `workdir/happ.yaml`
-   with a non-zero clone limit and `deferred: false`, which the platform forces rather than
-   Volla merely suggesting (§4). (PARTLY DONE, #183: the DNA, the membrane gate, the
-   coordinator, the base-cell write refusal, the role and membrane test coverage. The message
-   and configuration entries remain.)
+   the message entry, the creation-time context in the clone's properties, the agreement
+   system message, and membrane validation against the participant pair those properties
+   name. Registered as a third role in `workdir/happ.yaml` with a non-zero clone limit and
+   `deferred: false`, which the platform forces rather than Volla merely suggesting (§4).
+   (PARTLY DONE, #183: the DNA, the membrane gate, the coordinator, the base-cell write
+   refusal, the role and membrane test coverage. The message entry and the context
+   properties remain.)
 4. **Clone lifecycle.** Create, join, disable, remove, and the frontend's conversation list
    assembled by enumerating clones. This needs its own harness: #183 provisions the role
    directly and does not exercise cloning. A freshly created or joined clone has no cap grant

--- a/documentation/architecture/chat-system.md
+++ b/documentation/architecture/chat-system.md
@@ -1,0 +1,142 @@
+# Messaging System — Architecture Design Note
+
+**Status:** Design of record.
+**R&O version at time of writing:** v0.6.1 (application release)
+**Implementation status:** The cross-agent signal substrate (see §7, build sequence steps 1–2) is **built and tested** on hdk 0.6.0, proven by a two-conductor Sweettest. The encryption and persistence layers below it (§5, §6, §8) are **designed but not yet built** — the substrate currently carries plaintext over an ephemeral signal. Read the sections below as the agreed plan, with only the substrate landed so far.
+**Relates to:** #91 (Chat System), #51 (Global Notifications), #12 (Real-time Signals), #144 (Breaking-version Migration), #163 / #162 (Flagging / Moderation)
+**Supersedes:** the *Security and Privacy* section of `documentation/requirements/post-mvp/messaging-system.md`
+
+---
+
+## Decisions at a glance
+
+- Private messaging in R&O uses **content encryption on the single shared DNA** (keypair-locking). Not membrane-isolated per-conversation DNAs, and not link-based checks.
+- Delivery is **persist plus signal**: every message is a committed encrypted entry (durability) *and* a remote signal (liveness). *(Substrate for the signal half is built; the persisted encrypted entry is next.)*
+- Deletion is **soft-delete now, plus non-migration at the next network bump**. Crypto-shredding was considered and is **out of scope** (see §8).
+- The cross-agent signal substrate is **step one, and is now done**: cap grant, `send_remote_signal`, `recv_remote_signal`, provenance, all verified end to end.
+
+---
+
+## 1. What this note decides
+
+#91 specifies the chat system in depth but leaves its central privacy question open, offering "Option A (single DNA, link-based participant checks) for MVP, Option B (Volla-style DNA per conversation) for production privacy." Neither is right for R&O as written: Option A is not private, and Option B breaks the feature's own data model. This note resolves that question, corrects the security framing inherited from `messaging-system.md`, and pins the message lifecycle and deletion model so the build can proceed. It is the design of record; #91 remains the implementation task list.
+
+## 2. Signing is not encryption
+
+`messaging-system.md` states messages are secured by "encryption via Holochain's agent-centric security model." That conflates two separate properties.
+
+The agent-centric model gives every action a signature by its author's agent key. That yields **authenticity, integrity, and non-repudiation** for free: any agent can verify who wrote a message and that it has not been altered. It does **not** give confidentiality. A public DHT entry is plaintext to any agent who can fetch and validate it. Signing proves authorship; it does not hide content.
+
+Confidentiality is therefore a deliberate, separate choice. The proof is close to hand: Fieldnotes had to add its own encryption layer (`crypto.rs`) precisely because Holochain does not encrypt entry content for you.
+
+## 3. Three ways to make messages private
+
+There is no single "private messaging" primitive in Holochain. There are three mechanisms, and the reference apps each pick a different one. Their code was read directly rather than taken on description.
+
+**Ephemeral, no persistence (ZipZap).** The message travels as a remote signal and is never written to the DHT. Private because nothing is stored. Cost: no history, and both parties must be online. Fit for typing indicators, presence, and read receipts, nothing heavier. *This is the exact pattern the current substrate is built on.*
+
+**Membrane-isolated per conversation (Volla Messages).** Each conversation is a separate cloned DNA with membrane proofs; non-participants are not in that network and never receive the entries. Volla's zomes contain no content encryption at all (grepped: no x25519, crypto_box, or private entries). Privacy is structural. This is durable and is the canonical Holochain chat pattern, but it is operationally heavy (a cell per conversation) and, decisively for us, it isolates each conversation from the main DHT.
+
+**Content-encrypted on the shared DNA (the Fieldnotes pattern).** Message content is encrypted so only participants can read it, and the ciphertext lives as an ordinary entry in the main DHT. This is the only one of the three that is genuinely end-to-end encryption. It keeps everything in one DHT. `crypto.rs` already implements it and is tested.
+
+## 4. Decision: content encryption on the single R&O DNA
+
+R&O keeps conversations and messages as entries in the existing `requests_and_offers` DNA and makes them private by encrypting content, using the keypair-locking pattern proven in Fieldnotes.
+
+The reason is R&O's own data model. #91's conversations link to requests, offers, organisations, and hREA proposals: `RequestToConversation`, `OfferToConversation`, `AgentToConversations` (the inbox), `OrganizationToConversations` (channels), `ConversationToProposal` (the hREA hook). That cross-domain linking is the entire "conversation first, propose a deal second" premise of the feature, and it only works if conversations live in the same DHT as the things they link to.
+
+Volla can afford membrane-per-conversation because a pure messenger has nothing to link to. R&O does. Adopting Volla's model would turn every one of those links into cross-cell plumbing and make propose-from-inside-a-chat genuinely hard. So Option B is out for the general case. Option A (link-based checks in a shared DNA) is also out, because it provides no confidentiality at all: any agent can read the entries regardless of the link structure.
+
+Content encryption is the synthesis #91 did not consider, because it framed the choice as membrane-or-nothing: keep the single DNA and all its linking, and get privacy from encryption instead of isolation.
+
+Membrane-per-conversation is retained as a **known escalation**, not a rejection. If a specific requirement ever demands network-level isolation for a class of conversation, Volla's pattern plus R&O's existing membrane-management work is the route, accepting the loss of linking for those conversations.
+
+## 5. Message lifecycle: persist plus signal
+
+ZipZap delivers liveness only; Volla persists. R&O needs both, so a message is written once and signalled once.
+
+1. **Encrypt.** The sender encrypts the message content (see §6).
+2. **Persist.** The sender commits it as a `Message` entry, linked into the conversation and into each participant's inbox. This is durability: the message survives, and reaches an offline recipient when they next come online and query their inbox.
+3. **Signal.** The sender calls `send_remote_signal` to the participants. This is liveness: if a recipient is online, their `recv_remote_signal` fires and their UI updates immediately.
+
+Step 3 is necessary because `post_commit` runs only on the committing agent. R&O's existing signal system emits `EntryCreated` locally to the sender's own client; nothing in it crosses to another agent. The remote signal is the only cross-agent path.
+
+**Built so far:** step 3 (the cross-agent signal). Steps 1 and 2 (encryption and the persisted entry) are the next work.
+
+## 6. Encryption detail
+
+Two cases, both covered by the Fieldnotes pattern (to be ported into the conversations zome; not yet present in R&O).
+
+**One to one.** A text message is small, comfortably under lair's 8 KB crypto_box ceiling, so it is locked directly to the recipient with `encrypt_to_agent` (lair's crypto_box, which converts the Ed25519 agent key to X25519 internally). No content key, no hybrid. Every participant's key is already known: it is their `AgentPubKey` (the 32-byte Ed25519 core).
+
+**Group and attachments.** For organisation channels and any payload over the 8 KB ceiling, use the hybrid: encrypt the content once with a fresh single-use key via `bulk_encrypt` (ChaCha20-Poly1305, host-side, no IPC limit), then wrap only that 32-byte key to each participant through `encrypt_to_agent`. This is the re-wrappable cohort pattern (Model B). It is what lets a many-participant channel or a file attachment be readable by the whole set.
+
+**Harden from the start.** Fieldnotes' `crypto.rs` uses an empty associated-data field, which means the ciphertext is not bound to its entry location. For messaging, bind the AEAD associated data to the conversation and sender, so a ciphertext cannot be lifted from one context and replayed in another. Cheap to do at the outset, awkward to retrofit.
+
+## 7. The substrate: cross-agent signalling (BUILT)
+
+R&O had no cross-agent signalling: its `init` was a bare `Ok(Pass)` and it held no cap grants. Its six zomes only ever emitted local signals to their own client via `post_commit`.
+
+The substrate is the ZipZap pattern, verified line by line against hdk 0.6.0 canon (this caught two drifts from ZipZap's 0.4 code: `GrantedFunctions::Listed` takes a `HashSet` not a `BTreeSet`, and the `SerializedBytes` derive is unnecessary on 0.6). It lives in a new coordinator-only `messaging` zome, mirroring the existing `misc` zome:
+
+- an `init` that creates an **Unrestricted** cap grant for `recv_remote_signal` (committed as a Private entry on the agent's own chain);
+- a `recv_remote_signal` handler that reads the sender from `call_info()?.provenance` and re-emits to the UI;
+- `send_remote_signal` in the `send_message` path;
+- a `Signal::Message` variant;
+- a `ping` health-check whose secondary job is to trigger lazy `init`, so a recipient's cap grant is committed before a signal arrives.
+
+**Proven** by a two-conductor Sweettest: Alice's `send_message` reaches Bob as a `Signal::Message` with correct content and a `from` field carrying Alice's key via provenance.
+
+**Security consequence of Unrestricted.** An unrestricted grant means any agent can call `recv_remote_signal` and push a signal to you. That is expected for messaging (you cannot know your correspondents in advance), but it means unsolicited or abusive signals are possible at the substrate level. Filtering (surface only messages from known contacts, rate-limit, tie into the flagging primitive #163) is an application-layer concern, not a substrate one.
+
+**Lazy init, noted.** A cell's `init` runs on its first zome call, not at install. A recipient must have been called at least once before a remote signal is authorised, or the grant does not yet exist and the signal is dropped silently. In the app this is a non-issue (a user's cell is exercised on login); the test primes both cells with `ping` to reproduce that.
+
+## 8. Deletion model
+
+Deletion on an append-only DHT is not erasure. R&O's model is layered and honest.
+
+**Now: soft-delete.** A deleted message is marked deleted and hidden from the UI, reusing the Active / Archived / Deleted status pattern already in the app.
+
+**At the next network bump: non-migration.** #144 (breaking-version migration) is a curation boundary: when the DNA modifiers change and a new DHT stands up, something decides what data seeds the new network. Deleted messages are simply not carried forward. The framing is filter-before-seed, not migrate-then-delete: the deleted entry is never written into the new DHT and dies with the abandoned cell. Under this design the abandoned cell holds only ciphertext, and if the keys are not migrated either, that ciphertext is permanently unreadable.
+
+**Out of scope: crypto-shredding.** Considered and deliberately deferred. Destroying a message's key would make its ciphertext unreadable immediately, without waiting for a migration. But it closes only a narrow window — between soft-delete and the next bump — and only against an adversary who has retained a copy of the old DHT *and* was one of the participants who could decrypt it. That is not R&O's threat model: this is commons infrastructure for cooperating members inside a membrane-gated network, not a tool built to resist a hostile party with a legal-grade erasure requirement. Worse, it forces a real downgrade: to shred a key you must be able to destroy it, which means keys cannot be durable DHT entries and must live device-locally, which makes message history device-bound — lose the device, lose the messages. Trading durable, recoverable history for an erasure guarantee most members will never need is the wrong default. Revisit only if a specific use case genuinely requires immediate cryptographic erasure (for example a dedicated channel for sensitive disclosures), and treat that as a scoped, opt-in decision, not the platform default.
+
+**The ceiling, stated plainly.** Anyone who retained the old cell's databases still holds the ciphertext bytes. Un-migrated keys make them meaningless, but the bytes exist. This is the true limit on any Holochain app, and the layered answer above is about as close to erasure as the substrate allows. Member-facing copy should say what "delete" means honestly: hidden immediately, cleared from the network at the next update — not instant total erasure.
+
+## 9. Entry and link model
+
+Adapted from #91, with the content field now carrying ciphertext.
+
+- `Message { conversation_hash, ciphertext, nonce, message_type, reply_to?, created_at }`. Content is the encrypted blob plus nonce, not plaintext. `message_type` distinguishes text from system messages (proposal actions, joins).
+- `Conversation { participants, context_hash?, context_type?, title?, created_at }`. `context_type` is Request, Offer, Organization, or Direct.
+- Links as #91 lists them: conversation to messages (time-bucketed for pagination, Volla's pattern), agent to conversations (inbox), request / offer / organization to conversation (context), conversation to hREA proposal (the exchange hook), message update chain.
+
+One open modelling question: whether a one-to-one `Conversation` needs its own entry or can be addressed by a deterministic id derived from the participant pair. Deferred to implementation.
+
+## 10. Build sequence
+
+The order follows the dependencies, not #91's phase numbers.
+
+1. **Substrate.** Add the init cap grant and the send / recv remote-signal path to one zome. *(DONE — the `messaging` zome, #12's unbuilt cross-agent half.)*
+2. **Prove it.** An ephemeral round-trip between two agents. *(DONE — two-conductor Sweettest, passing.)*
+3. **Persisted encrypted layer.** The `Message` and `Conversation` entries, the encryption, the persist-plus-signal send path. *(NEXT.)*
+4. **UI.** Conversation list, thread, inbox, and the request / offer entry points.
+
+## 11. Open questions carried forward
+
+- Key location for the encrypted layer (which agent keys, extraction of the 32-byte Ed25519 core from an `AgentPubKey` for `encrypt_to_agent`).
+- Organisation-channel membership churn and key re-wrap on join.
+- One-to-one `Conversation` entry versus derived id (see §9).
+- Escalation criteria for moving a conversation class to membrane isolation (§4).
+
+*Resolved and closed:* the HDK pin (hdk 0.6.0 / hdi 0.7.0, confirmed against Cargo.lock) and the durability-versus-shreddability fork (settled in favour of durable history; crypto-shred out of scope, §8).
+
+## 12. References
+
+- Fieldnotes `crypto.rs`: the keypair-locking and hybrid encryption pattern, tested (round-trip, tamper, wrong-key).
+- ZipZap (`github.com/lightningrodlabs/zipzap`): the ephemeral cross-agent signal substrate. The pattern the built substrate is based on.
+- Volla Messages (`github.com/holochain-apps/volla-messages`): membrane-isolated persistent chat; the durability and time-bucketing patterns.
+- #91: chat system implementation specification.
+- #51, #12: notifications and the shared real-time signal substrate.
+- #144: breaking-version migration, on which the deletion model depends.
+- #163, #162: flagging and moderation, the application-layer filter for unsolicited messages.

--- a/documentation/architecture/chat-system.md
+++ b/documentation/architecture/chat-system.md
@@ -1,142 +1,436 @@
 # Messaging System — Architecture Design Note
 
 **Status:** Design of record.
-**R&O version at time of writing:** v0.6.1 (application release)
-**Implementation status:** The cross-agent signal substrate (see §7, build sequence steps 1–2) is **built and tested** on hdk 0.6.0, proven by a two-conductor Sweettest. The encryption and persistence layers below it (§5, §6, §8) are **designed but not yet built** — the substrate currently carries plaintext over an ephemeral signal. Read the sections below as the agreed plan, with only the substrate landed so far.
-**Relates to:** #91 (Chat System), #51 (Global Notifications), #12 (Real-time Signals), #144 (Breaking-version Migration), #163 / #162 (Flagging / Moderation)
-**Supersedes:** the *Security and Privacy* section of `documentation/requirements/post-mvp/messaging-system.md`
+**Holochain stack:** hdk 0.6.1 / hdi 0.7.1 / conductor 0.6.1, confirmed against `Cargo.lock`.
+**R&O application version:** to be confirmed against the root `package.json` before publication.
+**Implementation status:** the cross-agent signal substrate (§7) is built and tested.
+Nothing else in this note is built.
+**Relates to:** #91 (Chat System), #51 (Global Notifications), #12 (Real-time Signals),
+#144 (Breaking-version Migration), #163 / #162 (Flagging / Moderation)
+**Supersedes:** the *Security and Privacy* section of
+`documentation/requirements/post-mvp/messaging-system.md`
 
 ---
 
 ## Decisions at a glance
 
-- Private messaging in R&O uses **content encryption on the single shared DNA** (keypair-locking). Not membrane-isolated per-conversation DNAs, and not link-based checks.
-- Delivery is **persist plus signal**: every message is a committed encrypted entry (durability) *and* a remote signal (liveness). *(Substrate for the signal half is built; the persisted encrypted entry is next.)*
-- Deletion is **soft-delete now, plus non-migration at the next network bump**. Crypto-shredding was considered and is **out of scope** (see §8).
-- The cross-agent signal substrate is **step one, and is now done**: cap grant, `send_remote_signal`, `recv_remote_signal`, provenance, all verified end to end.
+- Conversations are **membrane-isolated clones**, one cloned DNA per conversation, not
+  entries on the shared `requests_and_offers` DNA.
+- Isolation is the **default for every conversation**, not an escalation for a sensitive
+  subset.
+- **No content encryption inside a clone.** Isolation is the confidentiality mechanism.
+- A conversation is created by **responding to a listing**. The response carries a random
+  network seed and a membrane proof, encrypted to the recipient.
+- Seeds are **random and transmitted**, never derived from public values (§6).
+- Deletion is **leave-and-remove**, which genuinely removes local data, plus archive for
+  tidiness. Crypto-shredding is not available on this platform (§8).
+- Administrators have **no standing access**. A participant may invite one, and that
+  invitation is announced in the conversation as a committed system message (§10).
+- The isolation guarantee has an **operational dependency**: R&O must run its own
+  bootstrap server with authentication enabled (§6).
 
 ---
 
 ## 1. What this note decides
 
-#91 specifies the chat system in depth but leaves its central privacy question open, offering "Option A (single DNA, link-based participant checks) for MVP, Option B (Volla-style DNA per conversation) for production privacy." Neither is right for R&O as written: Option A is not private, and Option B breaks the feature's own data model. This note resolves that question, corrects the security framing inherited from `messaging-system.md`, and pins the message lifecycle and deletion model so the build can proceed. It is the design of record; #91 remains the implementation task list.
+#91 specifies the chat system in depth but leaves its central privacy question open,
+offering "Option A (single DNA, link-based participant checks) for MVP, Option B
+(Volla-style DNA per conversation) for production privacy". This note resolves that
+question in favour of isolation, and sets out the conversation lifecycle, the deletion
+model, the administrator access model and the member-facing guarantee that follow from it.
+
+The argument turns on a distinction #91 does not draw: the difference between protecting
+what was said and protecting who said it to whom. §3 sets out why that distinction
+decides the design.
+
+This note is the design of record. #91 remains the implementation task list.
 
 ## 2. Signing is not encryption
 
-`messaging-system.md` states messages are secured by "encryption via Holochain's agent-centric security model." That conflates two separate properties.
+`messaging-system.md` states messages are secured by "encryption via Holochain's
+agent-centric security model". That conflates two separate properties.
 
-The agent-centric model gives every action a signature by its author's agent key. That yields **authenticity, integrity, and non-repudiation** for free: any agent can verify who wrote a message and that it has not been altered. It does **not** give confidentiality. A public DHT entry is plaintext to any agent who can fetch and validate it. Signing proves authorship; it does not hide content.
+The agent-centric model gives every action a signature by its author's agent key. That
+yields authenticity, integrity and non-repudiation for free: any agent can verify who
+wrote a message and that it has not been altered. It does not give confidentiality. A
+public DHT entry is plaintext to any agent who can fetch and validate it. Signing proves
+authorship; it does not hide content.
 
-Confidentiality is therefore a deliberate, separate choice. The proof is close to hand: Fieldnotes had to add its own encryption layer (`crypto.rs`) precisely because Holochain does not encrypt entry content for you.
+Confidentiality is therefore a deliberate, separate choice. This note makes it
+structurally rather than cryptographically.
 
-## 3. Three ways to make messages private
+## 3. What a shared DNA cannot protect
 
-There is no single "private messaging" primitive in Holochain. There are three mechanisms, and the reference apps each pick a different one. Their code was read directly rather than taken on description.
+There is no single private-messaging primitive in Holochain. There are three mechanisms.
 
-**Ephemeral, no persistence (ZipZap).** The message travels as a remote signal and is never written to the DHT. Private because nothing is stored. Cost: no history, and both parties must be online. Fit for typing indicators, presence, and read receipts, nothing heavier. *This is the exact pattern the current substrate is built on.*
+**Ephemeral, no persistence.** The message travels as a remote signal and is never
+written to any DHT. Private because nothing is stored. Cost: no history, and both parties
+must be online. This is the pattern the built substrate uses (§7), and it remains useful
+for liveness and for invitation delivery (§5).
 
-**Membrane-isolated per conversation (Volla Messages).** Each conversation is a separate cloned DNA with membrane proofs; non-participants are not in that network and never receive the entries. Volla's zomes contain no content encryption at all (grepped: no x25519, crypto_box, or private entries). Privacy is structural. This is durable and is the canonical Holochain chat pattern, but it is operationally heavy (a cell per conversation) and, decisively for us, it isolates each conversation from the main DHT.
+**Content-encrypted on a shared DNA.** Message content is encrypted so only participants
+can read it, and the ciphertext lives as an ordinary entry in the shared DHT. This is
+genuine end-to-end encryption of content, and it works in a zome on this stack (§6).
 
-**Content-encrypted on the shared DNA (the Fieldnotes pattern).** Message content is encrypted so only participants can read it, and the ciphertext lives as an ordinary entry in the main DHT. This is the only one of the three that is genuinely end-to-end encryption. It keeps everything in one DHT. `crypto.rs` already implements it and is tested.
+**Membrane-isolated per conversation.** Each conversation is a separate cloned DNA gated
+by a membrane proof. Non-participants are not in that network and never receive the
+entries. Privacy is structural.
 
-## 4. Decision: content encryption on the single R&O DNA
+The choice between the second and third is decided by what content encryption leaves
+exposed.
 
-R&O keeps conversations and messages as entries in the existing `requests_and_offers` DNA and makes them private by encrypting content, using the keypair-locking pattern proven in Fieldnotes.
+**The author field.** Every Holochain action carries a public `author: AgentPubKey`.
+Ten action variants in `holochain_integrity_types` 0.6.1 each declare it, and it cannot be
+otherwise, because validation is signature verification against the author's key. An
+action whose author cannot be read cannot be validated, so the DHT cannot function
+without it.
 
-The reason is R&O's own data model. #91's conversations link to requests, offers, organisations, and hREA proposals: `RequestToConversation`, `OfferToConversation`, `AgentToConversations` (the inbox), `OrganizationToConversations` (channels), `ConversationToProposal` (the hREA hook). That cross-domain linking is the entire "conversation first, propose a deal second" premise of the feature, and it only works if conversations live in the same DHT as the things they link to.
+On a shared DNA, any member can therefore fetch a message entry and read its action,
+which names the sender and the time, with no decryption, no link traversal and no
+privileged position. Correlated against the public request and offer entries a
+conversation is linked to, that reconstructs who is negotiating with whom about what. A
+hundred messages leave a hundred such records.
 
-Volla can afford membrane-per-conversation because a pure messenger has nothing to link to. R&O does. Adopting Volla's model would turn every one of those links into cross-cell plumbing and make propose-from-inside-a-chat genuinely hard. So Option B is out for the general case. Option A (link-based checks in a shared DNA) is also out, because it provides no confidentiality at all: any agent can read the entries regardless of the link structure.
+A shared-DNA entry model leaks in several further places, and only one is fixable:
 
-Content encryption is the synthesis #91 did not consider, because it framed the choice as membrane-or-nothing: keep the single DNA and all its linking, and get privacy from encryption instead of isolation.
+- a `participants` field on a public conversation entry (fixable by encrypting it);
+- an agent-to-conversations inbox link, whose base is a public agent key;
+- a listing-to-conversation context link, revealing who is negotiating over what;
+- creation timestamps and time-bucketed message links, giving timing and volume.
 
-Membrane-per-conversation is retained as a **known escalation**, not a rejection. If a specific requirement ever demands network-level isolation for a class of conversation, Volla's pattern plus R&O's existing membrane-management work is the route, accepting the loss of linking for those conversations.
+Link bases are public by construction and pagination requires the buckets, so the last
+three are not fixable. None of them matters beside the author field, which sits in the
+action wrapper rather than the entry body and so cannot be encrypted at all.
 
-## 5. Message lifecycle: persist plus signal
+**Why this decides it.** R&O's threat model includes an adversary who joins the membrane
+specifically to harvest. Against that adversary, content encryption on a shared DNA
+protects what was said and exposes the social graph in full. For a mutual aid network the
+graph is frequently the sensitive part: knowing a member is in sustained contact with a
+particular coordinator conveys most of what the content would, and unlike content it
+requires no cryptographic work to obtain.
 
-ZipZap delivers liveness only; Volla persists. R&O needs both, so a message is written once and signalled once.
+## 4. Decision: membrane-isolated conversation clones
 
-1. **Encrypt.** The sender encrypts the message content (see §6).
-2. **Persist.** The sender commits it as a `Message` entry, linked into the conversation and into each participant's inbox. This is durability: the message survives, and reaches an offline recipient when they next come online and query their inbox.
-3. **Signal.** The sender calls `send_remote_signal` to the participants. This is liveness: if a recipient is online, their `recv_remote_signal` fires and their UI updates immediately.
+Every conversation is a cloned DNA with its own network seed, its own DHT and its own
+membrane, containing exactly its participants.
 
-Step 3 is necessary because `post_commit` runs only on the committing agent. R&O's existing signal system emits `EntryCreated` locally to the sender's own client; nothing in it crosses to another agent. The remote signal is the only cross-agent path.
+A harvester who is not in the clone cannot fetch its actions at all, so the author field
+stops being a leak: it still exists inside the clone, where both parties already know who
+said what. Exposure reduces from one permanent record per message, with full structure, to
+at most one record per conversation at initiation (§5).
 
-**Built so far:** step 3 (the cross-agent signal). Steps 1 and 2 (encryption and the persisted entry) are the next work.
+**Why the default rather than an escalation.** A tiered model asks members to predict
+sensitivity before the conversation happens. People predict that badly, and the wrong
+guess is not recoverable once the messages are written. Uniform isolation removes the
+prediction.
 
-## 6. Encryption detail
+**Cross-domain references survive.** The objection to isolation is that it breaks R&O's
+links from conversations to requests, offers and organisations. In practice R&O already
+resolves a cross-DNA reference frontend-side: hREA proposals live in the separate `hrea`
+DNA, and `ui/src/lib/services/hrea.service.ts` resolves them over GraphQL rather than by
+any DHT link. A conversation clone holds the listing hash it concerns and resolves it the
+same way. The reference becomes one-directional: a participant can enumerate their own
+conversations and see which listing each concerns, and nobody can go the other way from a
+listing to its conversations. That is a small feature loss and a privacy gain.
 
-Two cases, both covered by the Fieldnotes pattern (to be ported into the conversations zome; not yet present in R&O).
+**What it costs.** This is not a configuration change. `workdir/happ.yaml` declares two
+roles, both with `clone_limit: 0`. Isolation requires a third role backed by a new
+conversation DNA built in this repository, with its own integrity and coordinator zomes
+and a non-zero clone limit.
 
-**One to one.** A text message is small, comfortably under lair's 8 KB crypto_box ceiling, so it is locked directly to the recipient with `encrypt_to_agent` (lair's crypto_box, which converts the Ed25519 agent key to X25519 internally). No content key, no hybrid. Every participant's key is already known: it is their `AgentPubKey` (the 32-byte Ed25519 core).
+**Precedent.** Volla Messages runs this model in production on Android and desktop. Their
+`happ.yaml` declares a single role with `clone_limit: 100` and `deferred: false`. Their
+integrity zome defines a `MembraneProofData` struct carrying a `conversation_id`, a
+target agent and a role, wrapped in a signed envelope, with DNA properties carrying a
+progenitor: a conversation clone is admitted by a progenitor-signed proof naming that
+specific conversation. Their entry types are all public with no visibility attribute, and
+their zomes contain no content encryption at all.
 
-**Group and attachments.** For organisation channels and any payload over the 8 KB ceiling, use the hybrid: encrypt the content once with a fresh single-use key via `bulk_encrypt` (ChaCha20-Poly1305, host-side, no IPC limit), then wrap only that 32-byte key to each participant through `encrypt_to_agent`. This is the re-wrappable cohort pattern (Model B). It is what lets a many-participant channel or a file attachment be readable by the whole set.
+Volla's profiles and file storage live inside the conversation clone, so they have no
+global member directory, and their invitation mechanism is an out-of-band QR exchange.
+R&O's shared DNA is exactly what they lack, and it is what makes isolation practical here
+without QR swapping (§5).
 
-**Harden from the start.** Fieldnotes' `crypto.rs` uses an empty associated-data field, which means the ciphertext is not bound to its entry location. For messaging, bind the AEAD associated data to the conversation and sender, so a ciphertext cannot be lifted from one context and replayed in another. Cheap to do at the outset, awkward to retrofit.
+**Unmeasured.** What a conductor costs at high cell count on R&O's stack. Volla runs 100
+clones as a pure messenger; R&O carries the shared DNA and the hREA cell alongside. This
+is measurable directly and should be measured before the clone limit is chosen.
+
+## 5. Conversation lifecycle
+
+**Creation.** A conversation begins when one member responds to another's listing. The
+response is the invitation. This reuses an interaction R&O wants anyway rather than
+introducing a separate invitation artefact with its own metadata cost.
+
+**Invitation contents.** A random network seed, and a membrane proof admitting the
+recipient to the clone, encrypted to the recipient's agent key. The responder creates the
+clone and is its progenitor. The recipient decrypts, creates a clone with the same seed
+and their proof, and the two are in a network nobody else can locate or enter.
+
+**Delivery, signal first.** If the recipient is online, the invitation travels as a remote
+signal and nothing is persisted anywhere, so the conversation leaves no trace on any DHT.
+Only if no acknowledgement arrives does the sender fall back to a persisted entry on the
+shared DNA. Signals are fire-and-forget with no delivery confirmation, so this requires
+the recipient's client to acknowledge by signal, and there is a race if the recipient
+appears just after the sender gives up. That race resolves to a persisted invitation,
+which is the safe direction.
+
+**The residual exposure.** A persisted invitation is an action authored by the responder,
+and that is unavoidable. What is avoidable is whether it names the recipient. Linking it
+from the listing draws the edge explicitly. Placing it under a global anchor, with each
+member scanning and keeping what decrypts, hides the recipient and leaves only the fact
+that someone responded at a given time. The anchor approach costs a scan proportional to
+total invitations, which is acceptable at community scale and should be time-bucketed.
+
+**Message delivery within a clone.** Persist plus signal. A message is committed as an
+entry in the clone, which is durability and reaches an offline participant when they
+return, and sent as a remote signal, which is liveness. `post_commit` runs only on the
+committing agent, so the remote signal is the only cross-agent path.
+
+**Dependency.** Where the response-to-a-listing event lives is not messaging's decision.
+The `exchanges` name is reserved in the frontend's `ZomeName` union but nothing implements
+it, and no domain store or composable exists for it. R&O runs hREA as a second DNA, and
+ValueFlows models proposals, intents, commitments and agreements, so the agreement itself
+may properly belong there. This note specifies what the conversation layer needs from that
+event, not where it is built.
+
+## 6. Encryption inside a clone
+
+**Not required.** A conversation clone contains exactly its participants, and both hold
+the plaintext by definition. Encrypting content that only its intended readers can fetch
+adds key management, key recovery and a device-loss failure mode in exchange for very
+little. Volla, a dedicated privacy messenger, reaches the same conclusion.
+
+**Data at rest.** Clone contents sit unencrypted in the conductor's local databases.
+Device-level protection is the member's own full-disk encryption, and member-facing copy
+should say so.
+
+**What is available, should encryption ever be wanted.** Two routes work in a zome on this
+stack, both proven by passing Sweettests on `spike/crypto-feasibility`:
+
+- *Direct box to an agent key.* `ed_25519_x_salsa20_poly1305_encrypt(sender, recipient,
+  data)` and `ed_25519_x_salsa20_poly1305_decrypt(recipient, sender, encrypted)`. Note the
+  opposed argument orders: both parameters are `AgentPubKey`, so a swap compiles cleanly
+  and fails at runtime. The recipient decrypts asynchronously using only their own keystore
+  and the sender's public key, with no handshake and no requirement that the sender be
+  online. Lair performs the Ed25519 to X25519 conversion internally, so an agent's existing
+  key is already a valid encryption address and no key publication layer is needed.
+- *Shared secret with re-wrap.* `x_salsa20_poly1305_shared_secret_create_random` mints a
+  content key that never leaves lair; `_export` wraps it to another agent's X25519 key and
+  `_ingest` admits it to their keystore. Content is encrypted once and only the key is
+  wrapped per member, and a member admitted after the fact can be granted access by
+  re-wrapping. This is the route for group conversations if they are ever built. It
+  requires each agent to mint an X25519 keypair via `create_x25519_keypair` and publish the
+  public half, which the direct-box route does not need.
+
+**Two constraints on record.** Every zome crypto primitive routes through lair over IPC
+and rejects a single call above 8192 bytes, so neither route is proven for attachments;
+chunking would be required and is not yet tested. And using an agent's signing key for
+encryption invokes a documented caveat, which libsodium raises and Thormarker's 2021
+analysis addresses: joint security of an Ed25519 signature scheme and an X25519 KEM
+sharing a key pair is proven in the random oracle model, including in the presence of a
+signing oracle. The residual is forward secrecy, since a long-lived key used for key
+exchange means compromise exposes past exchanges. That is not achievable on this platform
+in any case (§8), and it is not part of R&O's threat model (§3).
+
+**The bootstrap dependency.** Isolation's guarantee is not complete at the DHT layer
+alone. Peer discovery runs through a bootstrap server, and in kitsune2 0.4.1 the space read
+route (`GET /bootstrap/{space}`) returns the agent list for whatever space identifier the
+caller supplies. It reads an `Authorization: Bearer` header, but with no authentication
+hook server configured the server issues tokens freely and treats every request as
+successful. On a public unauthenticated bootstrap, anyone who knows a space identifier can
+enumerate its members, which for a two-agent clone is a social graph edge.
+
+Two consequences follow. R&O should **run its own bootstrap with an authentication hook**,
+for which the existing joining service is the natural candidate. And independently,
+**network seeds must be random and transmitted, never derived from public values**. A seed
+derived from a listing hash and an agent key would be computable by every member, handing
+the conversation graph to anyone willing to enumerate. The membrane still prevents them
+entering the clone, but membership enumeration alone is the leak this design exists to
+prevent.
 
 ## 7. The substrate: cross-agent signalling (BUILT)
 
-R&O had no cross-agent signalling: its `init` was a bare `Ok(Pass)` and it held no cap grants. Its six zomes only ever emitted local signals to their own client via `post_commit`.
+R&O had no cross-agent signalling: `init` was a bare `Ok(Pass)` and no cap grants existed.
+Every coordinator zome emitted only local signals to its own client via `post_commit`.
 
-The substrate is the ZipZap pattern, verified line by line against hdk 0.6.0 canon (this caught two drifts from ZipZap's 0.4 code: `GrantedFunctions::Listed` takes a `HashSet` not a `BTreeSet`, and the `SerializedBytes` derive is unnecessary on 0.6). It lives in a new coordinator-only `messaging` zome, mirroring the existing `misc` zome:
+The substrate lives in a coordinator-only `messaging` zome:
 
-- an `init` that creates an **Unrestricted** cap grant for `recv_remote_signal` (committed as a Private entry on the agent's own chain);
-- a `recv_remote_signal` handler that reads the sender from `call_info()?.provenance` and re-emits to the UI;
-- `send_remote_signal` in the `send_message` path;
+- an `init` creating an Unrestricted cap grant for `recv_remote_signal`, committed as a
+  Private entry on the agent's own chain;
+- a `recv_remote_signal` handler reading the sender from `call_info()?.provenance` and
+  re-emitting to the UI;
+- `send_remote_signal` in the send path;
 - a `Signal::Message` variant;
-- a `ping` health-check whose secondary job is to trigger lazy `init`, so a recipient's cap grant is committed before a signal arrives.
+- a `ping` health-check whose secondary job is to trigger lazy `init`.
 
-**Proven** by a two-conductor Sweettest: Alice's `send_message` reaches Bob as a `Signal::Message` with correct content and a `from` field carrying Alice's key via provenance.
+Verified against hdk 0.6.0 canon, which caught two drifts from older reference code:
+`GrantedFunctions::Listed` takes a `HashSet` rather than a `BTreeSet`, and the
+`SerializedBytes` derive is unnecessary on 0.6. Proven by a two-conductor Sweettest.
 
-**Security consequence of Unrestricted.** An unrestricted grant means any agent can call `recv_remote_signal` and push a signal to you. That is expected for messaging (you cannot know your correspondents in advance), but it means unsolicited or abusive signals are possible at the substrate level. Filtering (surface only messages from known contacts, rate-limit, tie into the flagging primitive #163) is an application-layer concern, not a substrate one.
+**The grant is `Listed`, naming exactly one function.** Nothing else in the zome is
+remotely callable, which matters for anything added to it later.
 
-**Lazy init, noted.** A cell's `init` runs on its first zome call, not at install. A recipient must have been called at least once before a remote signal is authorised, or the grant does not yet exist and the signal is dropped silently. In the app this is a non-issue (a user's cell is exercised on login); the test primes both cells with `ping` to reproduce that.
+**Security consequence of Unrestricted.** Any agent can call `recv_remote_signal` and push
+a signal. That is expected for messaging, and filtering unsolicited or abusive signals is
+an application-layer concern tied to the flagging primitive (#163).
 
-## 8. Deletion model
+**Lazy init.** A cell's `init` runs on its first zome call, not at install. A recipient
+must have been called at least once before a remote signal is authorised. In the
+application this is a non-issue; the test primes both cells with `ping`.
 
-Deletion on an append-only DHT is not erasure. R&O's model is layered and honest.
+**Where it sits under this design.** The substrate carries invitations (§5) and provides
+liveness within a clone. Whether the zome belongs in the conversation DNA, the shared DNA,
+or both, is open (§13).
 
-**Now: soft-delete.** A deleted message is marked deleted and hidden from the UI, reusing the Active / Archived / Deleted status pattern already in the app.
+## 8. Deletion and archiving
 
-**At the next network bump: non-migration.** #144 (breaking-version migration) is a curation boundary: when the DNA modifiers change and a new DHT stands up, something decides what data seeds the new network. Deleted messages are simply not carried forward. The framing is filter-before-seed, not migrate-then-delete: the deleted entry is never written into the new DHT and dies with the abandoned cell. Under this design the abandoned cell holds only ciphertext, and if the keys are not migrated either, that ciphertext is permanently unreadable.
+**What the platform allows.** Destroying a key requires a store that can forget, and
+nothing in this stack can. The `lair_keystore_api` crate contains no deletion, removal or
+destruction operation for stored key material anywhere in its source, and Holochain's only
+purge operates on whole databases when a cell is uninstalled. The source chain is
+append-only by design; this is the architecture working as intended. Crypto-shredding is
+therefore not available, and nothing in the design should assume it as a future option.
 
-**Out of scope: crypto-shredding.** Considered and deliberately deferred. Destroying a message's key would make its ciphertext unreadable immediately, without waiting for a migration. But it closes only a narrow window — between soft-delete and the next bump — and only against an adversary who has retained a copy of the old DHT *and* was one of the participants who could decrypt it. That is not R&O's threat model: this is commons infrastructure for cooperating members inside a membrane-gated network, not a tool built to resist a hostile party with a legal-grade erasure requirement. Worse, it forces a real downgrade: to shred a key you must be able to destroy it, which means keys cannot be durable DHT entries and must live device-locally, which makes message history device-bound — lose the device, lose the messages. Trading durable, recoverable history for an erasure guarantee most members will never need is the wrong default. Revisit only if a specific use case genuinely requires immediate cryptographic erasure (for example a dedicated channel for sensitive disclosures), and treat that as a scoped, opt-in decision, not the platform default.
+**What isolation gives instead.** Removing a conversation clone removes its local
+databases. That is real removal of local data, not a soft-delete flag. The primitive is
+**leave and remove**: a participant may leave a conversation and delete their copy.
 
-**The ceiling, stated plainly.** Anyone who retained the old cell's databases still holds the ciphertext bytes. Un-migrated keys make them meaningless, but the bytes exist. This is the true limit on any Holochain app, and the layered answer above is about as close to erasure as the substrate allows. Member-facing copy should say what "delete" means honestly: hidden immediately, cleared from the network at the next update — not instant total erasure.
+**What it cannot do.** Remove the other participant's copy. No distributed system can
+compel that, and member-facing copy must not imply otherwise.
+
+**Archive.** A lighter action for tidiness: disable the clone so it stops running and drops
+out of the inbox, with data preserved and the clone re-enabled on demand. Holochain
+supports disabling and re-enabling clone cells directly.
 
 ## 9. Entry and link model
 
-Adapted from #91, with the content field now carrying ciphertext.
+Two models, because two DNAs are involved.
 
-- `Message { conversation_hash, ciphertext, nonce, message_type, reply_to?, created_at }`. Content is the encrypted blob plus nonce, not plaintext. `message_type` distinguishes text from system messages (proposal actions, joins).
-- `Conversation { participants, context_hash?, context_type?, title?, created_at }`. `context_type` is Request, Offer, Organization, or Direct.
-- Links as #91 lists them: conversation to messages (time-bucketed for pagination, Volla's pattern), agent to conversations (inbox), request / offer / organization to conversation (context), conversation to hREA proposal (the exchange hook), message update chain.
+**In the conversation clone:**
 
-One open modelling question: whether a one-to-one `Conversation` needs its own entry or can be addressed by a deterministic id derived from the participant pair. Deferred to implementation.
+- `Message { content, message_type, reply_to?, created_at }`. Content is plaintext (§6).
+  `message_type` distinguishes member messages from system messages, of which the
+  administrator-invitation notice (§10) is one.
+- Conversation metadata as a configuration entry: the listing hash this conversation
+  concerns, its type (Request, Offer, Direct), and an optional hREA proposal id. Both the
+  listing hash and the proposal id are resolved frontend-side against the other cells;
+  neither is a DHT link, and neither can be.
+- Links: conversation to messages, time-bucketed for pagination. The message update chain.
 
-## 10. Build sequence
+Participants are the clone's membrane, not a field on an entry.
 
-The order follows the dependencies, not #91's phase numbers.
+**On the shared `requests_and_offers` DNA:**
 
-1. **Substrate.** Add the init cap grant and the send / recv remote-signal path to one zome. *(DONE — the `messaging` zome, #12's unbuilt cross-agent half.)*
-2. **Prove it.** An ephemeral round-trip between two agents. *(DONE — two-conductor Sweettest, passing.)*
-3. **Persisted encrypted layer.** The `Message` and `Conversation` entries, the encryption, the persist-plus-signal send path. *(NEXT.)*
-4. **UI.** Conversation list, thread, inbox, and the request / offer entry points.
+- The invitation entry, only when signal delivery fails (§5): a random seed and a membrane
+  proof, encrypted to the recipient, under a time-bucketed global anchor.
 
-## 11. Open questions carried forward
+## 10. Administrator access
 
-- Key location for the encrypted layer (which agent keys, extraction of the 32-byte Ed25519 core from an `AgentPubKey` for `encrypt_to_agent`).
-- Organisation-channel membership churn and key re-wrap on join.
-- One-to-one `Conversation` entry versus derived id (see §9).
-- Escalation criteria for moving a conversation class to membrane isolation (§4).
+**No standing access.** Administrators are not members of any conversation clone by default
+and have no mechanism to enter one uninvited. Any design granting standing access would
+make the member-facing guarantee (§11) false.
 
-*Resolved and closed:* the HDK pin (hdk 0.6.0 / hdi 0.7.0, confirmed against Cargo.lock) and the durability-versus-shreddability fork (settled in favour of durable history; crypto-shred out of scope, §8).
+**Participant invitation only.** A participant may invite an administrator into a
+conversation, for support or dispute resolution.
 
-## 12. References
+**Announced, structurally.** The invitation commits a system message to the conversation,
+so every participant sees that it happened. This must be a committed entry rather than a
+client-side rendering, so a modified client cannot suppress it.
 
-- Fieldnotes `crypto.rs`: the keypair-locking and hybrid encryption pattern, tested (round-trip, tamper, wrong-key).
-- ZipZap (`github.com/lightningrodlabs/zipzap`): the ephemeral cross-agent signal substrate. The pattern the built substrate is based on.
-- Volla Messages (`github.com/holochain-apps/volla-messages`): membrane-isolated persistent chat; the durability and time-bucketing patterns.
-- #91: chat system implementation specification.
-- #51, #12: notifications and the shared real-time signal substrate.
-- #144: breaking-version migration, on which the deletion model depends.
-- #163, #162: flagging and moderation, the application-layer filter for unsolicited messages.
+**What the administrator sees.** Gossip carries the clone's full history. An administrator
+invited today reads everything said before they arrived, from both participants. This is
+retrospective access to the entire conversation, not observation from the moment of
+joining, and the consent wording must say so plainly rather than implying an administrator
+is joining an ongoing room.
+
+**Not a substitute for flagging.** Screenshot-based reporting into the flagging primitive
+(#163) remains available and discloses far less. Administrator invitation is the heavier
+instrument and should be presented as such.
+
+**Open for governance.** The exact consent wording, and whether both participants must
+agree rather than one inviting unilaterally with notice, is a governance decision rather
+than an architectural one.
+
+## 11. What members are told
+
+The guarantee, in plain terms:
+
+- Conversations are visible only to their participants. Other members of the network
+  cannot see that a conversation exists, who is in it, or anything said in it.
+- Responding to a listing may leave a record that you responded, if the other party is
+  offline at the time. Nothing after that point is visible to anyone else.
+- No administrator has access to any conversation unless a participant invites them, and
+  that invitation is announced in the conversation. An invited administrator can read the
+  conversation's whole history.
+- Leaving a conversation removes your copy. It cannot remove the other participant's copy.
+- Conversation data is stored unencrypted on your own device. Device-level protection is
+  your own disk encryption.
+
+## 12. Build sequence
+
+1. **Substrate.** Cap grant and remote signal path. (DONE, §7.)
+2. **Prove it.** Two-conductor Sweettest. (DONE.)
+3. **Conversation DNA.** A new DNA in this repository with integrity and coordinator zomes,
+   the message and configuration entries, and membrane proof validation against a
+   progenitor. Registered as a third role in `workdir/happ.yaml` with a non-zero clone
+   limit and, following Volla, `deferred: false`.
+4. **Clone lifecycle.** Create, join, disable, remove, and the frontend's conversation list
+   assembled by enumerating clones.
+5. **Invitation.** Signal-first delivery with the persisted anchor fallback. Depends on the
+   listing-response design (§5).
+6. **UI.** Conversation list, thread, inbox, and the listing entry points.
+
+Steps 3 and 4 can proceed independently of step 5.
+
+## 13. Open questions and dependencies
+
+**Ours to resolve:**
+
+- Conductor cost at high cell count on R&O's stack, which sets the clone limit. Measurable.
+- Attachment handling. Chunking within a clone is straightforward since content is
+  unencrypted, and the community `holochain-open-dev/file-storage` zome chunks client-side
+  and performs no encryption, which suits an isolated clone directly. Chunk size against
+  the current conductor payload ceiling is unverified; the 256KB figure in circulation
+  dates from a much older Holochain version.
+- Whether the `messaging` zome belongs in the conversation DNA, the shared DNA, or both.
+
+**Dependencies on others:**
+
+- The listing-response design, and whether it belongs in R&O or hREA (§5).
+- Administrator invitation consent wording and whether it requires mutual agreement (§10).
+- Bootstrap operation with an authentication hook (§6).
+
+**Settled, with evidence:**
+
+- Encryption can run in a zome, proven by passing Sweettests (§6).
+- Crypto-shredding is not available on this platform (§8).
+- Forward secrecy is not achievable here and is not required by the threat model (§6).
+- Sender identity cannot be hidden on a shared DNA (§3).
+- A clone limit is a resource guard set in the manifest, not an architectural ceiling.
+  Holochain's own documentation shows `u32::MAX` as a valid value.
+
+## 14. Evidence base
+
+Claims in this note were established by reading source directly. The principal sources:
+
+- `spike/crypto-feasibility` (this repository):
+  `tests/sweettest/tests/administration/spike_crypto.rs` proves cross-agent direct-box
+  encryption in a zome; `spike_sharedsecret.rs` proves shared-secret content keys with
+  re-wrap to a later-admitted third agent. Both pass on this stack.
+- `holochain_integrity_types` 0.6.1, `action.rs`: the public `author` field on every action
+  variant.
+- `hdk` 0.6.1 and `hdi` 0.7.1, `x_salsa20_poly1305.rs`: the encryption and decryption
+  signatures and their opposed argument orders.
+- `lair_keystore_api` 0.6.3: absence of any deletion operation.
+- `kitsune2_bootstrap_srv` 0.4.1, `space.rs`, `auth.rs`, `http.rs`: space read scoping and
+  the optional authentication hook.
+- `HelloVolla/volla-messages`: `workdir/happ.yaml`, and the relay integrity zome's
+  `MembraneProofData`, `Properties` and entry type declarations.
+- `holochain-open-dev/file-storage` and its predecessor: client-side chunking, manifest of
+  chunk hashes, no encryption.
+- E. Thormarker, *On using the same key pair for Ed25519 and an X25519 based KEM*, IACR
+  ePrint 2021/509, cited by libsodium and by IETF EDHOC.
+
+**Correction owed elsewhere:** `CellCloning.md` states that `deferred: true` is required
+for clonable roles. Two production manifests set `deferred: false` with a non-zero clone
+limit.

--- a/documentation/requirements/post-mvp/messaging-system.md
+++ b/documentation/requirements/post-mvp/messaging-system.md
@@ -75,17 +75,29 @@ non-repudiation — for free. It does **not** give confidentiality: a public DHT
 entry is plaintext to any member who can fetch it. Confidentiality is a
 deliberate, separate choice.
 
-R&O keeps conversations in the single shared DNA and makes message content
-private by **encrypting it to the recipient's keypair** (`encrypt_to_agent`,
-lair crypto_box; a cohort-wrapped content key for group channels). The ciphertext
-lives as an ordinary entry in the main DHT — readable by nobody except the locked
-participants, including admins. Privacy comes from encryption, not from isolating
-the network.
+R&O gets confidentiality structurally rather than cryptographically. Each
+conversation is a membrane-isolated clone: its own DNA, its own network seed, its
+own DHT, containing exactly its participants. Members who are not in a
+conversation do not receive its entries and cannot see that it exists.
 
-Deletion is layered and honest: soft-delete hides a message immediately, and
-non-migration drops it from the network at the next version bump. Immediate total
-erasure is not something an append-only DHT can promise; member-facing copy should
-say so plainly.
+This is chosen over encrypting content on the shared DNA because encryption
+protects only the entry body. Every Holochain action carries a public author
+field, which validation requires, so on a shared DNA any member could read who
+sent each message and when, without decrypting anything. That exposes the social
+graph even when the content is safe. Isolation removes the exposure by putting
+the entries out of reach.
+
+Administrators have no standing access to any conversation. A participant may
+invite one, and that invitation is announced in the conversation itself.
+
+The MVP is one-to-one messaging; group conversations are a documented escalation,
+not baseline.
+
+Deletion is leave-and-remove: removing a conversation removes its local data,
+which is real removal rather than a hidden flag. It cannot remove the other
+participant's copy, and no distributed system can promise otherwise;
+member-facing copy should say so plainly. Archiving disables a conversation
+without deleting it.
 
 ### Access Controls
 

--- a/documentation/requirements/post-mvp/messaging-system.md
+++ b/documentation/requirements/post-mvp/messaging-system.md
@@ -101,10 +101,15 @@ without deleting it.
 
 ### Access Controls
 
-- Only participants can read/write messages
-- Organization channel moderation by coordinators/admins
-- User blocking capabilities
-- Message retention policies
+- Only participants can read or write messages, enforced structurally: a
+  non-participant is not in the conversation's network and never receives its
+  entries
+- Administrators have no standing access. A participant may invite one, and the
+  invitation is announced in the conversation
+- Blocking operates at invitation time: a blocked member's conversation requests
+  are refused rather than filtered after arrival
+- Retention is per-device. Each participant holds their own copy and may remove
+  it; there is no network-wide retention policy to set
 
 ## Implementation Reference
 
@@ -119,7 +124,7 @@ The full technical specification lives in **Issue #91**, including:
 
 ## Key References
 
-- **Volla Messages**: https://github.com/holochain-apps/volla-messages (primary Holochain chat reference)
+- **Volla Messages**: https://github.com/HelloVolla/volla-messages (primary Holochain chat reference)
 - **Vines**: https://github.com/lightningrodlabs/vines (bead-thread conceptual model)
 - **ZipZap**: https://github.com/lightningrodlabs/zipzap (ephemeral signal pattern)
 - **Simbi**: https://simbi.com (conversation-first UX inspiration)

--- a/documentation/requirements/post-mvp/messaging-system.md
+++ b/documentation/requirements/post-mvp/messaging-system.md
@@ -63,11 +63,29 @@ graph LR
 
 ## Security and Privacy
 
-### End-to-End Encryption
+> The security model for messaging is defined in
+> [`documentation/architecture/chat-system.md`](../../architecture/chat-system.md),
+> which is the design of record. The summary below reflects it; the linked note
+> has the full reasoning.
 
-- Message encryption via Holochain's agent-centric security model
-- Cryptographic signing of all messages
-- Conversation access restricted to participants
+### Confidentiality (not "E2E via the agent-centric model")
+
+Holochain's agent-centric model gives **signing** — authenticity, integrity, and
+non-repudiation — for free. It does **not** give confidentiality: a public DHT
+entry is plaintext to any member who can fetch it. Confidentiality is a
+deliberate, separate choice.
+
+R&O keeps conversations in the single shared DNA and makes message content
+private by **encrypting it to the recipient's keypair** (`encrypt_to_agent`,
+lair crypto_box; a cohort-wrapped content key for group channels). The ciphertext
+lives as an ordinary entry in the main DHT — readable by nobody except the locked
+participants, including admins. Privacy comes from encryption, not from isolating
+the network.
+
+Deletion is layered and honest: soft-delete hides a message immediately, and
+non-migration drops it from the network at the next version bump. Immediate total
+erasure is not something an append-only DHT can promise; member-facing copy should
+say so plainly.
 
 ### Access Controls
 

--- a/tests/sweettest/Cargo.toml
+++ b/tests/sweettest/Cargo.toml
@@ -74,3 +74,7 @@ path = "tests/offers.rs"
 [[test]]
 name = "mediums_of_exchange"
 path = "tests/mediums_of_exchange.rs"
+
+[[test]]
+name = "messaging"
+path = "tests/messaging.rs"

--- a/tests/sweettest/tests/messaging.rs
+++ b/tests/sweettest/tests/messaging.rs
@@ -1,0 +1,113 @@
+//! Messaging zome substrate test.
+//!
+//! Proves the cross-agent signal path end to end: Alice calls `send_message`
+//! addressed to Bob, and Bob's conductor receives the emitted signal with the
+//! correct content and a `from` field set to Alice via call provenance.
+//!
+//! Both cells are primed with a `ping` call first, because `init` runs lazily
+//! on a cell's first zome call, and it is `init` that commits the cap grant
+//! authorising `recv_remote_signal`. Without priming Bob, his grant would not
+//! exist when Alice's signal arrives and it would be silently dropped.
+//!
+//! canonical `remote_signal_test` does); `RUST_LOG` alone is not enough.
+
+use holochain::prelude::*;
+use requests_and_offers_sweettest::common::*;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Mirror of the messaging zome's `SendMessageInput` (camelCase to match the zome).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SendMessageInput {
+    stream_id: String,
+    content: String,
+    agents: Vec<AgentPubKey>,
+}
+
+/// Mirror of the messaging zome's `Signal` (internally tagged on `type`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+enum MessagingSignal {
+    Message {
+        stream_id: String,
+        content: String,
+        from: AgentPubKey,
+    },
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn send_message_delivers_remote_signal_to_recipient() {
+    // Turn on conductor tracing so RUST_LOG=info actually surfaces logs.
+
+    let (conductors, alice, bob) = setup_two_agents().await;
+
+    // Prime both cells so their `init` runs and the cap grant for
+    // `recv_remote_signal` is committed before any signal is sent.
+    let alice_ping: String = conductors[0]
+        .call(&alice.zome("messaging"), "ping", ())
+        .await;
+    let bob_ping: String = conductors[1]
+        .call(&bob.zome("messaging"), "ping", ())
+        .await;
+    println!("PRIME: alice ping = {alice_ping:?}, bob ping = {bob_ping:?}");
+
+    // Give the cap grants and peer connections a moment to settle.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Subscribe Bob before Alice sends.
+    let mut bob_signals =
+        conductors[1].subscribe_to_app_signals("requests_and_offers".to_string());
+
+    let stream_id = "alice-bob".to_string();
+    let content = "hello bob".to_string();
+
+    println!("SEND: alice -> bob ({})", bob.agent_pubkey());
+    let _: () = conductors[0]
+        .call(
+            &alice.zome("messaging"),
+            "send_message",
+            SendMessageInput {
+                stream_id: stream_id.clone(),
+                content: content.clone(),
+                agents: vec![bob.agent_pubkey().clone()],
+            },
+        )
+        .await;
+    println!("SEND: send_message returned ok");
+
+    let received: MessagingSignal = tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            match bob_signals.recv().await.expect("Bob signal channel error") {
+                Signal::App { signal, .. } => {
+                    match signal.into_inner().decode::<MessagingSignal>() {
+                        Ok(msg) => {
+                            println!("RECV: bob decoded a MessagingSignal");
+                            break msg;
+                        }
+                        Err(e) => println!("RECV: bob got an app signal we could not decode: {e:?}"),
+                    }
+                }
+                other => println!("RECV: bob got a non-app signal: {other:?}"),
+            }
+        }
+    })
+    .await
+    .expect("Timed out waiting for Bob to receive the message signal");
+
+    match received {
+        MessagingSignal::Message {
+            stream_id: got_stream,
+            content: got_content,
+            from,
+        } => {
+            assert_eq!(got_stream, stream_id, "stream_id should round-trip");
+            assert_eq!(got_content, content, "content should round-trip");
+            assert_eq!(
+                &from,
+                alice.agent_pubkey(),
+                "sender should be Alice, taken from call provenance"
+            );
+        }
+    }
+}

--- a/tests/sweettest/tests/messaging.rs
+++ b/tests/sweettest/tests/messaging.rs
@@ -1,15 +1,18 @@
 //! Messaging zome substrate test.
 //!
-//! Proves the cross-agent signal path end to end: Alice calls `send_message`
-//! addressed to Bob, and Bob's conductor receives the emitted signal with the
-//! correct content and a `from` field set to Alice via call provenance.
+//! Proves cross-agent signal delivery end to end: Alice's `send_message` reaches
+//! Bob as a `Signal::Message` with the correct content and a `from` field set to
+//! Alice via call provenance. Two conductors are used so the signal genuinely
+//! crosses the network rather than short-circuiting within one node.
 //!
-//! Both cells are primed with a `ping` call first, because `init` runs lazily
-//! on a cell's first zome call, and it is `init` that commits the cap grant
+//! Both cells are primed with a `ping` call first, because `init` runs lazily on
+//! a cell's first zome call, and it is `init` that commits the cap grant
 //! authorising `recv_remote_signal`. Without priming Bob, his grant would not
 //! exist when Alice's signal arrives and it would be silently dropped.
 //!
-//! canonical `remote_signal_test` does); `RUST_LOG` alone is not enough.
+//! The zome's own `Signal` and `SendMessageInput` types cannot be imported
+//! (coordinator crates require a wasm target), so they are mirrored here with a
+//! matching serde shape, exactly as `common/mirrors.rs` does for entry types.
 
 use holochain::prelude::*;
 use requests_and_offers_sweettest::common::*;
@@ -38,21 +41,18 @@ enum MessagingSignal {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn send_message_delivers_remote_signal_to_recipient() {
-    // Turn on conductor tracing so RUST_LOG=info actually surfaces logs.
-
     let (conductors, alice, bob) = setup_two_agents().await;
 
     // Prime both cells so their `init` runs and the cap grant for
     // `recv_remote_signal` is committed before any signal is sent.
-    let alice_ping: String = conductors[0]
+    let _: String = conductors[0]
         .call(&alice.zome("messaging"), "ping", ())
         .await;
-    let bob_ping: String = conductors[1]
+    let _: String = conductors[1]
         .call(&bob.zome("messaging"), "ping", ())
         .await;
-    println!("PRIME: alice ping = {alice_ping:?}, bob ping = {bob_ping:?}");
 
-    // Give the cap grants and peer connections a moment to settle.
+    // Let the cap grants and peer connections settle.
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     // Subscribe Bob before Alice sends.
@@ -62,7 +62,6 @@ async fn send_message_delivers_remote_signal_to_recipient() {
     let stream_id = "alice-bob".to_string();
     let content = "hello bob".to_string();
 
-    println!("SEND: alice -> bob ({})", bob.agent_pubkey());
     let _: () = conductors[0]
         .call(
             &alice.zome("messaging"),
@@ -74,21 +73,20 @@ async fn send_message_delivers_remote_signal_to_recipient() {
             },
         )
         .await;
-    println!("SEND: send_message returned ok");
 
+    // Bob should receive the remote signal, decodable as our Message. The timeout
+    // turns a silent non-delivery into a loud failure rather than a hang.
     let received: MessagingSignal = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             match bob_signals.recv().await.expect("Bob signal channel error") {
                 Signal::App { signal, .. } => {
-                    match signal.into_inner().decode::<MessagingSignal>() {
-                        Ok(msg) => {
-                            println!("RECV: bob decoded a MessagingSignal");
-                            break msg;
-                        }
-                        Err(e) => println!("RECV: bob got an app signal we could not decode: {e:?}"),
+                    if let Ok(msg) = signal.into_inner().decode::<MessagingSignal>() {
+                        break msg;
                     }
+                    // Some other app-signal shape; keep waiting.
                 }
-                other => println!("RECV: bob got a non-app signal: {other:?}"),
+                // System signals are irrelevant here; keep waiting.
+                Signal::System(_) => {}
             }
         }
     })

--- a/workdir/dna.yaml
+++ b/workdir/dna.yaml
@@ -65,3 +65,7 @@ coordinator:
       path: "../target/wasm32-unknown-unknown/release/mediums_of_exchange.wasm"
       dependencies:
         - name: mediums_of_exchange_integrity
+    - name: messaging
+      hash: ~
+      path: "../target/wasm32-unknown-unknown/release/messaging.wasm"
+      dependencies: []


### PR DESCRIPTION
Builds the cross-agent signalling layer that #12 requires and that both #91 (chat) and #51 (notifications) depend on. Before this, the app had no cross-agent signalling at all: every coordinator zome only did local post_commit to emit_signal, a cache-invalidation bus for the agents own UI. This adds the missing half.

Scope: this is the substrate only, step one of the chat build sequence. It sends plaintext over an ephemeral signal. The persisted conversation layer is deliberately NOT in this PR, it is the next step recorded in the design note. Merging this unblocks that work without committing to it prematurely.

What it adds:
- New coordinator-only zome messaging (mirrors the misc zome pattern, no integrity pair since ephemeral signals are not entries)
- init commits an Unrestricted cap grant authorising recv_remote_signal
- send_message, recv_remote_signal, ping health-check, and a Signal::Message variant
- Registered in both dna.yaml manifests
- Two-conductor Sweettest at tests/sweettest/tests/messaging.rs proving the signal genuinely crosses the network. Passes against 0.6.1.

Design of record: documentation/architecture/chat-system.md, which governs the full messaging design and resolves the privacy question #91 leaves open. Headline decisions, with the full reasoning in the note:

- Conversations are membrane-isolated clones, one cloned DNA per conversation, rather than entries on the shared requests_and_offers DNA. Isolation is the default for every conversation, not an escalation for a sensitive subset.
- The deciding argument is metadata rather than content. Every Holochain action carries a public author field, which validation requires. Content encryption on a shared DNA therefore protects what was said while leaving who said it to whom readable by any member, and correlating that against public listings reconstructs the social graph. For a mutual aid network that graph is frequently the sensitive part. Isolation puts the entries out of reach instead.
- No content encryption inside a clone. A clone contains exactly its participants, who hold the plaintext by definition. This follows Volla, whose conversation zomes contain no content encryption at all.
- A conversation begins by responding to a listing, which carries a random network seed and a membrane proof encrypted to the recipient. Signal-first delivery means an online recipient leaves no DHT record at all.
- Deletion is leave-and-remove, which genuinely removes local data. Crypto-shredding is not deferred but unavailable: nothing in lair or Holochain can destroy stored key material, and the append-only source chain is the architecture working as intended.
- Administrators have no standing access. A participant may invite one, and the invitation is announced in the conversation as a committed system message.

Two things the note flags for wider input. The design has an operational dependency on running our own bootstrap with authentication enabled, since kitsune2's space read route will otherwise enumerate a clone's members to anyone holding the space id. And it interacts with #90: a conversation can hold an agreement id and resolve it frontend-side, but the reverse lookup from a public agreement to a private conversation cannot exist under isolation, and any conversation identifier stored on an agreement must be opaque rather than derived from the network seed.

Where this substrate now sits: it carries invitations and provides liveness within a clone. Whether the zome belongs in the conversation DNA, the shared DNA, or both, is recorded as open.

The design note also supersedes the Security and Privacy summary in messaging-system.md, which has been updated to match it.

Running the Sweettest needs the Nix fix from #180, now merged to dev.