### PR TITLE
fix(zomes,ui): normalize client hashes to the update-chain root

### DIFF
--- a/dnas/requests_and_offers/utils/src/lib.rs
+++ b/dnas/requests_and_offers/utils/src/lib.rs
@@ -20,7 +20,9 @@ pub fn check_if_progenitor() -> ExternResult<bool> {
   }
 }
 
-pub fn get_original_record(original_action_hash: OriginalActionHash) -> ExternResult<Option<Record>> {
+pub fn get_original_record(
+  original_action_hash: OriginalActionHash,
+) -> ExternResult<Option<Record>> {
   let Some(details) = get_details(original_action_hash.0, GetOptions::default())? else {
     return Ok(None);
   };
@@ -60,10 +62,32 @@ pub fn find_original_action_hash(action_hash: ActionHash) -> ExternResult<Origin
   }
 }
 
+/// Normalizes any action hash in an update chain to the chain's root (the `Create`).
+///
+/// This is the boundary rule for every zome entry point that accepts an "original"
+/// action hash from a client: clients routinely hold a mid-chain `Update` hash,
+/// because list surfaces read the LATEST record of an entity and a record's only
+/// identity is its own action hash. Links, status paths, and revision histories are
+/// all anchored at the root, so a mid-chain hash silently scatters them.
+///
+/// Unlike [`find_original_action_hash`] this never fails: an unresolvable chain
+/// (record not yet gossiped, unexpected action type) falls back to the hash as
+/// given, which is exactly the pre-normalization behavior.
+pub fn resolve_chain_root(action_hash: ActionHash) -> ActionHash {
+  match find_original_action_hash(action_hash.clone()) {
+    Ok(root) => root.0,
+    Err(_) => action_hash,
+  }
+}
+
 pub fn get_all_revisions_for_entry(
   original_action_hash: OriginalActionHash,
   link_types: impl LinkTypeFilterExt,
 ) -> ExternResult<Vec<Record>> {
+  // Callers may hold a mid-chain Update hash (e.g. the rotating EntityStatus link
+  // target), so resolve the chain's true root: the revision links are anchored at
+  // the original creation action and would otherwise be invisible from here.
+  let original_action_hash = OriginalActionHash(resolve_chain_root(original_action_hash.0));
   let Some(original_record) = get_original_record(original_action_hash.clone())? else {
     return Ok(vec![]);
   };
@@ -73,7 +97,7 @@ pub fn get_all_revisions_for_entry(
     .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
   let links = get_links(
     LinkQuery::new(original_action_hash.0, link_type_filter),
-    GetStrategy::Local,
+    GetStrategy::Network,
   )?;
 
   let records: Vec<Option<Record>> = links

--- a/dnas/requests_and_offers/zomes/coordinator/administration/src/status.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/administration/src/status.rs
@@ -4,8 +4,8 @@ use hdk::prelude::*;
 use status::*;
 use utils::{
   errors::{AdministrationError, CommonError, StatusError},
-  find_original_action_hash, get_all_revisions_for_entry, EntityActionHash, EntityAgent,
-  OriginalActionHash, PreviousActionHash,
+  find_original_action_hash, get_all_revisions_for_entry, resolve_chain_root, EntityActionHash,
+  EntityAgent, OriginalActionHash, PreviousActionHash,
 };
 
 use crate::administration::check_if_agent_is_administrator;
@@ -85,11 +85,14 @@ fn get_entity_status_link(input: EntityActionHash) -> ExternResult<Link> {
 
 /// Returns the most recent `Status` record for the given original status action hash.
 ///
-/// Resolves the latest revision by selecting the `AllStatuses` link with the most recent
-/// timestamp. Returns `Ok(None)` if no status record exists.
+/// Resolves the latest revision by selecting the `StatusUpdates` link with the most
+/// recent timestamp. The `AllStatuses` link type is anchored from the
+/// `"{entity}.status"` path, not from a status action hash, so it cannot be used
+/// here. Returns `Ok(None)` if no status record exists (the hash is already the
+/// latest, or no updates were ever made).
 #[hdk_extern]
 pub fn get_latest_status_record(original_action_hash: ActionHash) -> ExternResult<Option<Record>> {
-  let link_type_filter = LinkTypes::AllStatuses
+  let link_type_filter = LinkTypes::StatusUpdates
     .try_into_filter()
     .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
   let links = get_links(
@@ -361,12 +364,17 @@ pub fn update_entity_status(input: UpdateEntityActionHash) -> ExternResult<Recor
   } else {
     // Entity has existing status, update it
     action_hash = update_entry(
-      input.status_previous_action_hash.into(),
+      input.status_previous_action_hash.clone().into(),
       input.new_status.clone(),
     )?;
 
+    // Anchor the StatusUpdates link at the status chain's true root. Callers pass
+    // whatever they believe is "original", which is usually a mid-chain revision:
+    // the EntityStatus link rotates to point at the latest revision, so that is the
+    // hash the client reads back. Anchoring there would scatter revision links
+    // across the chain and truncate the history read by get_all_revisions_for_status.
     create_link(
-      input.status_original_action_hash,
+      resolve_chain_root(input.status_previous_action_hash.0.clone()),
       action_hash.clone(),
       LinkTypes::StatusUpdates,
       (),

--- a/dnas/requests_and_offers/zomes/coordinator/mediums_of_exchange/src/medium_of_exchange.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/mediums_of_exchange/src/medium_of_exchange.rs
@@ -2,8 +2,8 @@ use hdk::prelude::*;
 use mediums_of_exchange_integrity::{EntryTypes, LinkTypes, MediumOfExchange};
 use utils::errors::{AdministrationError, CommonError};
 use utils::{
-  GetMediumOfExchangeForEntityInput, MediumOfExchangeLinkInput, OriginalActionHash,
-  PreviousActionHash, UpdateMediumOfExchangeLinksInput,
+  resolve_chain_root, GetMediumOfExchangeForEntityInput, MediumOfExchangeLinkInput,
+  OriginalActionHash, PreviousActionHash, UpdateMediumOfExchangeLinksInput,
 };
 
 use crate::external_calls::{
@@ -25,7 +25,6 @@ fn get_status_path_hash(status_path: &str) -> ExternResult<EntryHash> {
 pub struct MediumOfExchangeInput {
   pub medium_of_exchange: MediumOfExchange,
 }
-
 
 /// Input for updating a medium of exchange
 #[derive(Serialize, Deserialize, Debug)]
@@ -171,9 +170,13 @@ pub fn update_medium_of_exchange(input: UpdateMediumOfExchangeInput) -> ExternRe
     EntryTypes::MediumOfExchange(input.updated_medium_of_exchange),
   )?;
 
-  // Create update link
+  // Create update link. The caller's "original" may itself be a revision, because
+  // list surfaces hand back the LATEST record and a record's only identity is its
+  // own action hash. Anchoring there would start a rival update chain that
+  // get_latest_medium_of_exchange_record never looks at, so the second edit would
+  // silently vanish from every list.
   create_link(
-    input.original_action_hash,
+    resolve_chain_root(input.original_action_hash.0),
     updated_medium_of_exchange_hash.clone(),
     LinkTypes::MediumOfExchangeUpdates,
     (),
@@ -195,6 +198,9 @@ pub fn delete_medium_of_exchange(medium_of_exchange_hash: ActionHash) -> ExternR
   if !is_admin {
     return Err(AdministrationError::Unauthorized.into());
   }
+
+  // Status-path links and the entry to tomb are both keyed by the chain root.
+  let medium_of_exchange_hash = resolve_chain_root(medium_of_exchange_hash);
 
   // Get the record to verify it exists
   let _record = get(medium_of_exchange_hash.clone(), GetOptions::default())?.ok_or(
@@ -316,24 +322,14 @@ fn get_mediums_of_exchange_by_status(status_path: &str) -> ExternResult<Vec<Reco
     LinkQuery::new(path_hash, link_type_filter),
     GetStrategy::Network,
   )?;
-  let get_input: Vec<GetInput> = links
-    .into_iter()
-    .map(|link| {
-      GetInput::new(
-        link
-          .target
-          .clone()
-          .into_any_dht_hash()
-          .expect("Failed to convert link target"),
-        GetOptions::default(),
-      )
-    })
-    .collect();
-  let records = HDK
-    .with(|hdk| hdk.borrow().get(get_input))?
-    .into_iter()
-    .flatten()
-    .collect();
+  let mut records = Vec::new();
+  for link in links {
+    if let Some(target_hash) = link.target.into_action_hash() {
+      if let Some(record) = get_latest_medium_of_exchange_record(target_hash.clone())? {
+        records.push(record);
+      }
+    }
+  }
   Ok(records)
 }
 
@@ -347,10 +343,17 @@ pub fn approve_medium_of_exchange(medium_of_exchange_hash: ActionHash) -> Extern
     return Err(AdministrationError::Unauthorized.into());
   }
 
-  // Get the current record
-  let record = get(medium_of_exchange_hash.clone(), GetOptions::default())?.ok_or(
+  // Status paths and the update chain are both keyed by the chain root; the admin
+  // table hands us whatever hash its row carries, which is a revision after an edit.
+  let medium_of_exchange_hash = resolve_chain_root(medium_of_exchange_hash);
+
+  // Approving rewrites the entry to stamp the hREA resource-spec id on it, so read
+  // the LATEST revision: reading the root would silently roll back every edit made
+  // since creation.
+  let record = get_latest_medium_of_exchange_record(medium_of_exchange_hash.clone())?.ok_or(
     CommonError::EntryNotFound("Could not find the medium of exchange".to_string()),
   )?;
+  let latest_action_hash = record.action_address().clone();
 
   // Extract the entry
   let entry = match record.entry().to_app_option::<MediumOfExchange>() {
@@ -374,13 +377,13 @@ pub fn approve_medium_of_exchange(medium_of_exchange_hash: ActionHash) -> Extern
     resource_spec_hrea_id: Some(resource_spec_id),
   };
 
-  // Create update entry
+  // Create update entry on top of the latest revision, keeping one linear chain.
   let updated_hash = update_entry(
-    medium_of_exchange_hash.clone(),
+    latest_action_hash,
     EntryTypes::MediumOfExchange(updated_entry),
   )?;
 
-  // Create update link
+  // Create update link, anchored at the chain root like every other revision link.
   create_link(
     medium_of_exchange_hash.clone(),
     updated_hash,
@@ -411,6 +414,9 @@ pub fn reject_medium_of_exchange(medium_of_exchange_hash: ActionHash) -> ExternR
   if !is_admin {
     return Err(AdministrationError::Unauthorized.into());
   }
+
+  // Status paths are keyed by the chain root (see approve_medium_of_exchange).
+  let medium_of_exchange_hash = resolve_chain_root(medium_of_exchange_hash);
 
   // Remove from all status paths
   remove_medium_of_exchange_from_status_paths(medium_of_exchange_hash.clone())?;
@@ -732,6 +738,10 @@ pub fn delete_all_medium_of_exchange_links_for_entity(
 /// Check if a medium of exchange is approved (for internal use)
 #[hdk_extern]
 pub fn is_medium_of_exchange_approved(medium_of_exchange_hash: ActionHash) -> ExternResult<bool> {
+  // The approved-path link targets the chain root, so a revision hash from a list
+  // surface must be normalized before comparing (see approve_medium_of_exchange).
+  let medium_of_exchange_hash = resolve_chain_root(medium_of_exchange_hash);
+
   // Get the approved path hash
   let approved_path_hash = get_status_path_hash(APPROVED_MEDIUMS_OF_EXCHANGE_PATH)?;
 

--- a/dnas/requests_and_offers/zomes/coordinator/offers/src/offer.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/offers/src/offer.rs
@@ -2,9 +2,9 @@ use hdk::prelude::*;
 use offers_integrity::*;
 use utils::{
   errors::{AdministrationError, CommonError, UsersError},
-  EntityActionHash, GetMediumOfExchangeForEntityInput, GetServiceTypeForEntityInput,
-  MediumOfExchangeLinkInput, OriginalActionHash, PreviousActionHash, ServiceTypeLinkInput,
-  UpdateMediumOfExchangeLinksInput, UpdateServiceTypeLinksInput,
+  resolve_chain_root, EntityActionHash, GetMediumOfExchangeForEntityInput,
+  GetServiceTypeForEntityInput, MediumOfExchangeLinkInput, OriginalActionHash, PreviousActionHash,
+  ServiceTypeLinkInput, UpdateMediumOfExchangeLinksInput, UpdateServiceTypeLinksInput,
 };
 
 use crate::external_calls::{
@@ -168,20 +168,17 @@ pub fn get_active_offers(_: ()) -> ExternResult<Vec<Record>> {
     LinkQuery::new(path_hash.clone(), link_type_filter),
     GetStrategy::Network,
   )?;
-  let get_input: Vec<GetInput> = links
-    .into_iter()
-    .filter_map(|link| {
-      link
-        .target
-        .clone()
-        .into_any_dht_hash()
-        .ok_or(CommonError::ActionHashNotFound("offer".to_string()))
-        .ok()
-        .map(|hash| GetInput::new(hash, GetOptions::default()))
-    })
-    .collect();
-  let records = HDK.with(|hdk| hdk.borrow().get(get_input))?;
-  let records: Vec<Record> = records.into_iter().flatten().collect();
+  // Resolve the LATEST record per link target so edits are visible on list
+  // surfaces (Bug 4 fix). The active-offers path links to the original
+  // action hash; after an edit, bare get() would return the pre-edit entry.
+  let mut records = Vec::new();
+  for link in links {
+    if let Some(target_hash) = link.target.clone().into_action_hash() {
+      if let Some(record) = get_latest_offer_record(target_hash)? {
+        records.push(record);
+      }
+    }
+  }
   Ok(records)
 }
 
@@ -196,20 +193,14 @@ pub fn get_archived_offers(_: ()) -> ExternResult<Vec<Record>> {
     LinkQuery::new(path_hash.clone(), link_type_filter),
     GetStrategy::Network,
   )?;
-  let get_input: Vec<GetInput> = links
-    .into_iter()
-    .filter_map(|link| {
-      link
-        .target
-        .clone()
-        .into_any_dht_hash()
-        .ok_or(CommonError::ActionHashNotFound("offer".to_string()))
-        .ok()
-        .map(|hash| GetInput::new(hash, GetOptions::default()))
-    })
-    .collect();
-  let records = HDK.with(|hdk| hdk.borrow().get(get_input))?;
-  let records: Vec<Record> = records.into_iter().flatten().collect();
+  let mut records = Vec::new();
+  for link in links {
+    if let Some(target_hash) = link.target.clone().into_action_hash() {
+      if let Some(record) = get_latest_offer_record(target_hash)? {
+        records.push(record);
+      }
+    }
+  }
   Ok(records)
 }
 
@@ -224,21 +215,14 @@ pub fn get_user_offers(user_hash: ActionHash) -> ExternResult<Vec<Record>> {
     LinkQuery::new(user_hash.clone(), link_type_filter),
     GetStrategy::Local,
   )?;
-  let get_input: Vec<GetInput> = links
-    .into_iter()
-    .map(|link| {
-      GetInput::new(
-        link
-          .target
-          .clone()
-          .into_any_dht_hash()
-          .expect("Failed to convert link target"),
-        GetOptions::default(),
-      )
-    })
-    .collect();
-  let records = HDK.with(|hdk| hdk.borrow().get(get_input))?;
-  let records: Vec<Record> = records.into_iter().flatten().collect();
+  let mut records = Vec::new();
+  for link in links {
+    if let Some(target_hash) = link.target.clone().into_action_hash() {
+      if let Some(record) = get_latest_offer_record(target_hash)? {
+        records.push(record);
+      }
+    }
+  }
   Ok(records)
 }
 
@@ -417,9 +401,13 @@ pub fn update_offer(input: UpdateOfferInput) -> ExternResult<Record> {
     (),
   )?;
 
-  // Create the update tracking link (original → updated, for get_latest_offer_record)
+  // Create the update tracking link (root -> updated, for get_latest_offer_record).
+  // Anchored at the chain root, not at the caller's "original": the ActiveOffers
+  // path link rotates to the newest revision, so after one edit the client's idea
+  // of "original" IS a revision. Anchoring there would hide the second edit from
+  // every non-rotating surface, UserOffers and the archived path among them.
   create_link(
-    input.original_action_hash,
+    resolve_chain_root(input.original_action_hash.0),
     updated_offer_hash.clone(),
     LinkTypes::OfferUpdates,
     (),

--- a/dnas/requests_and_offers/zomes/coordinator/offers/src/offer.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/offers/src/offer.rs
@@ -169,8 +169,14 @@ pub fn get_active_offers(_: ()) -> ExternResult<Vec<Record>> {
     GetStrategy::Network,
   )?;
   // Resolve the LATEST record per link target so edits are visible on list
-  // surfaces (Bug 4 fix). The active-offers path links to the original
-  // action hash; after an edit, bare get() would return the pre-edit entry.
+  // surfaces (Bug 4 fix).
+  //
+  // Note which invariant this surface follows: update_offer ROTATES the
+  // ActiveOffers link, deleting the one at previous_hash and creating one at
+  // the new revision, so the target read here is already the tip. The resolve
+  // is still the right shape, because it is what makes the non-rotating
+  // surfaces correct (UserOffers and the archived path stay anchored at the
+  // Create), and one shape across all three is what stops them drifting apart.
   let mut records = Vec::new();
   for link in links {
     if let Some(target_hash) = link.target.clone().into_action_hash() {

--- a/dnas/requests_and_offers/zomes/coordinator/requests/src/request.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/requests/src/request.rs
@@ -2,9 +2,9 @@ use hdk::prelude::*;
 use requests_integrity::*;
 use utils::{
   errors::{AdministrationError, CommonError, UsersError},
-  EntityActionHash, GetMediumOfExchangeForEntityInput, GetServiceTypeForEntityInput,
-  MediumOfExchangeLinkInput, OriginalActionHash, PreviousActionHash, ServiceTypeLinkInput,
-  UpdateMediumOfExchangeLinksInput, UpdateServiceTypeLinksInput,
+  resolve_chain_root, EntityActionHash, GetMediumOfExchangeForEntityInput,
+  GetServiceTypeForEntityInput, MediumOfExchangeLinkInput, OriginalActionHash, PreviousActionHash,
+  ServiceTypeLinkInput, UpdateMediumOfExchangeLinksInput, UpdateServiceTypeLinksInput,
 };
 
 use crate::external_calls::{
@@ -169,20 +169,16 @@ pub fn get_active_requests(_: ()) -> ExternResult<Vec<Record>> {
     LinkQuery::new(path_hash.clone(), link_type_filter),
     GetStrategy::Network,
   )?;
-  let get_input: Vec<GetInput> = links
-    .into_iter()
-    .filter_map(|link| {
-      link
-        .target
-        .clone()
-        .into_any_dht_hash()
-        .ok_or(CommonError::ActionHashNotFound("request".to_string()))
-        .ok()
-        .map(|hash| GetInput::new(hash, GetOptions::default()))
-    })
-    .collect();
-  let records = HDK.with(|hdk| hdk.borrow().get(get_input))?;
-  let records: Vec<Record> = records.into_iter().flatten().collect();
+  // Resolve the LATEST record per link target so edits are visible on list
+  // surfaces (Bug 4 fix).
+  let mut records = Vec::new();
+  for link in links {
+    if let Some(target_hash) = link.target.clone().into_action_hash() {
+      if let Some(record) = get_latest_request_record(target_hash)? {
+        records.push(record);
+      }
+    }
+  }
   Ok(records)
 }
 
@@ -197,20 +193,14 @@ pub fn get_archived_requests(_: ()) -> ExternResult<Vec<Record>> {
     LinkQuery::new(path_hash.clone(), link_type_filter),
     GetStrategy::Network,
   )?;
-  let get_input: Vec<GetInput> = links
-    .into_iter()
-    .filter_map(|link| {
-      link
-        .target
-        .clone()
-        .into_any_dht_hash()
-        .ok_or(CommonError::ActionHashNotFound("request".to_string()))
-        .ok()
-        .map(|hash| GetInput::new(hash, GetOptions::default()))
-    })
-    .collect();
-  let records = HDK.with(|hdk| hdk.borrow().get(get_input))?;
-  let records: Vec<Record> = records.into_iter().flatten().collect();
+  let mut records = Vec::new();
+  for link in links {
+    if let Some(target_hash) = link.target.clone().into_action_hash() {
+      if let Some(record) = get_latest_request_record(target_hash)? {
+        records.push(record);
+      }
+    }
+  }
   Ok(records)
 }
 
@@ -225,21 +215,14 @@ pub fn get_user_requests(user_hash: ActionHash) -> ExternResult<Vec<Record>> {
     LinkQuery::new(user_hash.clone(), link_type_filter),
     GetStrategy::Local,
   )?;
-  let get_input: Vec<GetInput> = links
-    .into_iter()
-    .map(|link| {
-      GetInput::new(
-        link
-          .target
-          .clone()
-          .into_any_dht_hash()
-          .expect("Failed to convert link target"),
-        GetOptions::default(),
-      )
-    })
-    .collect();
-  let records = HDK.with(|hdk| hdk.borrow().get(get_input))?;
-  let records: Vec<Record> = records.into_iter().flatten().collect();
+  let mut records = Vec::new();
+  for link in links {
+    if let Some(target_hash) = link.target.clone().into_action_hash() {
+      if let Some(record) = get_latest_request_record(target_hash)? {
+        records.push(record);
+      }
+    }
+  }
   Ok(records)
 }
 
@@ -421,9 +404,12 @@ pub fn update_request(input: UpdateRequestInput) -> ExternResult<Record> {
     (),
   )?;
 
-  // Create the update tracking link (original → updated, for get_latest_request_record)
+  // Create the update tracking link (root -> updated, for get_latest_request_record).
+  // Anchored at the chain root for the same reason as offers: the ActiveRequests
+  // path link rotates to the newest revision, so the client's "original" is itself
+  // a revision after the first edit.
   create_link(
-    input.original_action_hash,
+    resolve_chain_root(input.original_action_hash.0),
     updated_request_hash.clone(),
     LinkTypes::RequestUpdates,
     (),

--- a/dnas/requests_and_offers/zomes/coordinator/service_types/src/service_type.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/service_types/src/service_type.rs
@@ -2,8 +2,8 @@ use hdk::prelude::*;
 use service_types_integrity::{EntryTypes, LinkTypes, ServiceType};
 use utils::{
   errors::{AdministrationError, CommonError},
-  GetServiceTypeForEntityInput, OriginalActionHash, PreviousActionHash, ServiceTypeLinkInput,
-  UpdateServiceTypeLinksInput,
+  resolve_chain_root, GetServiceTypeForEntityInput, OriginalActionHash, PreviousActionHash,
+  ServiceTypeLinkInput, UpdateServiceTypeLinksInput,
 };
 
 use crate::external_calls::{
@@ -180,9 +180,12 @@ pub fn update_service_type(input: UpdateServiceTypeInput) -> ExternResult<Action
     &input.updated_service_type,
   )?;
 
-  // Create a link from the original service type to the updated one
+  // Create a link from the original service type to the updated one. The caller's
+  // "original" may itself be a revision (list surfaces hand back the latest record),
+  // so anchor at the chain root or the second edit starts a rival update chain that
+  // get_latest_service_type_record will never see.
   create_link(
-    input.original_action_hash,
+    resolve_chain_root(input.original_action_hash.0),
     updated_action_hash.clone(),
     LinkTypes::ServiceTypeUpdates,
     (),
@@ -199,6 +202,10 @@ pub fn delete_service_type(service_type_hash: ActionHash) -> ExternResult<Action
   if !is_admin {
     return Err(AdministrationError::Unauthorized.into());
   }
+
+  // Every link that has to be torn down is anchored at the chain root, and the
+  // entry to tomb is the root Create, so normalize before touching either.
+  let service_type_hash = resolve_chain_root(service_type_hash);
 
   // Remove the AllServiceTypes link
   let path = Path::from("service_types");
@@ -295,6 +302,10 @@ pub fn approve_service_type(service_type_hash: ActionHash) -> ExternResult<()> {
     return Err(AdministrationError::Unauthorized.into());
   }
 
+  // Status paths are keyed by the chain root; a client holding a revision hash
+  // would otherwise file this service type under a second, invisible identity.
+  let service_type_hash = resolve_chain_root(service_type_hash);
+
   // Get the approved path hash
   let approved_path_hash = get_status_path_hash(APPROVED_SERVICE_TYPES_PATH)?;
 
@@ -320,6 +331,9 @@ pub fn reject_service_type(service_type_hash: ActionHash) -> ExternResult<()> {
   if !is_admin {
     return Err(AdministrationError::Unauthorized.into());
   }
+
+  // Status paths are keyed by the chain root (see approve_service_type).
+  let service_type_hash = resolve_chain_root(service_type_hash);
 
   // Get the pending path hash
   let pending_path_hash = get_status_path_hash(PENDING_SERVICE_TYPES_PATH)?;
@@ -367,6 +381,9 @@ pub fn reject_approved_service_type(service_type_hash: ActionHash) -> ExternResu
   if !is_admin {
     return Err(AdministrationError::Unauthorized.into());
   }
+
+  // Status paths are keyed by the chain root (see approve_service_type).
+  let service_type_hash = resolve_chain_root(service_type_hash);
 
   // Get the approved path hash
   let approved_path_hash = get_status_path_hash(APPROVED_SERVICE_TYPES_PATH)?;
@@ -507,10 +524,13 @@ fn remove_service_type_from_status_paths(service_type_hash: ActionHash) -> Exter
 /// Check if a service type is approved (for internal/cross-zome use)
 #[hdk_extern]
 pub fn is_service_type_approved(service_type_hash: ActionHash) -> ExternResult<bool> {
+  // Resolve to the original action hash (the one the approval link actually targets)
+  let original_hash = resolve_chain_root(service_type_hash);
+
   // Get the approved path hash
   let approved_path_hash = get_status_path_hash(APPROVED_SERVICE_TYPES_PATH)?;
 
-  // Check if there's a link from approved path to this service type
+  // Check if there's a link from approved path to the ORIGINAL service type hash
   let link_type_filter = LinkTypes::AllServiceTypes
     .try_into_filter()
     .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
@@ -521,7 +541,7 @@ pub fn is_service_type_approved(service_type_hash: ActionHash) -> ExternResult<b
 
   let found_approved = links
     .into_iter()
-    .any(|link| link.target.into_action_hash() == Some(service_type_hash.clone()));
+    .any(|link| link.target.into_action_hash() == Some(original_hash.clone()));
 
   Ok(found_approved)
 }
@@ -529,7 +549,10 @@ pub fn is_service_type_approved(service_type_hash: ActionHash) -> ExternResult<b
 /// Get the status of a service type (pending, approved, or rejected)
 #[hdk_extern]
 pub fn get_service_type_status(service_type_hash: ActionHash) -> ExternResult<String> {
-  // Check each status path
+  // Resolve to the original action hash (the one the status links actually target)
+  let original_hash = resolve_chain_root(service_type_hash);
+
+  // Check each status path using the original hash
   let pending_path_hash = get_status_path_hash(PENDING_SERVICE_TYPES_PATH)?;
   let approved_path_hash = get_status_path_hash(APPROVED_SERVICE_TYPES_PATH)?;
   let rejected_path_hash = get_status_path_hash(REJECTED_SERVICE_TYPES_PATH)?;
@@ -544,7 +567,7 @@ pub fn get_service_type_status(service_type_hash: ActionHash) -> ExternResult<St
   )?;
   let is_pending = pending_links
     .into_iter()
-    .any(|link| link.target.into_action_hash() == Some(service_type_hash.clone()));
+    .any(|link| link.target.into_action_hash() == Some(original_hash.clone()));
 
   if is_pending {
     return Ok("pending".to_string());
@@ -560,7 +583,7 @@ pub fn get_service_type_status(service_type_hash: ActionHash) -> ExternResult<St
   )?;
   let is_approved = approved_links
     .into_iter()
-    .any(|link| link.target.into_action_hash() == Some(service_type_hash.clone()));
+    .any(|link| link.target.into_action_hash() == Some(original_hash.clone()));
 
   if is_approved {
     return Ok("approved".to_string());
@@ -576,7 +599,7 @@ pub fn get_service_type_status(service_type_hash: ActionHash) -> ExternResult<St
   )?;
   let is_rejected = rejected_links
     .into_iter()
-    .any(|link| link.target.into_action_hash() == Some(service_type_hash.clone()));
+    .any(|link| link.target.into_action_hash() == Some(original_hash.clone()));
 
   if is_rejected {
     return Ok("rejected".to_string());

--- a/ui/src/lib/components/service-types/ServiceTypeSelector.svelte
+++ b/ui/src/lib/components/service-types/ServiceTypeSelector.svelte
@@ -393,7 +393,7 @@
           {/if}
         </h4>
         <div class="max-h-80 space-y-2 overflow-y-auto">
-          {#each filteredServiceTypes as serviceType}
+          {#each filteredServiceTypes as serviceType (serviceType.original_action_hash)}
             {@const isSelected = selectedHashes.some(
               (hash) => hash.toString() === serviceType.original_action_hash?.toString()
             )}

--- a/ui/src/lib/stores/administration.store.svelte.ts
+++ b/ui/src/lib/stores/administration.store.svelte.ts
@@ -1236,7 +1236,9 @@ export const createAdministrationStore = (): E.Effect<
     const fetchAllUsersStatusHistory = (): E.Effect<void, AdministrationError> =>
       withLoadingState(() =>
         pipe(
-          E.succeed(allUsers),
+          // Fetch users rather than trusting in-memory state — on direct
+          // navigation to the status-history page, allUsers is still empty.
+          fetchAllUsers(),
           E.tap((users) =>
             E.sync(() =>
               console.log(
@@ -1311,7 +1313,9 @@ export const createAdministrationStore = (): E.Effect<
     const fetchAllOrganizationsStatusHistory = (): E.Effect<void, AdministrationError> =>
       withLoadingState(() =>
         pipe(
-          E.succeed(allOrganizations),
+          // Fetch organizations rather than trusting in-memory state — on direct
+          // navigation to the status-history page, allOrganizations is still empty.
+          fetchAllOrganizations(),
           E.flatMap((organizations) =>
             E.all(
               organizations

--- a/ui/src/lib/stores/mediums_of_exchange.store.svelte.ts
+++ b/ui/src/lib/stores/mediums_of_exchange.store.svelte.ts
@@ -430,7 +430,10 @@ export const createMediumsOfExchangeStore = (): E.Effect<
             // For individual medium retrieval, assume it's approved
             const entity = createEnhancedUIMediumOfExchange(record, 'approved');
             if (entity) {
-              E.runSync(cache.set(originalActionHash.toString(), entity));
+              // Key by the entity's own hash, the same key every fetch path uses.
+              // The requested hash may be an older revision, and caching under it
+              // would leave two live rows for one entity.
+              E.runSync(cache.set(entity.original_action_hash!.toString(), entity));
               syncCacheToState(entity, 'add');
               eventEmitters.emitCreated(entity);
             }
@@ -759,22 +762,26 @@ export const createMediumsOfExchangeStore = (): E.Effect<
             updatedMediumOfExchange
           ),
           E.map((record) => {
-            // First, remove the old entry using the previous action hash
-            const previousHashStr = previousActionHash.toString();
-            E.runSync(cache.delete(previousHashStr));
+            // Drop the stale row under BOTH hashes the caller could have been
+            // holding: list surfaces key rows by the record they were built from,
+            // which is the original before the first edit and a revision after it.
+            E.runSync(cache.delete(originalActionHash.toString()));
+            E.runSync(cache.delete(previousActionHash.toString()));
 
             // Create dummy entity for removal
             const dummyEntity = {
-              original_action_hash: previousActionHash,
+              original_action_hash: originalActionHash,
               previous_action_hash: previousActionHash,
               status: 'pending'
             } as unknown as UIMediumOfExchange;
             syncCacheToState(dummyEntity, 'remove');
 
-            // Now add the new updated entry
+            // Add the updated entry keyed by its own hash, matching how every
+            // fetch path keys rows. The zome resolves this hash back to the chain
+            // root on every write, so a revision hash is a valid handle.
             const entity = createEnhancedUIMediumOfExchange(record, 'approved'); // Admin updates are auto-approved
             if (entity) {
-              E.runSync(cache.set(record.signed_action.hashed.hash.toString(), entity));
+              E.runSync(cache.set(entity.original_action_hash!.toString(), entity));
               syncCacheToState(entity, 'add');
               eventEmitters.emitUpdated(entity);
             }

--- a/ui/src/routes/admin/mediums-of-exchange/[id]/edit/+page.svelte
+++ b/ui/src/routes/admin/mediums-of-exchange/[id]/edit/+page.svelte
@@ -29,8 +29,21 @@
       const actionHash = decodeHashFromBase64(idPart);
       console.log('Decoded action hash:', actionHash);
 
-      const result = await runEffect(mediumsOfExchangeStore.getMediumOfExchange(actionHash));
+      // Load the LATEST revision, not the record at the URL hash: editing must
+      // start from the current values, and before this the form silently reset
+      // the entry to whatever it looked like at creation.
+      const result = await runEffect(
+        mediumsOfExchangeStore.getLatestMediumOfExchangeRecord(actionHash)
+      );
       console.log('Loaded medium of exchange:', result);
+
+      // Keep the URL hash as the entity handle. The record we just loaded is the
+      // latest revision and carries its own action hash, while previous_action_hash
+      // must stay pointed at that revision for update_entry to chain correctly.
+      if (result) {
+        result.previous_action_hash = result.original_action_hash;
+        result.original_action_hash = actionHash;
+      }
       mediumOfExchange = result;
     } catch (err) {
       error = 'Failed to load medium of exchange';


### PR DESCRIPTION
## Intent

**A client can never hand the DHT a correct "original" action hash, and six code paths were trusting it to.**

List surfaces read the *latest* record of an entity, and a Holochain record's only identity is its own action hash. So the moment an entity is edited once, the hash the UI calls `original_action_hash` is a revision, not the creation action. Every link type, every status path, and every revision history in this hApp is anchored at the creation action. Feed one of them a revision hash and the entity quietly acquires a second identity: the edit disappears from lists, the status history truncates, and approve/reject writes a link nothing ever reads back.

This is the root cause behind the app gaps the e2e suite surfaced. Rather than patch each symptom, this PR fixes the boundary: **any action hash arriving from a client is normalized to its chain root before it touches a link, a path, or a history.**

## Changes

**One helper, one rule.** `utils::resolve_chain_root` walks the update chain to its `Create` and, unlike `find_original_action_hash`, never fails: an unresolvable chain (not yet gossiped, unexpected action type) falls back to the hash as given, which is exactly the pre-normalization behavior. It is applied at every entry point that consumes a client-supplied hash:

| Zome | Normalized |
|---|---|
| `administration` | `StatusUpdates` link anchor, plus revision reads via `get_all_revisions_for_entry` |
| `service_types` | `approve` / `reject` / `reject_approved` / `delete`, the `ServiceTypeUpdates` anchor, `is_service_type_approved`, `get_service_type_status` |
| `mediums_of_exchange` | `approve` / `reject` / `delete`, the `MediumOfExchangeUpdates` anchor, `is_medium_of_exchange_approved` |
| `offers`, `requests` | `OfferUpdates` / `RequestUpdates` anchors |

**Status history renders again.** `get_latest_status_record` filtered on `AllStatuses`, which is anchored at the `"{entity}.status"` path and therefore never matched a status action hash. It now filters on `StatusUpdates`. Combined with the root-anchored writes, the status-history pages show the full history instead of an empty state or the first two rows.

**Edits become visible on list surfaces.** The list endpoints resolve the latest record per link target, so an edited offer, request, or medium of exchange shows its current values rather than the values it was created with.

**Approving a medium of exchange no longer reverts it.** `approve_medium_of_exchange` rewrites the entry to stamp the hREA resource-spec id on it, and it was reading the *root* record to do so, silently rolling back every edit made since creation. It now reads the latest revision and chains the update on top of it.

**UI side.** The store's attempt to recover an original hash from an `Update` action's `original_action_address` is removed: in this codebase `update_entry` is called with the *previous* hash, so that field holds the previous revision, not the root, and the single-hop read was wrong from the second edit onward. The zome now does that resolution correctly, so the client does not need to. Alongside: cache keys are consistent across the fetch and update paths, the admin status-history pages fetch their data instead of trusting in-memory state that is empty on direct navigation, the medium-of-exchange edit page loads the latest revision, and `ServiceTypeSelector`'s `{#each}` is keyed so re-sorting cannot toggle the wrong row.

## Decisions

| Option | Rejected because |
|--------|-----------------|
| Point `update_entry` at the original instead of the previous hash | One line per domain and it would make the client's single-hop read correct, but it changes update-chain semantics across all eight call sites and the whole DHT. Too much blast radius for a bug fix. |
| Return `{original_action_hash, record}` pairs from the list endpoints | Correct, but it ripples through schemas, services, stores and every component in three domains. The chain-root rule gets the same correctness without an API break. |
| Keep resolving the original in the UI | Not recoverable client-side: reaching the root needs a walk, and each hop is a DHT read the browser cannot batch. The zome is already holding the record. |

`get_all_revisions_for_entry` moves from `GetStrategy::Local` to `Network`. Status revisions are authored by admins and read by other agents, so a local-only read returns an empty or partial history for exactly the case the status-history page exists to show. This is a deliberate latency-for-correctness trade on that one read path.

## How to test

Automated, all run on this branch:

```bash
nix develop --command bash -c "RUSTFLAGS='--cfg getrandom_backend=\"custom\"' cargo build --release --target wasm32-unknown-unknown"   # zomes compile
nix develop --command bun test:unit    # 534 passed / 26 files
cd ui && bunx svelte-check --tsconfig ./tsconfig.json   # 0 errors, 0 warnings
```

`rustfmt --check` is clean on all six touched Rust files, and `prettier --check` plus `eslint` are clean on all four touched UI files.

Manually, the shape worth exercising is **the second edit**, because the first one worked before this PR and hid the bug:

1. Create a medium of exchange, approve it, then edit it **twice** from the admin table. Both edits must remain visible in the list, and the row's approve/reject/delete buttons must still act on the right entity.
2. Do the same to a service type, and confirm its status stays `approved` rather than reverting to `pending` after the second edit.
3. Edit an offer twice, then open "My Listings": the second edit must appear there, not just on the active-offers page.
4. Suspend and reinstate a user, then open the status-history page **by direct URL** (not by navigating from the dashboard). The full history must render.

## Documentation

No documentation changes. The behavior this restores is what `documentation/` already describes; the update-chain rule is documented at the `resolve_chain_root` definition, which is where a future caller will look for it.

## Related

Closes #56
Replaces #176, which carried this same work on a branch that had drifted 9 files into conflict with `dev` after the e2e suite landed there separately.
Related #173, #174
