### PR TITLE
docs: correct architecture doc paths and index membrane designs

### DIFF
--- a/documentation/architecture/MEMBRANE_MANAGEMENT_OFF_DHT.md
+++ b/documentation/architecture/MEMBRANE_MANAGEMENT_OFF_DHT.md
@@ -1,7 +1,7 @@
 # Membrane Management — The Off-DHT Half
 
 **Status:** frame-check draft (v0.1) — for endorse-or-redirect, not a build spec
-**Companion:** `documentation/MEMBRANE_MANAGEMENT.md` (the in-DHT half, PR #170)
+**Companion:** `documentation/architecture/MEMBRANE_MANAGEMENT.md` (the in-DHT half, PR #170)
 **Related issues:** #144 (breaking-version migration), #143 (version-drift detection), #95 (joining UX)
 
 ---
@@ -206,7 +206,7 @@ The §6 install-flow finding is a *contribution to #144*, not a question we are 
 
 ## 8. References
 
-- In-DHT companion: `documentation/MEMBRANE_MANAGEMENT.md` (PR #170)
+- In-DHT companion: `documentation/architecture/MEMBRANE_MANAGEMENT.md` (PR #170)
 - Joining service: `JOINING_SERVICE_API.md`; the auth-method plugins (`plugin.ts`, `invite-code.ts`, `email-code.ts`, `agent-allow-list.ts`, `hc-auth-approval.ts`); `gen-signing-key.ts`; `DEPLOYMENT.md`
 - Migration: #144 (breaking-version migration system), #143 (version-drift detection), #95 (joining UX / QR invite)
 - Kangaroo source consulted for §6: `kangaroo-electron` `src/main/{filesystem.ts, holochainManager.ts, lairKeystore.ts}` (branch `main-0.6`)

--- a/documentation/architecture/README.md
+++ b/documentation/architecture/README.md
@@ -61,3 +61,5 @@ The project integrates the hREA (Holochain Resource-Event-Agent) framework for V
 - [The Progenitor Pattern](../progenitor.md) — network bootstrap mechanism
 - [Administration Zome Spec](../technical-specs/zomes/administration.md) — admin/progenitor API
 - [hREA Integration](hrea-integration.md) — Valueflows economic layer
+- [Membrane Management](MEMBRANE_MANAGEMENT.md) — in-DHT membrane enforcement
+- [Membrane Management (Off-DHT)](MEMBRANE_MANAGEMENT_OFF_DHT.md) — off-DHT companion


### PR DESCRIPTION
Small follow-through on the documentation/architecture/ convention.

Two companion references in MEMBRANE_MANAGEMENT_OFF_DHT.md (lines 4 and 209) still point at documentation/MEMBRANE_MANAGEMENT.md, which resolves to nothing now that both membrane designs live under architecture/. The bare filename reference at line 11 is untouched, since it is correct as a sibling reference.

Neither membrane design appeared in the Further Reading list in architecture/README.md, so both are added there.

Two files, +4/-2. No content changes.