### PR TITLE
feat(conversation): conversation DNA with membrane-isolated clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "conversation"
+version = "0.0.1"
+dependencies = [
+ "conversation_integrity",
+ "hdk",
+ "holochain",
+ "holochain_serialized_bytes",
+ "pkcs8 0.11.0-rc.11",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "utils",
+]
+
+[[package]]
+name = "conversation_integrity"
+version = "0.0.1"
+dependencies = [
+ "hdi",
+ "holochain_serialized_bytes",
+ "serde",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6522,6 +6546,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,9 @@ path = "dnas/requests_and_offers/zomes/coordinator/exchanges"
 
 [workspace.dependencies.exchanges_integrity]
 path = "dnas/requests_and_offers/zomes/integrity/exchanges"
+
+[workspace.dependencies.conversation]
+path = "dnas/conversation/zomes/coordinator/conversation"
+
+[workspace.dependencies.conversation_integrity]
+path = "dnas/conversation/zomes/integrity/conversation"

--- a/dnas/conversation/workdir/dna.yaml
+++ b/dnas/conversation/workdir/dna.yaml
@@ -1,0 +1,17 @@
+manifest_version: '0'
+name: conversation
+integrity:
+  network_seed: null
+  properties: null
+  zomes:
+  - name: conversation_integrity
+    hash: null
+    path: ../../../target/wasm32-unknown-unknown/release/conversation_integrity.wasm
+    dependencies: null
+coordinator:
+  zomes:
+  - name: conversation
+    hash: null
+    path: ../../../target/wasm32-unknown-unknown/release/conversation.wasm
+    dependencies:
+    - name: conversation_integrity

--- a/dnas/conversation/zomes/coordinator/conversation/Cargo.toml
+++ b/dnas/conversation/zomes/coordinator/conversation/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "conversation"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "conversation"
+
+[dependencies]
+hdk = { workspace = true }
+serde = { workspace = true }
+holochain_serialized_bytes = { workspace = true }
+thiserror = { workspace = true }
+
+utils = { workspace = true }
+conversation_integrity = { workspace = true }
+
+[dev-dependencies]
+holochain = { workspace = true, features = ["wasmer_sys", "transport-iroh", "test_utils"] }
+tokio = { workspace = true }
+
+# Temporarily pinned, remove when upgrading to Holochain 0.7
+pkcs8 = "=0.11.0-rc.11"

--- a/dnas/conversation/zomes/coordinator/conversation/src/errors.rs
+++ b/dnas/conversation/zomes/coordinator/conversation/src/errors.rs
@@ -1,0 +1,26 @@
+use hdk::prelude::{wasm_error, WasmError, WasmErrorInner};
+use thiserror::Error;
+
+/// Conversation-specific errors only. Anything with a `CommonError` equivalent
+/// uses `utils::errors::CommonError` instead, following the house pattern of a
+/// domain enum alongside it (`dnas/requests_and_offers/utils/src/errors.rs`).
+#[derive(Debug, Error)]
+pub enum ConversationError {
+  /// `UsersError::NotAuthor` exists but belongs to the users domain in the
+  /// shared DNA, and this DNA has no users.
+  #[error("Not the author")]
+  NotAuthor,
+
+  #[error("Only a participant in this conversation may issue membrane proofs")]
+  NotAParticipant,
+
+  /// See `conversation_properties` in `lib.rs`.
+  #[error("This cell holds no conversation")]
+  NotAConversation,
+}
+
+impl From<ConversationError> for WasmError {
+  fn from(err: ConversationError) -> Self {
+    wasm_error!(WasmErrorInner::Guest(err.to_string()))
+  }
+}

--- a/dnas/conversation/zomes/coordinator/conversation/src/lib.rs
+++ b/dnas/conversation/zomes/coordinator/conversation/src/lib.rs
@@ -1,0 +1,158 @@
+pub mod errors;
+pub mod membrane;
+
+use conversation_integrity::*;
+use errors::ConversationError;
+use hdk::prelude::*;
+use utils::errors::CommonError;
+
+#[hdk_extern]
+pub fn init() -> ExternResult<InitCallbackResult> {
+  Ok(InitCallbackResult::Pass)
+}
+
+// ============================================================================
+// BASE CELL GUARD
+// ============================================================================
+
+/// Read this clone's properties, refusing to operate in a cell that holds no conversation.
+///
+/// `check_agent` in the integrity zome admits any agent, with no proof, to a cell whose
+/// properties are absent. That escape is load-bearing rather than cosmetic:
+/// `strategy: clone_only` panics the conductor in 0.6.1 and on upstream `main-0.6`, so a
+/// base conversation cell is provisioned on every install and has to pass genesis.
+///
+/// The consequence is that the base cell is a live DHT with an open membrane, shared by
+/// every install because they all derive it from the same `workdir/happ.yaml`. The integrity
+/// zome refuses writes there; this guard makes our own functions refuse earlier, with a
+/// readable error, and hands the caller the peer set and conversation id it needed anyway.
+pub fn conversation_properties() -> ExternResult<Properties> {
+  let info = dna_info()?;
+
+  // Encoded msgpack nil is one byte. Same test as the integrity zome, same reason.
+  if info.modifiers.properties.bytes().len() == 1 {
+    return Err(ConversationError::NotAConversation.into());
+  }
+
+  Properties::try_from(info.modifiers.properties).map_err(|e| CommonError::Serialize(e).into())
+}
+
+// ============================================================================
+// SIGNALS
+// ============================================================================
+
+/// Shape follows the shared DNA's `Signal`
+/// (`dnas/requests_and_offers/zomes/coordinator/requests/src/lib.rs` line 16) so a frontend
+/// service layer can reuse the same discriminated union.
+///
+/// One variant is deliberately absent. `EntryDeleted` has no counterpart here because
+/// `reject_delete` in the integrity zome makes a delete unvalidatable: the removal
+/// primitive in this design is leaving the clone, not deleting an entry. A delete could
+/// still be written to a local source chain and fail on publish, so emitting a signal for
+/// it would advertise a capability that does not exist. `Action::Delete` therefore falls
+/// through to the catch-all in `signal_action`.
+#[allow(clippy::large_enum_variant)]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type")]
+pub enum Signal {
+  LinkCreated {
+    action: SignedActionHashed,
+    link_type: LinkTypes,
+  },
+  LinkDeleted {
+    action: SignedActionHashed,
+    link_type: LinkTypes,
+  },
+  EntryCreated {
+    action: SignedActionHashed,
+    app_entry: EntryTypes,
+  },
+  EntryUpdated {
+    action: SignedActionHashed,
+    app_entry: EntryTypes,
+    original_app_entry: EntryTypes,
+  },
+}
+
+#[hdk_extern(infallible)]
+pub fn post_commit(committed_actions: Vec<SignedActionHashed>) {
+  for action in committed_actions {
+    if let Err(err) = signal_action(action) {
+      error!("Error signaling new action: {:?}", err);
+    }
+  }
+}
+
+fn signal_action(action: SignedActionHashed) -> ExternResult<()> {
+  match action.hashed.content.clone() {
+    Action::CreateLink(create_link) => {
+      if let Ok(Some(link_type)) = LinkTypes::from_type(create_link.zome_index, create_link.link_type)
+      {
+        emit_signal(Signal::LinkCreated { action, link_type })?;
+      }
+      Ok(())
+    }
+    Action::DeleteLink(delete_link) => {
+      let record = get(delete_link.link_add_address.clone(), GetOptions::default())?.ok_or(
+        CommonError::LinkNotFound("Failed to fetch CreateLink action".to_string()),
+      )?;
+      match record.action() {
+        Action::CreateLink(create_link) => {
+          if let Ok(Some(link_type)) =
+            LinkTypes::from_type(create_link.zome_index, create_link.link_type)
+          {
+            emit_signal(Signal::LinkDeleted { action, link_type })?;
+          }
+          Ok(())
+        }
+        _ => Err(CommonError::LinkNotFound("Create Link should exist".to_string()).into()),
+      }
+    }
+    Action::Create(_create) => {
+      if let Ok(Some(app_entry)) = get_entry_for_action(&action.hashed.hash) {
+        emit_signal(Signal::EntryCreated { action, app_entry })?;
+      }
+      Ok(())
+    }
+    Action::Update(update) => {
+      if let Ok(Some(app_entry)) = get_entry_for_action(&action.hashed.hash) {
+        if let Ok(Some(original_app_entry)) = get_entry_for_action(&update.original_action_address) {
+          emit_signal(Signal::EntryUpdated {
+            action,
+            app_entry,
+            original_app_entry,
+          })?;
+        }
+      }
+      Ok(())
+    }
+    _ => Ok(()),
+  }
+}
+
+/// Copied unchanged from the shared DNA (`requests/src/lib.rs` line 107).
+fn get_entry_for_action(action_hash: &ActionHash) -> ExternResult<Option<EntryTypes>> {
+  let record = match get_details(action_hash.clone(), GetOptions::default())? {
+    Some(Details::Record(record_details)) => record_details.record,
+    _ => {
+      return Ok(None);
+    }
+  };
+  let entry = match record.entry().as_option() {
+    Some(entry) => entry,
+    None => {
+      return Ok(None);
+    }
+  };
+  let (zome_index, entry_index) = match record.action().entry_type() {
+    Some(EntryType::App(AppEntryDef {
+      zome_index,
+      entry_index,
+      ..
+    })) => (zome_index, entry_index),
+    _ => {
+      return Ok(None);
+    }
+  };
+  EntryTypes::deserialize_from_type(*zome_index, *entry_index, entry)
+}

--- a/dnas/conversation/zomes/coordinator/conversation/src/membrane.rs
+++ b/dnas/conversation/zomes/coordinator/conversation/src/membrane.rs
@@ -1,0 +1,43 @@
+use conversation_integrity::*;
+use hdk::prelude::*;
+use utils::errors::CommonError;
+
+use crate::conversation_properties;
+use crate::errors::ConversationError;
+
+/// Issue a membrane proof admitting `for_agent` to this conversation clone.
+///
+/// Only for agents not named in the clone's properties, which in this design means an
+/// invited administrator: participants are admitted by identity and need no proof.
+///
+/// Mirrors Volla's `generate_membrane_proof`
+/// (`_reference/volla-messages/dnas/relay/zomes/coordinator/relay/src/lib.rs` line 257):
+/// sign the data struct, wrap it, serialise. Signing over the struct rather than raw bytes
+/// means `sign` here and `verify_signature` in `check_agent` serialise through one
+/// mechanism and cannot drift apart. Do not add a byte-encoding helper.
+///
+/// `conversation_id` is read from `dna_info()` rather than taken as input, as Volla does:
+/// a caller-supplied id that mismatched would produce a proof rejected at the recipient's
+/// genesis, with nothing surfacing to the issuer.
+#[hdk_extern]
+pub fn issue_membrane_proof(for_agent: AgentPubKey) -> ExternResult<SerializedBytes> {
+  let props = conversation_properties()?;
+  let me = agent_info()?.agent_initial_pubkey;
+
+  if !props.peers.contains(&me) {
+    return Err(ConversationError::NotAParticipant.into());
+  }
+
+  let data = MembraneProofData {
+    conversation_id: props.conversation_id,
+    for_agent,
+    signer: me.clone(),
+  };
+
+  let envelope = MembraneProofEnvelope {
+    signature: sign(me, data.clone())?,
+    data,
+  };
+
+  SerializedBytes::try_from(envelope).map_err(|e| CommonError::Serialize(e).into())
+}

--- a/dnas/conversation/zomes/integrity/conversation/Cargo.toml
+++ b/dnas/conversation/zomes/integrity/conversation/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "conversation_integrity"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "conversation_integrity"
+
+[dependencies]
+hdi = { workspace = true }
+serde = { workspace = true }
+holochain_serialized_bytes = { workspace = true }

--- a/dnas/conversation/zomes/integrity/conversation/src/lib.rs
+++ b/dnas/conversation/zomes/integrity/conversation/src/lib.rs
@@ -1,0 +1,414 @@
+use hdi::prelude::*;
+
+/// Volla's production shape: a plain `AgentPubKey`, not the base64 string the shared
+/// `requests_and_offers` DNA uses, because a clone receives its properties from the clone
+/// creation call at runtime rather than from YAML.
+#[derive(Serialize, Deserialize, Debug, SerializedBytes, Clone)]
+pub struct Properties {
+  /// Every participant in this conversation, ascending by key bytes.
+  ///
+  /// Properties feed the DNA hash, so an unordered pair would let two participants derive
+  /// two different hashes from the same conversation and land in separate networks with no
+  /// error anywhere. `check_agent` enforces the ordering rather than trusting it.
+  ///
+  /// Both hold the same authority: either may admit an administrator. This is what makes
+  /// unilateral invitation possible for both participants rather than only the one who
+  /// answered the listing.
+  pub peers: Vec<AgentPubKey>,
+
+  /// Opaque random identifier, deliberately NOT the network seed as it is in Volla. A
+  /// conversation id may reach a public hREA agreement, and the seed must stay secret:
+  /// kitsune2 0.4.1's `GET /bootstrap/{space}` returns a space's agent list to any caller
+  /// when no authentication hook is configured (note section 6). The seed must also be
+  /// random and transmitted, never derived from public values.
+  pub conversation_id: String,
+}
+
+/// False for the empty base cell, which carries no properties.
+///
+/// A base cell is provisioned on every install because `strategy: clone_only` hits
+/// `unimplemented!()` in `holochain_conductor_api-0.6.1/src/app_interface.rs` at line 491,
+/// byte-identical on upstream `main-0.6`. `deferred: true` is the same branch.
+/// `dna_info()` is deterministic, so this is permitted in validation.
+pub fn is_conversation_cell() -> ExternResult<bool> {
+  Ok(dna_info()?.modifiers.properties.bytes().len() != 1)
+}
+
+/// Volla's naming. Their `as_role: u32` is not adopted: note section 10 gives an invited
+/// administrator no distinct role.
+#[derive(Serialize, Deserialize, Debug, SerializedBytes, Clone)]
+pub struct MembraneProofData {
+  pub conversation_id: String,
+  pub for_agent: AgentPubKey,
+
+  /// Inside the signed data, not on the envelope: the signature covers the claim of who
+  /// issued it, so the signer field cannot be swapped for another peer's after signing.
+  pub signer: AgentPubKey,
+}
+
+#[derive(Serialize, Deserialize, Debug, SerializedBytes)]
+pub struct MembraneProofEnvelope {
+  pub signature: Signature,
+  pub data: MembraneProofData,
+}
+
+/// Deterministic: a properties read and a signature verification, no DHT access.
+///
+/// The signature covers the `MembraneProofData` struct rather than raw bytes, so `sign` and
+/// `verify_signature` serialise through the same mechanism and cannot drift apart. No shared
+/// byte-encoding helper is needed; do not add one.
+pub fn check_agent(
+  agent_pub_key: AgentPubKey,
+  membrane_proof: Option<MembraneProof>,
+) -> ExternResult<ValidateCallbackResult> {
+  // The base cell must be joinable or the app will not install. It is not writable.
+  if !is_conversation_cell()? {
+    return Ok(ValidateCallbackResult::Valid);
+  }
+
+  let props =
+    Properties::try_from(dna_info()?.modifiers.properties).map_err(|e| wasm_error!(e))?;
+
+  // `windows(2)` with strict `<` rejects an unordered pair and a duplicated key together.
+  // Not `is_sorted`, whose stabilisation varies by toolchain.
+  if props.peers.len() < 2 || !props.peers.windows(2).all(|w| w[0] < w[1]) {
+    return Ok(ValidateCallbackResult::Invalid(
+      "conversation properties must carry at least two peers, ascending and distinct".to_string(),
+    ));
+  }
+
+  // Participants are admitted by identity; nobody issues them a proof for their own clone.
+  if props.peers.contains(&agent_pub_key) {
+    return Ok(ValidateCallbackResult::Valid);
+  }
+
+  match membrane_proof {
+    None => Ok(ValidateCallbackResult::Invalid(
+      "a membrane proof is required to join this conversation".to_string(),
+    )),
+    Some(serialized_proof) => {
+      let envelope =
+        MembraneProofEnvelope::try_from((*serialized_proof).clone()).map_err(|e| wasm_error!(e))?;
+
+      if envelope.data.conversation_id != props.conversation_id {
+        return Ok(ValidateCallbackResult::Invalid(
+          "membrane proof is not for this conversation".to_string(),
+        ));
+      }
+
+      if envelope.data.for_agent != agent_pub_key {
+        return Ok(ValidateCallbackResult::Invalid(
+          "membrane proof is not for this agent".to_string(),
+        ));
+      }
+
+      if !props.peers.contains(&envelope.data.signer) {
+        return Ok(ValidateCallbackResult::Invalid(
+          "membrane proof was not signed by a participant in this conversation".to_string(),
+        ));
+      }
+
+      if verify_signature(
+        envelope.data.signer.clone(),
+        envelope.signature,
+        envelope.data,
+      )? {
+        return Ok(ValidateCallbackResult::Valid);
+      }
+
+      Ok(ValidateCallbackResult::Invalid(
+        "membrane proof signature invalid".to_string(),
+      ))
+    }
+  }
+}
+
+/// Request, Offer, Direct. The note's list; Organization is not in it.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum ContextType {
+  Request,
+  Offer,
+  Direct,
+}
+
+/// Committed rather than rendered, because note section 10 requires the administrator
+/// invitation announcement to be an entry a modified client cannot suppress. Structured
+/// rather than prose so the member-facing wording stays a UI string, revisable and
+/// translatable without a DNA change. `AdminInvited` names only the administrator; the
+/// inviting participant is the action's author. Invitation policy is recorded on #91, and
+/// the wording is a governance matter.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum SystemEvent {
+  AdminInvited { admin: AgentPubKey },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum MessageType {
+  Text,
+  System(SystemEvent),
+}
+
+/// No `participants` field: participants are the clone's membrane, not entry data (note
+/// section 9). No `created_at`, so this entry is addressed purely by its content and
+/// committing the same configuration twice yields one entry rather than two.
+#[hdk_entry_helper]
+#[derive(Clone)]
+pub struct ConversationConfig {
+  /// Points into the shared DNA. Resolved frontend-side, as hREA proposals already are.
+  pub context_hash: Option<ActionHash>,
+
+  pub context_type: ContextType,
+
+  /// Also resolved frontend-side.
+  pub proposal_id: Option<String>,
+}
+
+/// No `created_at`. The action header carries a timestamp, and a client-supplied one would
+/// be forgeable: a participant could date a message into the past and have every client
+/// render it earlier in the thread than it was sent.
+#[hdk_entry_helper]
+#[derive(Clone)]
+pub struct Message {
+  /// Plaintext (note section 6), and empty for system messages, whose payload is the event.
+  pub content: String,
+
+  pub message_type: MessageType,
+  pub reply_to: Option<ActionHash>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+  ConversationConfig(ConversationConfig),
+  Message(Message),
+}
+
+#[derive(Serialize, Deserialize)]
+#[hdk_link_types]
+pub enum LinkTypes {
+  /// Time-bucketed for pagination. Bucket width not yet chosen.
+  PathToMessage,
+
+  MessageUpdates,
+
+  /// NOT IN THE DESIGN NOTE. The note does not say how the configuration entry is
+  /// discovered, and an entry nothing links to is unreachable. Reconcile against the note.
+  PathToConfig,
+}
+
+/// Pinned to the lair IPC ceiling rather than a round number. Note section 6 records that
+/// every zome crypto primitive rejects a single call above 8192 bytes and keeps two
+/// encryption routes open, so a higher cap would foreclose encrypting one message unchunked.
+const MAX_MESSAGE_BYTES: usize = 8192;
+
+fn validate_message(message: &Message) -> ExternResult<ValidateCallbackResult> {
+  match &message.message_type {
+    // The event is the payload.
+    MessageType::System(_) => {
+      if !message.content.is_empty() {
+        return Ok(ValidateCallbackResult::Invalid(
+          "a system message must carry no content; its event is the payload".to_string(),
+        ));
+      }
+    }
+
+    MessageType::Text => {
+      if message.content.trim().is_empty() {
+        return Ok(ValidateCallbackResult::Invalid(
+          "message content must not be empty".to_string(),
+        ));
+      }
+
+      // `String::len` is bytes, not chars, which is what the ceiling is measured in.
+      if message.content.len() > MAX_MESSAGE_BYTES {
+        return Ok(ValidateCallbackResult::Invalid(format!(
+          "message content exceeds {} bytes",
+          MAX_MESSAGE_BYTES
+        )));
+      }
+    }
+  }
+
+  Ok(ValidateCallbackResult::Valid)
+}
+
+/// Nothing checkable yet: `context_type` is type-checked by deserialisation, and the two
+/// identifiers resolve in other cells, which validation cannot read.
+fn validate_conversation_config(
+  _config: &ConversationConfig,
+) -> ExternResult<ValidateCallbackResult> {
+  Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_entry(entry: &EntryTypes) -> ExternResult<ValidateCallbackResult> {
+  match entry {
+    EntryTypes::Message(message) => validate_message(message),
+    EntryTypes::ConversationConfig(config) => validate_conversation_config(config),
+  }
+}
+
+/// The base cell may be joined but never written to.
+///
+/// Its membrane admits anyone and every install shares its DNA hash, so it is one open
+/// network every member joins. Nothing sensitive can leak from it, but left writable it is a
+/// storage-abuse surface, since anything committed there is stored and gossiped by every
+/// member's node. Integrity-level because a coordinator guard stops nobody who compiles
+/// their own coordinator against this crate.
+fn refuse_base_cell_write() -> ExternResult<ValidateCallbackResult> {
+  Ok(ValidateCallbackResult::Invalid(
+    "the base conversation cell holds no conversation and accepts no writes".to_string(),
+  ))
+}
+
+/// NOT IN THE DESIGN NOTE. Without it either participant could rewrite the other's messages
+/// through the update chain, and the plain read every client performs would show the altered
+/// text under the original author's name. `must_get_action` on a hash the action already
+/// names is deterministic, so it is permitted here; enumerating with `get_links` would not be.
+fn validate_update_author(
+  original_action_hash: ActionHash,
+  updating_author: &AgentPubKey,
+) -> ExternResult<ValidateCallbackResult> {
+  let original = must_get_action(original_action_hash)?;
+
+  if original.action().author() != updating_author {
+    return Ok(ValidateCallbackResult::Invalid(
+      "only the agent who authored an entry may update it".to_string(),
+    ));
+  }
+
+  Ok(ValidateCallbackResult::Valid)
+}
+
+/// NOT IN THE DESIGN NOTE. The same forgery one layer down: linking an entry you authored
+/// yourself from the other participant's message as its update.
+fn validate_update_link_author(
+  base_address: AnyLinkableHash,
+  linking_author: &AgentPubKey,
+) -> ExternResult<ValidateCallbackResult> {
+  let Some(base_action_hash) = base_address.into_action_hash() else {
+    return Ok(ValidateCallbackResult::Invalid(
+      "a MessageUpdates link must be based on an action hash".to_string(),
+    ));
+  };
+
+  let base = must_get_action(base_action_hash)?;
+
+  match base.action().author() == linking_author {
+    true => Ok(ValidateCallbackResult::Valid),
+    false => Ok(ValidateCallbackResult::Invalid(
+      "only the agent who authored a message may link an update to it".to_string(),
+    )),
+  }
+}
+
+/// Note section 8: crypto-shredding is unavailable on this stack, so removal is
+/// leave-and-remove, which uninstalls the clone and its local databases. A delete would only
+/// write a tombstone beside an entry that remains in the DHT regardless. Archiving is clone
+/// disable. Volla does permit deletes, so this is a conscious divergence.
+fn reject_delete() -> ExternResult<ValidateCallbackResult> {
+  Ok(ValidateCallbackResult::Invalid(
+    "entries are not deletable in a conversation; removal is leaving the conversation".to_string(),
+  ))
+}
+
+/// Runs on the joining agent's own device: a courtesy check a modified conductor can skip,
+/// not the gate. The macro maps this to the versioned extern `genesis_self_check_2`.
+#[hdk_extern]
+pub fn genesis_self_check(data: GenesisSelfCheckData) -> ExternResult<ValidateCallbackResult> {
+  check_agent(data.agent_key, data.membrane_proof)
+}
+
+/// Runs on every agent already in the clone. This is the real gate.
+pub fn validate_agent_joining(
+  agent_pub_key: AgentPubKey,
+  membrane_proof: &Option<MembraneProof>,
+) -> ExternResult<ValidateCallbackResult> {
+  check_agent(agent_pub_key, (*membrane_proof).clone())
+}
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+  // Read once. Only the app-entry and link arms consult it, because the base cell must stay
+  // joinable.
+  let in_conversation = is_conversation_cell()?;
+
+  match op.flattened::<EntryTypes, LinkTypes>()? {
+    FlatOp::StoreEntry(store_entry) => match store_entry {
+      OpEntry::CreateEntry { app_entry, .. } | OpEntry::UpdateEntry { app_entry, .. } => {
+        if !in_conversation {
+          return refuse_base_cell_write();
+        }
+        validate_entry(&app_entry)
+      }
+      _ => Ok(ValidateCallbackResult::Valid),
+    },
+
+    FlatOp::RegisterUpdate(update_entry) => match update_entry {
+      OpUpdate::Entry { app_entry, action } => {
+        if !in_conversation {
+          return refuse_base_cell_write();
+        }
+        match validate_update_author(action.original_action_address, &action.author)? {
+          ValidateCallbackResult::Valid => validate_entry(&app_entry),
+          other => Ok(other),
+        }
+      }
+      _ => Ok(ValidateCallbackResult::Valid),
+    },
+
+    FlatOp::RegisterDelete(_) => reject_delete(),
+
+    FlatOp::RegisterCreateLink {
+      link_type,
+      base_address,
+      action,
+      ..
+    } => {
+      if !in_conversation {
+        return refuse_base_cell_write();
+      }
+      match link_type {
+        LinkTypes::PathToMessage => Ok(ValidateCallbackResult::Valid),
+        LinkTypes::PathToConfig => Ok(ValidateCallbackResult::Valid),
+        LinkTypes::MessageUpdates => validate_update_link_author(base_address, &action.author),
+      }
+    }
+
+    FlatOp::RegisterDeleteLink { link_type, .. } => match link_type {
+      LinkTypes::PathToMessage => Ok(ValidateCallbackResult::Valid),
+      LinkTypes::MessageUpdates => Ok(ValidateCallbackResult::Valid),
+      LinkTypes::PathToConfig => Ok(ValidateCallbackResult::Valid),
+    },
+
+    FlatOp::StoreRecord(store_record) => match store_record {
+      OpRecord::CreateEntry { app_entry, .. } | OpRecord::UpdateEntry { app_entry, .. } => {
+        if !in_conversation {
+          return refuse_base_cell_write();
+        }
+        validate_entry(&app_entry)
+      }
+      OpRecord::DeleteEntry { .. } => reject_delete(),
+      _ => Ok(ValidateCallbackResult::Valid),
+    },
+
+    // The membrane: a CreateAgent action is preceded by an AgentValidationPkg carrying the
+    // joining agent's proof.
+    FlatOp::RegisterAgentActivity(agent_activity) => match agent_activity {
+      OpActivity::CreateAgent { agent, action } => {
+        let previous_action = must_get_action(action.prev_action)?;
+        match previous_action.action() {
+          Action::AgentValidationPkg(AgentValidationPkg { membrane_proof, .. }) => {
+            validate_agent_joining(agent, membrane_proof)
+          }
+          _ => Ok(ValidateCallbackResult::Invalid(
+            "the previous action for a CreateAgent action must be an AgentValidationPkg"
+              .to_string(),
+          )),
+        }
+      }
+      _ => Ok(ValidateCallbackResult::Valid),
+    },
+  }
+}

--- a/tests/sweettest/Cargo.toml
+++ b/tests/sweettest/Cargo.toml
@@ -20,6 +20,7 @@ holochain  = { workspace = true }
 tokio      = { workspace = true }
 serde      = { workspace = true }
 serde_json = "1"
+serde_yaml = "0.9"
 rmp-serde  = "1"
 holochain_serialized_bytes = { workspace = true }
 
@@ -74,3 +75,7 @@ path = "tests/offers.rs"
 [[test]]
 name = "mediums_of_exchange"
 path = "tests/mediums_of_exchange.rs"
+
+[[test]]
+name = "conversation_membrane"
+path = "tests/conversation_membrane.rs"

--- a/tests/sweettest/src/common/conversation.rs
+++ b/tests/sweettest/src/common/conversation.rs
@@ -1,0 +1,163 @@
+//! Conductor setup for the conversation DNA.
+//!
+//! Separate from `conductors.rs` because that module installs a single DNA via
+//! `SweetConductor::setup_app`, which hardcodes `None` for every membrane proof
+//! (`holochain-0.6.1/src/sweettest/sweet_conductor.rs` line 323, an upstream TODO,
+//! unchanged in 0.6.3 and 0.7.0). The conversation DNA gates genesis on a proof, so
+//! it needs `ConductorHandle::install_app_bundle`, which is public and takes a
+//! per-role `RoleSettings::Provisioned { membrane_proof, modifiers }`.
+
+use holochain::conductor::error::ConductorResult;
+use holochain::prelude::*;
+use holochain::sweettest::*;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Path to the packed hApp bundle. `bun run build:happ` must have been run.
+pub const HAPP_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../workdir/requests_and_offers.happ"
+);
+
+/// The conversation role name in `workdir/happ.yaml`.
+pub const CONVERSATION_ROLE: &str = "conversation";
+
+/// Mirror of `Properties` from `conversation_integrity`.
+///
+/// Mirrored rather than imported: each integrity crate emits C-level
+/// `__num_entry_types` / `__num_link_types` symbols that collide when two are linked
+/// into one binary (see `mirrors.rs`).
+///
+/// Keys are base64 strings here because the conductor takes properties as
+/// `YamlProperties` and converts to msgpack, which the zome then reads as typed
+/// `AgentPubKey`. This is the shape Volla uses in production.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationProperties {
+    pub peers: Vec<String>,
+    pub conversation_id: String,
+}
+
+/// Mirror of `MembraneProofData`.
+#[derive(Debug, Clone, Serialize, Deserialize, SerializedBytes)]
+pub struct MembraneProofData {
+    pub conversation_id: String,
+    pub for_agent: AgentPubKey,
+    pub signer: AgentPubKey,
+}
+
+/// Mirror of `MembraneProofEnvelope`.
+#[derive(Debug, Clone, Serialize, Deserialize, SerializedBytes)]
+pub struct MembraneProofEnvelope {
+    pub signature: Signature,
+    pub data: MembraneProofData,
+}
+
+/// Sort keys as the integrity zome requires: ascending and distinct.
+pub fn ordered_peers(keys: &[AgentPubKey]) -> Vec<AgentPubKey> {
+    let mut out = keys.to_vec();
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Build conversation properties from the peer list exactly as given, including an
+/// order the integrity zome will refuse. For tests that exercise the ordering guard.
+pub fn conversation_properties_unchecked(
+    peers: &[AgentPubKey],
+    conversation_id: &str,
+) -> YamlProperties {
+    let props = ConversationProperties {
+        peers: peers.iter().map(|k| k.to_string()).collect(),
+        conversation_id: conversation_id.to_string(),
+    };
+
+    YamlProperties::new(serde_yaml::to_value(props).expect("properties should serialise to YAML"))
+}
+
+/// Build conversation properties for a peer set, sorted as the zome requires.
+pub fn conversation_properties(
+    peers: &[AgentPubKey],
+    conversation_id: &str,
+) -> YamlProperties {
+    conversation_properties_unchecked(&ordered_peers(peers), conversation_id)
+}
+
+/// Install the hApp on `conductor`, provisioning the conversation role with the given
+/// properties and optional membrane proof.
+///
+/// `ignore_genesis_failure` is set so a refused proof leaves the app installed with
+/// empty cells rather than uninstalling it, which makes the refusal observable.
+pub async fn install_with_conversation(
+    conductor: &SweetConductor,
+    properties: YamlProperties,
+    membrane_proof: Option<MembraneProof>,
+    agent: Option<AgentPubKey>,
+) -> ConductorResult<InstalledApp> {
+    let mut roles_settings: RoleSettingsMap = HashMap::new();
+    roles_settings.insert(
+        CONVERSATION_ROLE.to_string(),
+        RoleSettings::Provisioned {
+            membrane_proof,
+            modifiers: Some(DnaModifiersOpt::default().with_properties(properties)),
+        },
+    );
+
+    conductor
+        .raw_handle()
+        .install_app_bundle(InstallAppPayload {
+            source: AppBundleSource::Path(std::path::PathBuf::from(HAPP_PATH)),
+            agent_key: agent,
+            installed_app_id: Some("requests_and_offers".to_string()),
+            network_seed: None,
+            roles_settings: Some(roles_settings),
+            ignore_genesis_failure: true,
+        })
+        .await
+}
+
+/// Assert an install was refused, and refused for the expected reason.
+///
+/// Validation messages reach the caller intact inside
+/// `GenesisFailed -> WorkflowError -> GenesisFailure`, so a substring match is enough.
+pub fn assert_refused<T>(result: ConductorResult<T>, expected: &str) {
+    match result {
+        Ok(_) => panic!("expected genesis to be refused, but the install succeeded"),
+        Err(err) => {
+            let text = format!("{err:?}");
+            assert!(
+                text.contains(expected),
+                "refused, but not for the expected reason.\n  expected: {expected}\n  actual: {text}"
+            );
+        }
+    }
+}
+
+/// Sign a membrane proof admitting `for_agent`, as `issue_membrane_proof` does.
+pub async fn issue_proof(
+    conductor: &SweetConductor,
+    signer: &AgentPubKey,
+    for_agent: &AgentPubKey,
+    conversation_id: &str,
+) -> MembraneProof {
+    let data = MembraneProofData {
+        conversation_id: conversation_id.to_string(),
+        for_agent: for_agent.clone(),
+        signer: signer.clone(),
+    };
+
+    // The keystore signs raw bytes. The zome's `sign(key, data)` serialises the struct
+    // to msgpack via SerializedBytes first, so this must do the same or the signature
+    // will not verify inside the DNA.
+    let bytes = SerializedBytes::try_from(data.clone()).expect("proof data should serialise");
+    let signature = conductor
+        .raw_handle()
+        .keystore()
+        .sign(signer.clone(), bytes.bytes().to_vec().into())
+        .await
+        .expect("signing should succeed");
+
+    let envelope = MembraneProofEnvelope { signature, data };
+
+    Arc::new(SerializedBytes::try_from(envelope).expect("envelope should serialise"))
+}

--- a/tests/sweettest/src/common/mod.rs
+++ b/tests/sweettest/src/common/mod.rs
@@ -1,7 +1,9 @@
 pub mod conductors;
+pub mod conversation;
 pub mod fixtures;
 pub mod mirrors;
 
 pub use conductors::*;
+pub use conversation::*;
 pub use fixtures::*;
 pub use mirrors::*;

--- a/tests/sweettest/tests/conversation_membrane.rs
+++ b/tests/sweettest/tests/conversation_membrane.rs
@@ -1,0 +1,89 @@
+//! Conversation membrane tests.
+//!
+//! The conversation role is provisioned directly with real properties rather than
+//! cloned, because that is the shortest path to exercising `check_agent` at genesis.
+//! The clone lifecycle is a separate concern with its own harness.
+
+use holochain::sweettest::*;
+use requests_and_offers_sweettest::common::*;
+
+const CONVERSATION_ID: &str = "test-conversation-0001";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn peer_is_admitted_without_a_membrane_proof() {
+    let conductor = SweetConductor::from_standard_config().await;
+    let (alice, bob) = SweetAgents::two(conductor.keystore()).await;
+
+    let peers = ordered_peers(&[alice.clone(), bob.clone()]);
+    let props = conversation_properties(&peers, CONVERSATION_ID);
+
+    let installed = install_with_conversation(&conductor, props, None, Some(alice.clone()))
+        .await
+        .expect("installing with alice as a listed peer should succeed");
+
+    assert_eq!(
+        installed.role_assignments().len(),
+        3,
+        "expected the three roles from happ.yaml"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unordered_peers_are_refused() {
+    let conductor = SweetConductor::from_standard_config().await;
+    let (alice, bob) = SweetAgents::two(conductor.keystore()).await;
+
+    // Deliberately reversed relative to `ordered_peers`, so the pair is descending.
+    let mut peers = ordered_peers(&[alice.clone(), bob.clone()]);
+    peers.reverse();
+
+    let props = conversation_properties_unchecked(&peers, CONVERSATION_ID);
+    let result = install_with_conversation(&conductor, props, None, Some(alice.clone())).await;
+
+    assert_refused(result, "ascending and distinct");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stranger_without_a_proof_is_refused() {
+    let conductor = SweetConductor::from_standard_config().await;
+    let (alice, bob) = SweetAgents::two(conductor.keystore()).await;
+    let carol = SweetAgents::one(conductor.keystore()).await;
+
+    let peers = ordered_peers(&[alice, bob]);
+    let props = conversation_properties(&peers, CONVERSATION_ID);
+
+    let result = install_with_conversation(&conductor, props, None, Some(carol)).await;
+
+    assert_refused(result, "a membrane proof is required");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stranger_with_a_peer_signed_proof_is_admitted() {
+    let conductor = SweetConductor::from_standard_config().await;
+    let (alice, bob) = SweetAgents::two(conductor.keystore()).await;
+    let carol = SweetAgents::one(conductor.keystore()).await;
+
+    let peers = ordered_peers(&[alice.clone(), bob.clone()]);
+    let props = conversation_properties(&peers, CONVERSATION_ID);
+    let proof = issue_proof(&conductor, &alice, &carol, CONVERSATION_ID).await;
+
+    install_with_conversation(&conductor, props, Some(proof), Some(carol))
+        .await
+        .expect("a proof signed by a peer should admit an invited agent");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn proof_signed_by_a_non_peer_is_refused() {
+    let conductor = SweetConductor::from_standard_config().await;
+    let (alice, bob) = SweetAgents::two(conductor.keystore()).await;
+    let carol = SweetAgents::one(conductor.keystore()).await;
+    let mallory = SweetAgents::one(conductor.keystore()).await;
+
+    let peers = ordered_peers(&[alice, bob]);
+    let props = conversation_properties(&peers, CONVERSATION_ID);
+    let proof = issue_proof(&conductor, &mallory, &carol, CONVERSATION_ID).await;
+
+    let result = install_with_conversation(&conductor, props, Some(proof), Some(carol)).await;
+
+    assert_refused(result, "not signed by a participant");
+}

--- a/workdir/happ.yaml
+++ b/workdir/happ.yaml
@@ -36,4 +36,4 @@ roles:
         network_seed: "conversation_base_alpha"
         properties: ~
       installed_hash: ~
-      clone_limit: 1000
+      clone_limit: 100

--- a/workdir/happ.yaml
+++ b/workdir/happ.yaml
@@ -26,3 +26,14 @@ roles:
         properties: ~
       installed_hash: ~
       clone_limit: 0
+  - name: conversation
+    provisioning:
+      strategy: create
+      deferred: false
+    dna:
+      path: "../dnas/conversation/workdir/conversation.dna"
+      modifiers:
+        network_seed: "conversation_base_alpha"
+        properties: ~
+      installed_hash: ~
+      clone_limit: 1000


### PR DESCRIPTION
Implements the conversation DNA: drop one of the messaging build sequence (step three in `documentation/architecture/chat-system.md`, #181).

Conversations are membrane-isolated clones rather than entries on the shared DNA, because every Holochain action carries a public author field that cannot be encrypted. Content encryption on a shared DHT would protect what was said and expose who said it to whom, which for a mutual aid network is frequently the sensitive part.

## What is here

- A third role backed by a new DNA, non-zero clone limit, `deferred: false`
- Properties carrying the participant set, ascending and distinct, because properties feed the DNA hash and an unordered pair would put two participants in separate networks with no error
- Both peers as membrane authorities, so either may admit an administrator; a proof names its signer inside the signed data
- A base cell that is joinable but refuses all writes at integrity level, because `strategy: clone_only` reaches an unimplemented branch in the conductor api and a base cell is unavoidable
- Five Sweettests covering admission, refusal, and proof signing, each refusal asserting its designed reason

## Notes for review

**Testing needed a new harness.** `SweetConductor::setup_app` hardcodes `None` for every membrane proof, an upstream TODO unchanged in 0.6.3 and 0.7.0. `install_app_bundle` is public and takes per-role settings carrying a proof, which is enough. The harness provisions the conversation role directly rather than cloning, which exercises the membrane gate at genesis; the clone lifecycle is step four and needs its own harness.

**Two open decisions**, both yours rather than mine:

- The peer set is `Vec<AgentPubKey>`, which is why an ordering guard is needed at all. A fixed pair would make the error unrepresentable, at the cost of foreclosing group conversations.
- `clone_limit` is set to 100, matching what Volla ships. The design note says conductor cost at high cell count is unmeasured and should be measured before a limit is chosen deliberately, so 100 is a holding value rather than a measured one.

**Not here:** message CRUD and the configuration entry, which are the rest of step three. The signal half of message delivery waits on whether the `messaging` zome belongs in this DNA, the shared DNA, or both.
