### PR TITLE
docs(architecture): add frontend refactoring programme

### DIFF
--- a/documentation/DOCUMENTATION_INDEX.md
+++ b/documentation/DOCUMENTATION_INDEX.md
@@ -47,8 +47,10 @@
 
 - **[Architecture README](architecture/README.md)** - Architecture overview: component layout, 7-layer pattern, network bootstrap
 - **[Architecture Overview](architecture.md)** - System architecture and design patterns
-- **[App Runtime (Effect TS)](architecture/app-runtime.md)** - Centralized runtime and DI with AppServicesTag
 - **[hREA Integration](architecture/hrea-integration.md)** - Holochain REA framework integration
+- **[Frontend Refactoring Programme](architecture/frontend-refactoring/README.md)** - Proposed evolution of the frontend: execution, coordination, representation
+
+> The former `architecture/app-runtime.md` entry pointed at a file deleted in `e31c0324`, which removed the `AppServicesTag` application-runtime abstraction. That history is now recorded in [Application runtime](architecture/frontend-refactoring/01-application-runtime.md).
 
 #### 🔑 Key Patterns
 
@@ -170,6 +172,7 @@
 - [System Architecture](ai/rules/system-architecture.md) - Architectural guidelines
 - [7-Layer Effect-TS Architecture](../CLAUDE.md#architectural-patterns) - Framework patterns
 - [hREA Integration](architecture/hrea-integration.md) - Resource-Event-Agent framework
+- [Frontend Refactoring Programme](architecture/frontend-refactoring/README.md) - Proposed frontend evolution and its implementation plan
 
 ### 💻 Development
 

--- a/documentation/architecture/README.md
+++ b/documentation/architecture/README.md
@@ -55,11 +55,20 @@ For a full explanation including configuration, API reference, and test patterns
 
 The project integrates the hREA (Holochain Resource-Event-Agent) framework for Valueflows-based economic coordination. For details see [hREA Integration](hrea-integration.md).
 
+## Frontend Refactoring Programme (proposed)
+
+A set of design documents proposing how the frontend should evolve, derived from a comparison with the Foldkit framework and grounded in a verified audit of the current code. Nothing in it is implemented.
+
+The programme moves the frontend along three axes: **execution** (where Effects run and who can cancel them), **coordination** (where cross-domain reactions live), and **representation** (what a domain's state can legally be). It is designed to be valuable in pieces: the first two phases deliver six of its eight invariants in about 4.5 weeks.
+
+Start with the [unified design](frontend-refactoring/00-unified-refactoring-design.md), then the [implementation plan](frontend-refactoring/08-implementation-plan.md). See [frontend-refactoring/README.md](frontend-refactoring/README.md) for the full index.
+
 ## Further Reading
 
 - [Architectural Patterns Guide](../guides/architectural-patterns.md) — 7-layer deep-dive
 - [The Progenitor Pattern](../progenitor.md) — network bootstrap mechanism
 - [Administration Zome Spec](../technical-specs/zomes/administration.md) — admin/progenitor API
 - [hREA Integration](hrea-integration.md) — Valueflows economic layer
+- [Frontend Refactoring Programme](frontend-refactoring/README.md) — proposed evolution of the store, error and testing layers
 - [Membrane Management](MEMBRANE_MANAGEMENT.md) — in-DHT membrane enforcement
 - [Membrane Management (Off-DHT)](MEMBRANE_MANAGEMENT_OFF_DHT.md) — off-DHT companion

--- a/documentation/architecture/frontend-refactoring/00-unified-refactoring-design.md
+++ b/documentation/architecture/frontend-refactoring/00-unified-refactoring-design.md
@@ -1,0 +1,118 @@
+# 0. Unified refactoring design
+
+The seven proposals are not seven refactors. They are one refactor with seven landing points, and reading them separately hides the thesis.
+
+## Thesis
+
+The Requests and Offers frontend coordinates itself implicitly. Nine stores reach into each other by import, react to each other through subscriptions registered inside store factories, run effects at 148 scattered call sites, and describe every domain's state with the same three loosely-related fields. Each of those is defensible on its own. Together they mean that no single file answers the question "what happens when a user is accepted", and no type prevents a state that cannot exist.
+
+The refactor makes coordination explicit along three axes, and nothing else.
+
+| Axis | Question it answers | Today | After | Proposals |
+|---|---|---|---|---|
+| **Execution** | Where does an Effect run, and who can stop it? | 148 call sites, 21 in components, no cancellation | One task-runner, fibers owned by their component and interrupted on teardown | 1 (Phase 0 only) |
+| **Coordination** | Where do cross-domain reactions live? | 15 in a store factory, 8 in components, 8 imports, two cycles | One routing table, one import direction, one entry door for local and remote change | 2, 3, 5, 7 |
+| **Representation** | What can a domain's state legally be? | `loading: boolean` plus nullable error, three fields, eight combinations | One tagged union of six states, transitions in a pure function | 4a, 6 |
+
+Two pieces sit outside all three and are filed as speculative rather than scheduled. Proposal 4b proposes a state the network does not report. Proposal 1's second phase, a `ManagedRuntime` over a merged layer, is close enough to the `createAppRuntime()` that commit `e31c0324` deliberately removed from this repository in September 2025 that it needs a fresh reason before it is scheduled, and the research did not supply one.
+
+## What the frontend looks like afterwards
+
+```mermaid
+graph TD
+  subgraph Edge
+    C[Components] -->|read state| ST
+    C -->|describe work| CO[Composables]
+  end
+  subgraph Execution
+    CO -->|E.Effect| TR[useEffectTask]
+    TR -->|runFork / interrupt| F[Fiber owned by the component]
+  end
+  subgraph Coordination
+    ST[Domain stores] -->|emit| B[storeEventBus]
+    SIG[SignalService] -->|remote change| B
+    B --> COORD[store-coordination]
+    B --> LOG[eventLog, dev]
+    COORD -->|handle*| ST
+  end
+  subgraph Representation
+    ST -->|dispatch| RED[reduce: state, event -> state]
+    RED --> US[EntityState union]
+  end
+  TR --> SVC[Service layer, Context.Tag]
+  SVC --> HC[HolochainClientService]
+```
+
+Read the arrows: nothing points sideways. Stores do not point at stores, components do not point at the bus, services do not point at stores. Every cycle in the current design becomes a loop through `store-coordination`, which is the one module allowed to know about everything.
+
+## Where each proposal lands in the seven layers
+
+| Layer | Touched by | Change |
+|---|---|---|
+| 1 Service | 3, 5 | `SignalServiceLive` added; cross-domain deps declared via `Context.Tag`. No aggregating tag: `AppServicesTag` was removed here in 2025 and stays removed |
+| 2 Store | 2, 3, 4a, 6 | Split into a pure `state.ts` and a rune wrapper; no store imports a store; no store subscribes cross-domain |
+| 3 Schema | 4a, 5 | `EntityState` union; `RoSignal` payload contract |
+| 4 Errors | none | Unchanged. The tagged error hierarchy is already right |
+| 5 Composables | 1 | Gains `useEffectTask`; owns cross-domain display joins |
+| 6 Components | 1, 2, 4a | Run no effects, hold no subscriptions, match on `_tag` |
+| 7 Testing | 6, 7 | Reducers testable without a DOM; event log exportable from a failing session |
+
+The seven-layer architecture is not replaced. Layers 1, 3 and 4 barely move. The refactor is almost entirely layer 2, plus a thin new seam at layer 5.
+
+## Invariants after the refactor
+
+These are the rules a reviewer can check mechanically. Each is enforceable by lint, grep, or a test, which is the point of writing them down.
+
+1. No file under `src/lib/stores/` imports another `*.store.svelte`.
+2. No `.svelte` file calls `runPromise`, `runSync`, or `runFork`.
+3. No `.svelte` file imports `storeEvents`, except under `components/hrea/test-page/`.
+4. Every cross-domain reaction appears in `store-coordination.ts` and nowhere else.
+5. `state.ts` modules import nothing from `svelte`, `effect`, or any service.
+6. No store exposes `loading: boolean`.
+7. Every effect started from a component is a fiber, and is interrupted on teardown.
+8. Local mutations and conductor signals reach stores through the same event vocabulary.
+
+## What deliberately does not change
+
+The service layer's `Context.Tag` and `Layer` design. Schema decoding at the zome boundary. The `Data.TaggedError` hierarchy with contexts. Fine-grained Svelte reactivity. SvelteKit routing. The Skeleton design system. The store-helper library under `utils/store-helpers/`, whose cache, record and fetching helpers survive intact; only `event-helpers.ts` narrows to same-domain use.
+
+Foldkit itself is not adopted, and cannot be: its `peerDependencies` pin `effect: 4.0.0-rc.109` exactly, while this project is on `^3.14.18`. Every borrowing here is an idea, never a dependency.
+
+## Three things the comparison settled that shape this design
+
+**The single Model is refused for a sourced reason, not a preference.** Foldkit's own `performance.md` states that the routes of a single app do not code-split, that splitting a program by route "would take design work against the single-Model architecture, not a configuration flag", and that a minimal counter app is roughly 90 KB gzipped with Effect the largest share. For an application with an admin section most users never open, that is the cost that decides it.
+
+**The virtual DOM is refused with Foldkit's own benchmark.** In their published TodoMVC comparison, Svelte optimized is the fastest of fifteen rows at 59.2 ms, Foldkit optimized is seventh at 119.3 ms, and Foldkit unoptimized is last at 352.9 ms. The 3x gap between their own two rows means memoization is mandatory rather than optional on real lists.
+
+**Envelope wrapping is refused because Foldkit ships six lint rules to police it.** `got-submodel-message-name`, `wrap-child-output-in-got-message`, `got-wrapper-carries-only-routing` and three more exist because the convention is easy to get wrong. Proposal 2's routing table gets most of the benefit with none of that.
+
+## Risk register
+
+| Risk | Where | Mitigation |
+|---|---|---|
+| Moving a subscription changes when it registers, so a boot-time emit is lost | 2 | Audit boot-time emits before moving; coordination initializes in the root layout before any store method is called |
+| Breaking a store import cycle changes evaluation order in a way tests do not cover | 3 | Import-order test: import each store first and assert identical behaviour |
+| `EntityState` migration touches every component that reads a store | 4a | Derived `data` and `isBusy` getters keep the old surface alive per domain until that domain's components are converted |
+| Signals arrive for entries the local agent cannot yet fetch | 5 | Routing is an Effect that may fail; `Stream.catchAll` back into the stream, never tear down |
+| Agents receive signals for their own writes | 5 | Suppress by action hash against a short-lived set of locally originated hashes |
+| A fiber outlives the component that started it | 1 | `useEffectTask` interrupts its own fiber on teardown |
+| Reintroducing an abstraction this repo already rejected | 1 | Phase 1 is speculative; `AppServicesTag` is never reintroduced |
+| Nine domains of reducer extraction stalls half-finished | 6 | Gate continuation on a measurement after the first domain, not on principle |
+
+## Sequencing
+
+The dependency graph is shallow. Full plan in [08-implementation-plan.md](08-implementation-plan.md).
+
+```mermaid
+graph LR
+  P7[7 event log] --> P2[2 coordination]
+  P1[1 runtime] --> P2
+  P2 --> P3[3 import boundary]
+  P2 --> P5[5 signals]
+  P4a[4a lifecycle states] --> P6[6 pure state]
+  P5 -.-> P4b[4b validation status, speculative]
+  P4a -.-> P4b
+  P6 -.-> P1b[1 Phase 1 runtime, speculative]
+```
+
+Proposal 7 moves to the front, against the original note's ordering. It costs about half a week, it is guarded by `dev` so it carries no production risk, and it instruments every phase that follows. Debugging proposal 5 without it means reading `console.log` output for ordering bugs across two agents, which is the exact problem the log exists to solve.

--- a/documentation/architecture/frontend-refactoring/00-unified-refactoring-design.md
+++ b/documentation/architecture/frontend-refactoring/00-unified-refactoring-design.md
@@ -99,6 +99,12 @@ Foldkit itself is not adopted, and cannot be: its `peerDependencies` pin `effect
 | Reintroducing an abstraction this repo already rejected | 1 | Phase 1 is speculative; `AppServicesTag` is never reintroduced |
 | Nine domains of reducer extraction stalls half-finished | 6 | Gate continuation on a measurement after the first domain, not on principle |
 
+## Why now
+
+The case is not that the current code is bad. It works, and it shipped an alpha. The case is that the next two drops of committed work each add a domain, and every architectural cost gets paid again per domain rather than once.
+
+See [09-pipeline-alignment.md](09-pipeline-alignment.md) for the mapping from each proposal to the open issues and pull requests it serves. The short version: the messaging work needs live signals and per-conversation resource lifecycles, the stewarding drop adds a tenth domain that will read users and administration, the `@holochain/client` 0.21.0 upgrade renames the signal payload field, and three open alpha-test bugs are these designs unbuilt.
+
 ## Sequencing
 
 The dependency graph is shallow. Full plan in [08-implementation-plan.md](08-implementation-plan.md).

--- a/documentation/architecture/frontend-refactoring/00-unified-refactoring-design.md
+++ b/documentation/architecture/frontend-refactoring/00-unified-refactoring-design.md
@@ -61,7 +61,13 @@ The seven-layer architecture is not replaced. Layers 1, 3 and 4 barely move. The
 
 ## Invariants after the refactor
 
-These are the rules a reviewer can check mechanically. Each is enforceable by lint, grep, or a test, which is the point of writing them down.
+**This section is the actual maintainability claim, and it is worth stating plainly: the step up is not in abstraction level, it is that these rules stop depending on whoever remembers them.**
+
+An architecture documented in prose is a convention. Conventions decay at exactly the moments they matter most: under deadline, in an unfamiliar domain, six months after the person who set them wrote them down, and above all in a codebase where one part-time maintainer carries the whole model in their head. Nothing in a document stops a store from importing a store. The reviewer either remembers the rule or does not.
+
+An architecture expressed as checks is different in kind. The rule fires at the moment of violation, addresses whoever is writing the code rather than whoever is reviewing it, and survives the author forgetting it. That is the difference between a design that holds and a design that was once true.
+
+Each invariant below is written so that a machine, not a memory, decides whether it holds. Each is enforceable by lint, grep, or a test. None requires judgment to evaluate.
 
 1. No file under `src/lib/stores/` imports another `*.store.svelte`.
 2. No `.svelte` file calls `runPromise`, `runSync`, or `runFork`.
@@ -71,6 +77,41 @@ These are the rules a reviewer can check mechanically. Each is enforceable by li
 6. No store exposes `loading: boolean`.
 7. Every effect started from a component is a fiber, and is interrupted on teardown.
 8. Local mutations and conductor signals reach stores through the same event vocabulary.
+
+### How each one is enforced
+
+| # | Mechanism | Fails at |
+|---|---|---|
+| 1 | ESLint `no-restricted-imports`, scoped to `src/lib/stores/**` | write time, in the editor |
+| 2 | `grep -rE "run(Promise\|Sync\|Fork)" ui/src --include=*.svelte` | CI |
+| 3 | ESLint `no-restricted-imports`, scoped to `components/**` and `routes/**`, with a `hrea/test-page` override | write time |
+| 4 | Follows from 1 and 3; no separate check needed | CI, transitively |
+| 5 | ESLint `no-restricted-imports`, scoped to `**/state.ts` | write time |
+| 6 | `grep -rn "loading: boolean" ui/src/lib/stores/` | CI |
+| 7 | A test that mounts, starts a task, unmounts, and asserts the fiber exit is `Interrupted` | `bun test:unit` |
+| 8 | A two-agent e2e assertion that a remote change reaches the UI through the bus | `bun test:e2e` |
+
+Five of the eight are lint or grep, which means they cost close to nothing to run and can go into CI on the first day. They are written to fail loudly and early rather than to be comprehensive: an invariant that needs interpretation is not an invariant.
+
+### The check job
+
+One script, added in Phase 0, red until the codebase earns each line and then permanently green:
+
+```bash
+# ui/scripts/check-invariants.sh: exits non-zero on the first violation
+set -e
+fail() { echo "INVARIANT $1 VIOLATED: $2"; exit 1; }
+
+grep -rqE "run(Promise|Sync|Fork)" src --include=*.svelte \
+  && fail 2 "components must not run Effects; use useEffectTask"
+grep -rq "from '\$lib/stores/.*\.store\.svelte'" src/lib/stores/ \
+  && fail 1 "stores must not import stores"
+grep -rq "loading: boolean" src/lib/stores/ \
+  && fail 6 "stores must expose EntityState, not a loading boolean"
+echo "all grep-checkable invariants hold"
+```
+
+Each invariant is introduced as a check in the same pull request that makes it true, never before and never after. A check added early is a broken build; a check added late is a rule that already drifted.
 
 ## What deliberately does not change
 

--- a/documentation/architecture/frontend-refactoring/01-application-runtime.md
+++ b/documentation/architecture/frontend-refactoring/01-application-runtime.md
@@ -129,7 +129,23 @@ The aggregating tag was the bad part, and removing it was right: it turned nine 
 
 Even so, **Phase 1 should be treated as speculative rather than scheduled**, for two reasons that compound. The prior attempt was rejected by the person who has to maintain it, which is evidence about this codebase that no external doctrine outweighs. And the research finding above removes the usual justification anyway: the layers are already built once at module scope, so a `ManagedRuntime` would buy a policy seam and a disposal hook, not the performance win it is normally sold for.
 
-Phase 0 carries the entire cancellation benefit and touches none of this. Ship Phase 0. Revisit Phase 1 only if a concrete need for a shared policy seam appears, for example when [proposal 5](05-conductor-signals.md)'s scoped websocket subscription needs an owner with a defined disposal point.
+Phase 0 carries the entire cancellation benefit and touches none of this. Ship Phase 0.
+
+### The maintainer's position, recorded so it is not relitigated
+
+The person who wrote and reverted the original abstraction has stated it directly: the attempt was made, it failed, it was reverted, and a second attempt is worth making later, on a more mature codebase and with the experience of the first attempt behind it.
+
+That is not a rejection of the idea. It is a judgment about ordering, and it is the correct one. A unified runtime is a claim that the layers underneath it are stable enough to be composed once and shared everywhere. In 2025 they were not: services were still being standardized across eight domains, and the abstraction was carrying weight the layers below it could not yet bear. That is the ordinary way this failure happens, and reverting was the right call rather than a defeat.
+
+**The revisit condition, stated so it can be checked rather than felt.** Phase 1 becomes worth attempting when all of the following hold:
+
+1. Invariants 1, 2, 3 and 4 from the [unified design](00-unified-refactoring-design.md) are enforced in CI, so no store imports a store and no component runs an Effect. A runtime over an acyclic, single-entry layer graph is a different proposition from a runtime over the current one.
+2. [Proposal 6](06-pure-state-modules.md) has landed for a majority of domains, so stores are thin wrappers rather than the place orchestration lives.
+3. A concrete shared-policy need exists, rather than an aesthetic preference for one. The likeliest candidate is [proposal 5](05-conductor-signals.md)'s scoped websocket subscription, which wants an owner with a defined disposal point, and reconnection policy that every consumer should share.
+
+If those three hold and the runtime still looks unnecessary, that is a real answer too, and this document should be closed rather than kept open indefinitely.
+
+**What the second attempt must not repeat.** No aggregating tag. `AppServicesTag` collapsed nine explicit dependencies into one, which made every module depend on everything and made the layer graph unreadable. The narrow version keeps per-service tags and adds only a memo map, a disposal point and a policy seam. If a future design reintroduces a god-tag, it has reproduced the thing that was reverted, whatever it is called.
 
 ```mermaid
 graph TD

--- a/documentation/architecture/frontend-refactoring/01-application-runtime.md
+++ b/documentation/architecture/frontend-refactoring/01-application-runtime.md
@@ -1,0 +1,184 @@
+# 1. One application runtime
+
+## Problem
+
+148 `runPromise` / `runSync` / `runFork` call sites across `ui/src`, 21 of them inside `.svelte` files. No `ManagedRuntime` anywhere.
+
+The obvious rationale for a single runtime does not apply here, and the design has to say so or it will be built for the wrong reason. Every store already provides its layers exactly once, at module scope:
+
+```ts
+// ui/src/lib/stores/requests.store.svelte.ts (tail)
+const requestsStore: RequestsStore = pipe(
+  createRequestsStore(),
+  E.provide(RequestsServiceLive),
+  E.provide(CacheServiceLive),
+  E.provide(HolochainClientServiceLive),
+  E.runSync
+);
+```
+
+No component contains an `E.provide` at all. Store methods return `E.Effect<A, E>` with `R = never`, and components run them directly. So services are constructed once per store module, the Apollo client memoized inside `HreaServiceLive` is safe, and "build the layers once instead of per call" is already satisfied by a different mechanism. Effect's own docs confirm why this works: layer memoization is by reference equality, and locally-provided layers do not memoize by default.
+
+What the 21 component call sites actually cost is **cancellation**. `E.runPromise` returns a Promise and no fiber. A modal that unmounts mid-fetch cannot interrupt its own work; the request completes, resolves into a destroyed component, and its error path has nowhere to go.
+
+```ts
+// ui/src/lib/components/users/UserDetailsModal.svelte:32
+const status = await E.runPromise(
+  administrationStore.getLatestStatusForEntity(user.original_action_hash!, ...)
+);
+```
+
+Secondary costs: no shared retry, timeout or telemetry policy, and no single seam at which to attach one.
+
+## Design
+
+Two phases. Phase 0 delivers the whole cancellation benefit with no runtime at all. Phase 1 adds the runtime once there is something for it to own.
+
+### Phase 0: a task-running composable
+
+```ts
+// ui/src/lib/composables/ui/useEffectTask.svelte.ts
+import { Effect as E, Exit, Fiber, Option } from 'effect';
+
+export type TaskState<A, Err> = {
+  readonly running: boolean;
+  readonly exit: Option.Option<Exit.Exit<A, Err>>;
+};
+
+/**
+ * Runs an already-provided Effect as a fiber owned by the calling component.
+ * The fiber is interrupted when the component's effect scope tears down,
+ * so a late response can never write into a destroyed component.
+ */
+export function useEffectTask<A, Err>() {
+  let running = $state(false);
+  let exit = $state<Option.Option<Exit.Exit<A, Err>>>(Option.none());
+  let fiber: Fiber.RuntimeFiber<A, Err> | null = null;
+
+  const run = (effect: E.Effect<A, Err>) => {
+    if (fiber) E.runPromise(Fiber.interrupt(fiber));
+    running = true;
+    fiber = E.runFork(
+      effect.pipe(
+        E.onExit((e) => E.sync(() => { exit = Option.some(e); running = false; fiber = null; }))
+      )
+    );
+    return fiber;
+  };
+
+  const cancel = () => { if (fiber) E.runPromise(Fiber.interrupt(fiber)); };
+
+  $effect(() => () => cancel());
+
+  return { get running() { return running; }, get exit() { return exit; }, run, cancel };
+}
+```
+
+Call sites become:
+
+```svelte
+<script lang="ts">
+  const statusTask = useEffectTask<UIStatus, AdministrationError>();
+  $effect(() => { statusTask.run(administrationStore.getLatestStatusForEntity(hash)); });
+</script>
+```
+
+### Phase 1: the runtime (speculative, see the history below)
+
+```ts
+// ui/src/lib/runtime/app-layer.ts
+export const AppLayer = Layer.mergeAll(
+  HolochainClientServiceLive,
+  CacheServiceLive,
+  UsersServiceLive,
+  RequestsServiceLive,
+  OffersServiceLive,
+  ServiceTypesServiceLive,
+  OrganizationsServiceLive,
+  AdministrationServiceLive,
+  MediumsOfExchangeServiceLive,
+  HreaServiceLive,
+  ConnectionServiceLive,
+  AdminStatusServiceLive,
+  DevFeaturesServiceLive,
+  WeaveServiceLive
+);
+
+// ui/src/lib/runtime/app-runtime.ts
+export const AppRuntime = ManagedRuntime.make(AppLayer);
+```
+
+Stores then stop self-providing, and `useEffectTask` forks through `AppRuntime.runFork` instead of `E.runFork`. That is the only point at which the runtime earns its place: one memo map, one disposal, one seam for policy.
+
+## Prior art in this repository, and why Phase 1 is speculative
+
+**This was built here once and removed on purpose.** Commit `58906914 refactor(runtime): centralize dependency injection with unified AppServicesTag` introduced `ui/src/lib/runtime/app-runtime.ts` with a `createAppRuntime()` that did `Layer.mergeAll` over all nine services, plus `documentation/architecture/app-runtime.md` describing it. Commit `e31c0324 refactor(architecture): remove application runtime abstraction and simplify service layer` (2025-09-29) deleted all of it: 32 files, 3,176 deletions against 646 insertions, roughly 2,530 net lines removed, including an 898-line `ui/tests/unit/runtime/app-runtime.test.ts`. Its stated reason was that the abstraction was complex and the simplification kept full functionality.
+
+The `DOCUMENTATION_INDEX.md` link to `architecture/app-runtime.md` still points at the deleted file, which is how this history surfaced.
+
+**What was actually removed, and what this document proposes, are not the same thing.**
+
+| | Removed in `e31c0324` | Proposed here |
+|---|---|---|
+| `AppServicesTag`, one aggregating tag every module depends on | yes | **no.** Stores keep their own per-service tags |
+| `Layer.mergeAll` over all services | yes | yes, in Phase 1 only |
+| Purpose | aggregate DI so modules import one tag | one memo map, one disposal, one policy seam |
+| Cancellation of component-started work | not addressed | the whole point of Phase 0 |
+
+The aggregating tag was the bad part, and removing it was right: it turned nine explicit dependencies into one god-tag, which is worse DI, not better. Nothing here proposes bringing it back.
+
+Even so, **Phase 1 should be treated as speculative rather than scheduled**, for two reasons that compound. The prior attempt was rejected by the person who has to maintain it, which is evidence about this codebase that no external doctrine outweighs. And the research finding above removes the usual justification anyway: the layers are already built once at module scope, so a `ManagedRuntime` would buy a policy seam and a disposal hook, not the performance win it is normally sold for.
+
+Phase 0 carries the entire cancellation benefit and touches none of this. Ship Phase 0. Revisit Phase 1 only if a concrete need for a shared policy seam appears, for example when [proposal 5](05-conductor-signals.md)'s scoped websocket subscription needs an owner with a defined disposal point.
+
+```mermaid
+graph TD
+  C[Svelte component] -->|describes| CO[Composable]
+  CO -->|E.Effect A, Err| T[useEffectTask]
+  T -->|runFork| R[AppRuntime]
+  R -->|services from| L[AppLayer]
+  L --> S[Service layer]
+  S --> HC[HolochainClientService singleton]
+  T -.->|interrupt on teardown| F[Fiber]
+```
+
+## Which services belong in the runtime
+
+Foldkit's `runtime.ts` gives the sharpest published test for this, and it applies unchanged. Hoist a service app-wide when construction is expensive relative to how often callers need it, or when every caller must share one instance. Provide it inside the effect when construction is cheap and stateless, when different callers want different implementations of the same tag, or when a service that can fail to construct should only take down its own callers. Foldkit adds the warning that matters: a layer that fails to build leaves no caller safe to run.
+
+Applied here: `HolochainClientServiceLive` and `HreaServiceLive` are clearly app-wide (one websocket, one Apollo client with a built GraphQL schema). `DevFeaturesServiceLive` and `WeaveServiceLive` are candidates for per-caller provision, since a Weave failure outside a Moss context should not take down the app.
+
+## Consequences
+
+**Gained.** Component-scoped cancellation. One seam for retry, timeout and telemetry. Effects stay values until the edge that runs them, which makes composables testable without a DOM.
+
+**Paid.** `ManagedRuntime.dispose()` closes the layer scope and poisons the runtime with `Effect.die`, but it does **not** interrupt fibers started with `runFork`; those fork against the global scheduler. Whatever `useEffectTask` forks, `useEffectTask` interrupts. A disposed runtime still passes `isManagedRuntime`, so that guard proves nothing about usability. The first `runSync` on an unbuilt layer goes through an async boundary and will throw unless the entire layer is synchronous, which is a real constraint given eleven of the thirteen services use `Layer.effect`.
+
+**Import note.** `import { ManagedRuntime } from 'effect'` works on both 3.x and 4.x. `import * as MR from 'effect/ManagedRuntime'` is 3.x only, since Effect 4 dropped per-module export subpaths.
+
+## Alternatives considered
+
+**Leave it alone.** Defensible today, because the layer-duplication problem does not exist. Rejected because the cancellation gap is a live bug class and grows with every new modal.
+
+**Wrap `runPromise` in a helper without fibers.** Cheaper, but a Promise cannot be interrupted, so it does not solve the actual problem.
+
+**Adopt Foldkit's `resources` model wholesale.** Blocked by the Effect 4 RC pin.
+
+**Reintroduce `createAppRuntime()` as it was.** Rejected on the repository's own evidence, see the history section above.
+
+## Migration
+
+1. Add `useEffectTask`, no other change. Convert the two riskiest component sites (`UserDetailsModal`, `OrganizationDetailsModal`).
+2. Sweep the remaining 19 `.svelte` call sites.
+3. Stop. Steps 1 and 2 are the scheduled work.
+4. Phase 1, only if revisited: add `AppLayer` and `AppRuntime`, then per store delete the trailing `E.provide` chain and construct through the runtime, one store per pull request, Service Types first. Read `e31c0324` before starting.
+
+## Verification
+
+- `grep -rE "run(Promise|Sync|Fork)" ui/src --include=*.svelte` returns 0 after step 2.
+- A test that mounts a component, starts a task, unmounts, and asserts the fiber's exit is `Interrupted`.
+- Phase 1 only, if it happens: `grep -c "E.provide" ui/src/lib/stores/*.ts` returns 0, and no `AppServicesTag` is reintroduced.
+
+## Open questions
+
+Whether a fiber surviving `dispose()` is intended Effect behaviour or incidental is undocumented either way. Treat it as a contract we do not have, and interrupt explicitly.

--- a/documentation/architecture/frontend-refactoring/01-application-runtime.md
+++ b/documentation/architecture/frontend-refactoring/01-application-runtime.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-148 `runPromise` / `runSync` / `runFork` call sites across `ui/src`, 21 of them inside `.svelte` files. No `ManagedRuntime` anywhere.
+148 `runPromise` / `runSync` / `runFork` call sites across `ui/src`, 21 of them inside `.svelte` files, counted at `bc0c0ac5`. No `ManagedRuntime` anywhere.
 
 The obvious rationale for a single runtime does not apply here, and the design has to say so or it will be built for the wrong reason. Every store already provides its layers exactly once, at module scope:
 

--- a/documentation/architecture/frontend-refactoring/02-store-coordination.md
+++ b/documentation/architecture/frontend-refactoring/02-store-coordination.md
@@ -1,0 +1,133 @@
+# 2. A single coordination module
+
+## Problem
+
+42 `storeEventBus.on` sites. The distribution matters more than the total:
+
+| Location | Count | Character |
+|---|---|---|
+| `stores/hrea.store.svelte.ts` | 15 | Cross-domain reactions buried in a store factory |
+| `utils/store-helpers/event-helpers.ts` | 7 | Generic factory, one per lifecycle event kind |
+| `components/hrea/test-page/*` | 12 | Dev-only surface |
+| Production components and routes | 8 | `ActionBar` 2, `UserDetailsModal` 1, `admin/+page` 2, `admin/users/+page` 1, `admin/users/status-history/+page` 2 |
+
+The production problem is 15 plus 8, not 15 plus 15. Every component subscriber unsubscribes correctly, so this is not a leak. It is a traceability problem: the `StoreEvents` map declares 30 typed events, the emit sites are clean, and the handler graph is readable nowhere.
+
+The chain that motivates the work: `users.store` emits `user:accepted`, `hrea.store` reacts inside its own factory by conditionally creating an hREA agent. Nothing in either file tells you the other exists.
+
+## Design
+
+One module owns every cross-domain subscription. Stores emit. Coordination routes. Components read reactive state and never subscribe.
+
+```ts
+// ui/src/lib/stores/store-coordination.ts
+import { storeEventBus } from './storeEvents';
+import hreaStore from './hrea.store.svelte';
+import administrationStore from './administration.store.svelte';
+
+type Unsubscribe = () => void;
+
+/**
+ * Every cross-domain reaction in the application, in one readable list.
+ * Called once at app boot. Returns a disposer for tests and HMR.
+ */
+export function initializeCoordination(): Unsubscribe {
+  const subs: Unsubscribe[] = [
+    // Identity accepted -> hREA agent exists
+    storeEventBus.on('user:accepted', ({ user }) => {
+      hreaStore.handleUserAccepted(user);
+    }),
+    storeEventBus.on('organization:accepted', ({ organization }) => {
+      hreaStore.handleOrganizationAccepted(organization);
+    }),
+
+    // Taxonomy approved -> hREA resource specification exists
+    storeEventBus.on('serviceType:approved', ({ serviceType }) => {
+      hreaStore.handleServiceTypeApproved(serviceType);
+    }),
+    storeEventBus.on('mediumOfExchange:approved', ({ mediumOfExchange }) => {
+      hreaStore.handleMediumOfExchangeApproved(mediumOfExchange);
+    }),
+
+    // Intent published -> hREA proposal exists
+    storeEventBus.on('request:created', ({ request }) => {
+      hreaStore.handleRequestCreated(request);
+    }),
+    storeEventBus.on('offer:created', ({ offer }) => {
+      hreaStore.handleOfferCreated(offer);
+    }),
+
+    // Administration mirrors status into the domain stores
+    storeEventBus.on('administrator:added', ({ administrator }) => {
+      administrationStore.syncAdministrator(administrator);
+    })
+  ];
+
+  return () => subs.forEach((off) => off());
+}
+```
+
+Boot:
+
+```ts
+// ui/src/routes/+layout.svelte
+$effect(() => initializeCoordination());
+```
+
+```mermaid
+sequenceDiagram
+  participant U as users.store
+  participant B as storeEventBus
+  participant C as store-coordination
+  participant H as hrea.store
+  U->>B: emit user:accepted
+  B->>C: route
+  C->>H: handleUserAccepted(user)
+  H->>H: create hREA agent if absent
+  H->>B: emit hrea:agent:created
+```
+
+### What each layer may do after this
+
+| Layer | May emit | May subscribe |
+|---|---|---|
+| Service | no | no |
+| Store | yes | only to its own domain's events, via `event-helpers` |
+| Coordination | no | yes, to anything |
+| Composable | yes, through a store | no |
+| Component | no | no |
+
+The seven factory subscriptions in `event-helpers.ts` stay. They are a store subscribing to its own domain's lifecycle events, which is not cross-domain coupling.
+
+### The hREA test page
+
+Its 12 subscriptions are a dev surface exercising hREA directly. They are exempt, and the exemption is documented rather than silent. If that page ever becomes a production surface, its subscriptions move here.
+
+## Consequences
+
+**Gained.** The `user:accepted` chain becomes one readable line. New contributors can answer "what happens when a user is accepted" by reading one file. Ordering between reactions to the same event becomes explicit and testable, which it is not today.
+
+**Paid.** One file grows toward 30 entries. Mitigate by grouping under comment headers by source domain, not by extracting sub-modules, which would recreate the problem. A store method called only from coordination looks unused to a naive reader; name those methods `handle*` so the convention carries the meaning.
+
+**Risk.** Moving a subscription out of `hrea.store`'s factory changes when it registers. Today it registers at store construction, which happens at module import. After the change it registers at layout mount. Any event emitted between those two points is lost. Audit for boot-time emits before moving.
+
+## Alternatives considered
+
+**Foldkit's parent `update`.** This is the same idea, and it is what the proposal borrows. Rejected as a wholesale pattern because full envelope wrapping of child messages costs more than it returns here; Foldkit ships six dedicated lint rules to police that convention, which is a fair measure of its friction.
+
+**Keep subscriptions local, add a doc.** Documentation of a graph nobody can see from the code drifts within a release.
+
+**Move to the Effect-based bus in `utils/eventBus.effect.ts`.** Already exists and is unused by the stores. Worth doing eventually, orthogonal to this proposal, and it would make coordination handlers Effects rather than callbacks. Deferred so that this change stays a move rather than a rewrite.
+
+## Migration
+
+1. Create `store-coordination.ts` with the module docstring and an empty list. Wire it in `+layout.svelte`.
+2. Move the 15 `hrea.store` subscriptions across, one commit per source domain. Extract each handler body into a named `hreaStore.handle*` method as it moves.
+3. Move the 8 production component and route subscriptions.
+4. Add an ESLint `no-restricted-imports` rule forbidding `storeEvents` in `components/` and `routes/`, with an override for `components/hrea/test-page/`.
+
+## Verification
+
+- `grep -rl "storeEventBus.on" ui/src/lib/components ui/src/routes` returns only `components/hrea/test-page/` paths.
+- `grep -c "storeEventBus.on" ui/src/lib/stores/hrea.store.svelte.ts` returns 0.
+- A unit test asserting that emitting `user:accepted` on a fresh bus with coordination initialized calls `hreaStore.handleUserAccepted` exactly once.

--- a/documentation/architecture/frontend-refactoring/03-store-import-boundary.md
+++ b/documentation/architecture/frontend-refactoring/03-store-import-boundary.md
@@ -1,0 +1,122 @@
+# 3. Ban store-to-store imports
+
+## Problem
+
+Eight direct store-to-store imports, verified:
+
+```
+users.store.svelte.ts:19          -> administration.store.svelte
+requests.store.svelte.ts:11,12    -> users.store.svelte, serviceTypes.store.svelte
+offers.store.svelte.ts:10,11      -> users.store.svelte, serviceTypes.store.svelte
+organizations.store.svelte.ts:22  -> administration.store.svelte
+administration.store.svelte.ts:32,33 -> users.store.svelte, organizations.store.svelte
+```
+
+That is **two** cycles, not one:
+
+```mermaid
+graph LR
+  users <--> administration
+  organizations <--> administration
+  requests --> users
+  requests --> serviceTypes
+  offers --> users
+  offers --> serviceTypes
+```
+
+A cycle between two modules that each construct a singleton at module scope (`pipe(createXStore(), E.provide(...), E.runSync)`) means one of the two observes the other as `undefined` during evaluation, and which one depends on bundler entry order. It works today. Nothing in the code makes it keep working.
+
+The convenience of a direct import is real. So is the cost: it is the mechanism by which a domain acquires an invisible dependency on another domain's initialization order.
+
+## Design
+
+Three replacements, chosen per call site by what the importing store actually needs.
+
+### A. Cross-domain read, resolved at the service layer
+
+When a store needs another domain's *data*, the dependency belongs in the service graph where `Context.Tag` already models it.
+
+```ts
+// before, in administration.store.svelte.ts
+import usersStore from '$lib/stores/users.store.svelte';
+const admins = usersStore.acceptedUsers.filter(isAdmin);
+
+// after: AdministrationService declares the dependency
+export const AdministrationServiceLive = Layer.effect(
+  AdministrationServiceTag,
+  E.gen(function* () {
+    const users = yield* UsersServiceTag;   // explicit, typed, acyclic
+    ...
+  })
+);
+```
+
+The layer graph is a DAG by construction. A cycle here is a compile error rather than a runtime accident.
+
+### B. Cross-domain read, resolved by the caller
+
+When the need is per-view rather than structural, the composable passes it.
+
+```ts
+// ui/src/lib/composables/domain/requests/useRequestsList.svelte.ts
+const rows = $derived(
+  requestsStore.requests.map((r) => ({
+    request: r,
+    creator: usersStore.byHash(r.creator),          // composable owns the join
+    serviceType: serviceTypesStore.byHash(r.service_type)
+  }))
+);
+```
+
+This is where most of the eight belong. `requests` and `offers` import `users` and `serviceTypes` to decorate rows for display, which is view concern, not store concern.
+
+### C. Cross-domain write, resolved by coordination
+
+Handled entirely by [proposal 2](02-store-coordination.md). A store never calls another store's mutator.
+
+### The lint rule
+
+```js
+// ui/.eslintrc.cjs
+rules: {
+  'no-restricted-imports': ['error', {
+    patterns: [{
+      group: ['**/stores/*.store.svelte'],
+      message: 'Stores must not import stores. Declare the dependency at the service layer (Context.Tag), pass it from a composable, or route the write through store-coordination.ts.'
+    }]
+  }]
+}
+```
+
+Scoped with an override so the rule applies inside `src/lib/stores/**` only. Composables, components and coordination keep importing stores freely; that is their job.
+
+## Consequences
+
+**Gained.** Both cycles removed. Initialization order stops being load-bearing. Each store becomes independently testable without pulling in the other seven.
+
+**Paid.** Option A moves work into the service layer, which means service interfaces grow. Option B pushes joins into composables, which means a list view assembles its own rows rather than reading a pre-joined store field. That is more code at the call site and less magic, which is the trade being made deliberately.
+
+**Not fixed by this.** `weave.store` imports `@holochain-open-dev/profiles`, which is a Lit web component package (`lit ^3.0.2`, `@lit/context`, Shoelace). That is an external dependency, not a store cycle, and is out of scope here.
+
+## Alternatives considered
+
+**Lazy imports inside functions.** Defers the cycle rather than removing it, and defeats the lint rule. Rejected.
+
+**A shared read-only facade module that both stores import.** Adds a ninth module that knows about everything, which is proposal 2's coordination module wearing a different hat, without its explicit routing. Rejected.
+
+**Do nothing and rely on it continuing to work.** The current arrangement has not broken. It is also untested against a change in bundler entry order, and a Vite major or a route reshuffle can change that order without anyone touching a store.
+
+## Migration
+
+Order matters, because the cycles must break before the lint rule can go in.
+
+1. `administration` and `users`. Decide which direction is structural; the evidence says administration depends on users, not the reverse. Move `users.store`'s use of administration to option A or B.
+2. `administration` and `organizations`. Same treatment.
+3. `requests` and `offers` toward `users` and `serviceTypes`. These are display joins; option B.
+4. Add the lint rule. It should pass on the first run, not require exceptions.
+
+## Verification
+
+- `grep -rn "from '\$lib/stores/.*\.store\.svelte'" ui/src/lib/stores/` returns nothing.
+- `bun run lint` passes with the new rule and zero inline disables.
+- A test importing `administration.store.svelte` first, then `users.store.svelte`, and the reverse, and asserting identical behaviour.

--- a/documentation/architecture/frontend-refactoring/04a-entity-lifecycle-states.md
+++ b/documentation/architecture/frontend-refactoring/04a-entity-lifecycle-states.md
@@ -1,0 +1,125 @@
+# 4a. Entity lifecycle as a tagged union
+
+## Problem
+
+Every store exposes the same shape: a data array, `loading: boolean`, and a nullable error.
+
+```
+offers.store.svelte.ts:57            readonly loading: boolean;
+serviceTypes.store.svelte.ts:54      readonly loading: boolean;
+organizations.store.svelte.ts:85     readonly loading: boolean;
+users.store.svelte.ts:72             readonly loading: boolean;
+mediums_of_exchange.store.svelte.ts:156
+requests.store.svelte.ts:82
+administration.store.svelte.ts:87
+hrea.store.svelte.ts:80
+```
+
+Three independent fields express eight combinations, of which roughly four are meaningful. `loading: true` with a populated array and a non-null error is representable and means nothing. Nothing forces a component to handle any particular case, so components handle the two they thought of.
+
+The specific gap that costs the most: with a cache that expires, "we have data and are refreshing it" and "we have data and it is past its expiry" are both `loading: false` with a full array. The UI cannot distinguish stale from fresh, so it renders stale data as though it were current.
+
+## Design
+
+Six states, not four. This borrows Foldkit's `AsyncData`, whose six-state union is the part of that framework most directly applicable here, precisely because it was designed against a cache.
+
+```ts
+// ui/src/lib/schemas/entity-state.schemas.ts
+import { Schema as S } from 'effect';
+
+export const EntityState = <A, I, E, EI>(
+  item: S.Schema<A, I>,
+  error: S.Schema<E, EI>
+) =>
+  S.Union(
+    S.Struct({ _tag: S.Literal('Idle') }),
+    S.Struct({ _tag: S.Literal('Loading') }),
+    S.Struct({ _tag: S.Literal('Refreshing'), data: S.Array(item) }),
+    S.Struct({ _tag: S.Literal('Stale'), data: S.Array(item), expiredAt: S.Number }),
+    S.Struct({ _tag: S.Literal('Failure'), error }),
+    S.Struct({ _tag: S.Literal('Success'), data: S.Array(item), fetchedAt: S.Number })
+  );
+```
+
+| State | Meaning | Typical UI |
+|---|---|---|
+| `Idle` | Never requested | Nothing, or a prompt |
+| `Loading` | First request in flight, no data | Skeleton |
+| `Refreshing` | Request in flight, previous data held | Data plus a subtle indicator |
+| `Stale` | Data held, past cache expiry, no request in flight | Data plus a refresh affordance |
+| `Failure` | No usable data | Error state with retry |
+| `Success` | Data held, within expiry | Data |
+
+The legal transitions:
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+  Idle --> Loading: fetch
+  Loading --> Success: ok
+  Loading --> Failure: err
+  Success --> Stale: expiry elapsed
+  Success --> Refreshing: fetch
+  Stale --> Refreshing: fetch
+  Refreshing --> Success: ok
+  Refreshing --> Stale: err with data held
+  Failure --> Loading: retry
+```
+
+`Refreshing` on failure degrades to `Stale`, not to `Failure`. Data already on screen must not be replaced by an error because a background refresh failed.
+
+### Store surface
+
+```ts
+export interface ServiceTypesStore {
+  readonly state: EntityState<UIServiceType, ServiceTypeError>;
+  // derived conveniences, so components rarely match by hand
+  readonly data: readonly UIServiceType[];   // [] unless the state carries data
+  readonly isBusy: boolean;                  // Loading or Refreshing
+}
+```
+
+Keeping `data` and `isBusy` as derived getters is what makes this migratable one component at a time. The union is the source of truth; the two getters are a compatibility surface that can be deleted per component as each one learns to match.
+
+### Component surface
+
+```svelte
+{#if state._tag === 'Idle' || state._tag === 'Loading'}
+  <SkeletonList />
+{:else if state._tag === 'Failure'}
+  <ErrorState error={state.error} onRetry={refresh} />
+{:else}
+  <ServiceTypeList items={state.data} stale={state._tag === 'Stale'} busy={state._tag === 'Refreshing'} />
+{/if}
+```
+
+## Consequences
+
+**Gained.** Illegal states stop being representable. `Stale` becomes visible to the UI, which is the only way a cache with expiry can be honest with a user. Exhaustive matching means a new state cannot be added without every consumer being forced to consider it.
+
+**Paid.** Every component that reads a store touches this. The derived-getter compatibility surface keeps that cost incremental rather than a single large change.
+
+**Known trap, inherited.** Foldkit documents that combining several `AsyncData` values is all-or-nothing on data: one input without data collapses the combined result. Their doc calls this forced rather than a bug. If a view combines three stores, decide deliberately whether one `Loading` should blank the whole view, and prefer combining at the component level over a generic `combine` helper.
+
+## Alternatives considered
+
+**Four states** (`NotAsked`, `Loading`, `Failed`, `Loaded`), as in the original note. Rejected: it cannot express `Refreshing` or `Stale`, which are the two the cache actually needs.
+
+**Keep the booleans, add a `stale` flag.** Four independent fields instead of three. Rejected, it makes the combinatorial problem worse.
+
+**`Effect.Cause` or `Exit` as the state type.** Models success and failure well, models "have data, refreshing" not at all.
+
+## Migration
+
+Per domain, starting with Service Types as the reference implementation, matching how previous standardizations were done here.
+
+1. Add `entity-state.schemas.ts` and the transition helpers.
+2. Convert `serviceTypes.store` to hold `EntityState` internally, keeping `loading` and the error field as derived getters so nothing downstream breaks.
+3. Convert Service Types components to match on `_tag`. Delete the compatibility getters for that domain.
+4. Repeat per domain. Eight more.
+
+## Verification
+
+- A property test over the transition function: no sequence of events produces a state carrying both an error and data, and `Refreshing` failure always yields `Stale`.
+- `grep -rn "loading: boolean" ui/src/lib/stores/` returns nothing when the last domain lands.
+- A component test asserting that a failed background refresh leaves the previously rendered rows on screen.

--- a/documentation/architecture/frontend-refactoring/04b-dht-validation-status.md
+++ b/documentation/architecture/frontend-refactoring/04b-dht-validation-status.md
@@ -1,0 +1,92 @@
+# 4b. DHT validation status
+
+**Status: speculative.** This document exists to record why the idea is harder than it first appears, and what it would actually cost. Do not schedule it until [proposal 5](05-conductor-signals.md) has landed and the optimistic-write problem has been observed in real use.
+
+## The original claim, and what is wrong with it
+
+The Foldkit note proposed:
+
+```ts
+const DhtStatus = S.Union([
+  Optimistic,        // in the UI only, not yet committed
+  ChainCommitted,    // in the source chain, not yet gossiped
+  DhtConfirmed,      // seen back from the DHT
+  ValidationRejected // peers refused it
+])
+```
+
+with the argument that every Holochain frontend faces this and most flatten it into a loading boolean, so making it a Schema union means the type system enforces what the network actually guarantees.
+
+The last clause is where it breaks. **The network does not tell you these things.** Verified:
+
+- Signals are emitted from `post_commit`, which the Holochain docs describe as running after the call-zome workflow writes actions to the source chain. A signal therefore reports `ChainCommitted`, and nothing further.
+- Validation status is reachable only through `RecordDetails.validation_status`, typed in the pinned client at `node_modules/@holochain/client/lib/hdk/record.d.ts:28` as `ValidationStatus = "Valid" | "Rejected" | "Abandoned"`. `RecordDetails` comes back from `get_details`, which is a call you make, per record.
+- No push channel carries validation outcomes to a UI. There is no subscription that fires when peers accept or reject an entry.
+
+So `DhtConfirmed` and `ValidationRejected` are not states you decode from an event stream. They are answers you poll for, one record at a time.
+
+Two further facts that should temper the design:
+
+- `holochain-open-dev/common`'s signals package, the most developed Holochain frontend state layer published, models exactly three states, `pending | completed | error`, and does not model validation at all. It runs a hardcoded 20 second poll alongside its signal subscriptions, treating signals as an optimization on top of polling rather than as a source of truth.
+- A search across published Holochain frontends found `validation_status` used only in conductor reimplementations and DHT inspection tools, never in an application UI. Code search is not proof of absence, but nobody appears to have shipped this.
+
+## What it would actually take
+
+```mermaid
+sequenceDiagram
+  participant UI
+  participant Z as coordinator zome
+  participant DHT
+  UI->>Z: create_offer
+  Z->>Z: commit to source chain
+  Z-->>UI: signal (post_commit) = ChainCommitted
+  loop bounded poll, backing off
+    UI->>Z: get_offer_details(hash)
+    Z->>DHT: get_details
+    DHT-->>Z: RecordDetails { validation_status }
+    Z-->>UI: Valid | Rejected | Abandoned
+  end
+```
+
+Required pieces:
+
+1. **A coordinator zome function per entry type** returning `validation_status` from `get_details`. None exists today. This is backend work in `dnas/requests_and_offers`, not frontend work.
+2. **A per-record poll scheduler** with backoff and a give-up bound, holding a set of records in `ChainCommitted` and retiring each as it resolves. `holochain-open-dev`'s `immutableEntrySignal` uses `maxRetries = 4` with a one second poll as prior art for the shape.
+3. **A UI vocabulary** for a record that is committed but unresolved, and for one that has been `Abandoned`, which is neither valid nor rejected and has no obvious user-facing meaning.
+
+The union itself, if built, should be:
+
+```ts
+export const DhtStatus = S.Union(
+  S.Struct({ _tag: S.Literal('Optimistic') }),
+  S.Struct({ _tag: S.Literal('ChainCommitted'), committedAt: S.Number }),
+  S.Struct({ _tag: S.Literal('Validated') }),
+  S.Struct({ _tag: S.Literal('Rejected') }),
+  S.Struct({ _tag: S.Literal('Abandoned') }),
+  S.Struct({ _tag: S.Literal('Unresolved'), attempts: S.Number })
+);
+```
+
+`DhtConfirmed` is renamed `Validated`, because "seen back from the DHT" and "peers validated it" are different claims and only the second is what `validation_status` reports. `Unresolved` is added because a bounded poll must be allowed to give up, and pretending otherwise produces a spinner that never stops.
+
+## Consequences
+
+**Gained, if built.** The UI could tell a user that their offer is on their own chain but not yet accepted by the network, which is true, currently invisible, and arguably something a peer-to-peer application owes its users.
+
+**Paid.** A zome function per entry type, a polling subsystem, six states to render, and a doubling of the state space when composed with [4a](04a-entity-lifecycle-states.md). For a project with roughly ten hours a week of attention, that is a large bill for a benefit nobody has yet asked for.
+
+## Alternatives considered
+
+**Optimistic plus reconciliation, no status surface.** Write optimistically, let the next fetch reconcile, show nothing about validation. This is what every published Holochain UI does. Cheapest, and the honest default.
+
+**Two states, not six.** `Pending` and `Settled`, where `Pending` means "we wrote it and have not seen it back from a fetch". Approximates the useful part with no zome work, using data the frontend already has.
+
+**Wait for the platform.** If Holochain later exposes validation outcomes as signals, this becomes cheap. Nothing suggests that is planned, so this is not a plan, only a reason not to build the polling version prematurely.
+
+## Open questions
+
+Whether signal arrival strictly precedes peer validation is not stated in any Holochain document found. The inference is reasonable and unverified. Whether `get_details` can return a record whose validation is still pending, and what it reports in that case, is also unverified and would need a Sweettest experiment before any of this is designed further.
+
+## Recommendation
+
+Take the two-state alternative if the problem becomes visible. Revisit this document only if a user-facing requirement appears that the two-state version cannot serve.

--- a/documentation/architecture/frontend-refactoring/05-conductor-signals.md
+++ b/documentation/architecture/frontend-refactoring/05-conductor-signals.md
@@ -2,9 +2,13 @@
 
 ## Problem
 
-There is no signal handling in `ui/src`. `AppSignal`, `onSignal`, `client.on('signal'` all return zero matches. The application learns about DHT changes only by fetching.
+**The backend already emits signals and the frontend discards every one of them.**
 
-This is the cheapest proposal on the list precisely because nothing has been built yet. The default path, when signals become necessary, is an ad hoc callback in `HolochainClientService` that reaches into a store and mutates it, which is the action at a distance the event bus exists to prevent.
+All six domain coordinator zomes (`requests`, `offers`, `users_organizations`, `administration`, `service_types`, `mediums_of_exchange`) implement `post_commit` and call `emit_signal` with a five-variant `Signal` enum. Only `misc`, which owns no entries, does not. Meanwhile `ui/src` contains no signal handling at all: `AppSignal`, `onSignal` and `client.on('signal'` return zero matches.
+
+PR #181 states the same thing from the other side: before it, "every coordinator zome only did local `post_commit` to `emit_signal`, a cache-invalidation bus for the agent's own UI". That bus was built and never connected.
+
+So this is not a greenfield proposal. It is finishing a half-built path, and the expensive half is already done. The default alternative, when the chat work forces the issue, is an ad hoc callback in `HolochainClientService` that reaches into a store and mutates it, which is the action at a distance the event bus exists to prevent.
 
 ## What the client actually gives you
 
@@ -81,21 +85,43 @@ export const SignalServiceLive = Layer.scoped(
 
 `Layer.scoped` is the point. The websocket subscription is acquired when the layer builds and released when its scope closes, which is what the runtime in [proposal 1](01-application-runtime.md) owns.
 
-### The payload contract
+### The payload contract already exists, in Rust
 
-The scaffolding tool's `post_commit` emits a shape that `holochain-open-dev` names `ActionCommittedSignal`, with variants `EntryCreated`, `EntryUpdated`, `EntryDeleted`, `LinkCreated`, `LinkDeleted`. The R&O zomes do not emit signals today, so the payload contract is ours to define. Define it deliberately rather than inheriting the scaffold's shape by accident:
+Do not invent one. Mirror what the zomes emit. From `dnas/requests_and_offers/zomes/coordinator/requests/src/lib.rs`, identical in all six:
+
+```rust
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type")]
+pub enum Signal {
+  LinkCreated  { action: SignedActionHashed, link_type: LinkTypes },
+  LinkDeleted  { action: SignedActionHashed, link_type: LinkTypes },
+  EntryCreated { action: SignedActionHashed, app_entry: EntryTypes },
+  EntryUpdated { action: SignedActionHashed, app_entry: EntryTypes, original_app_entry: EntryTypes },
+  EntryDeleted { action: SignedActionHashed, original_app_entry: EntryTypes },
+}
+```
+
+`#[serde(tag = "type")]` means the discriminant arrives on a `type` key, not `_tag`. The TypeScript side therefore decodes on `type` and may re-tag internally:
 
 ```ts
 // ui/src/lib/schemas/signal.schemas.ts
-export const RoSignal = S.Union(
-  S.Struct({ _tag: S.Literal('EntryCreated'), entry_type: S.String, action_hash: HashSchema }),
-  S.Struct({ _tag: S.Literal('EntryUpdated'), entry_type: S.String, action_hash: HashSchema, original: HashSchema }),
-  S.Struct({ _tag: S.Literal('EntryDeleted'), entry_type: S.String, action_hash: HashSchema }),
-  S.Struct({ _tag: S.Literal('StatusChanged'), entity: S.String, action_hash: HashSchema, status: S.String })
+const Variant = <T extends string, F extends S.Struct.Fields>(tag: T, fields: F) =>
+  S.Struct({ type: S.Literal(tag), ...fields });
+
+export const ZomeSignal = S.Union(
+  Variant('LinkCreated',  { action: SignedActionHashedSchema, link_type: S.Unknown }),
+  Variant('LinkDeleted',  { action: SignedActionHashedSchema, link_type: S.Unknown }),
+  Variant('EntryCreated', { action: SignedActionHashedSchema, app_entry: S.Unknown }),
+  Variant('EntryUpdated', { action: SignedActionHashedSchema, app_entry: S.Unknown, original_app_entry: S.Unknown }),
+  Variant('EntryDeleted', { action: SignedActionHashedSchema, original_app_entry: S.Unknown })
 );
 ```
 
-`StatusChanged` is added because the administration flow is where remote changes matter most to this application: an admin accepting a user on another agent's machine should reach that user's UI without a page refresh.
+This is where Schema earns its place rather than decorating: the Rust enum is the contract, and a decode failure at this boundary is the early warning that the two sides drifted, which is exactly what a DNA upgrade causes.
+
+**One gap to close on the Rust side, and only one.** These five variants carry entry lifecycle, not status transitions. The administration flow is where remote change matters most, since an admin accepting a user on another machine should reach that user's UI without a refresh, and `EntryUpdated` on a status entry is a weak signal for it. Either add a `StatusChanged` variant to the `administration` zome, or route on `EntryUpdated` plus the entry type and accept a coarser trigger. Start with the coarser version, which needs no Rust change at all.
+
+**PR #181 adds a seventh emitter with a different shape.** Its `messaging` zome defines `Signal::Message { stream_id, content, from }`, ephemeral and not entry-derived. That is a second union, not a variant of this one, and the routing layer should keep them separate: entry lifecycle invalidates caches, messages append to a conversation.
 
 ### Routing into the existing vocabulary
 
@@ -122,7 +148,9 @@ A signal carries hashes, not entities. Routing therefore has to fetch before emi
 
 **Gained.** Multi-agent flows become live. The existing typed `StoreEvents` map is reused rather than duplicated, so [proposal 2](02-store-coordination.md)'s routing table handles remote events with no new concepts. Because the subscription is a scoped resource, connection loss and reconnection have a defined shape.
 
-**Paid.** Backend work: the coordinator zomes must emit signals from `post_commit`, which does not happen today. A signal referring to an entry the local agent cannot yet fetch is normal and must be tolerated. Echo suppression is needed, since an agent receives signals for its own writes and would otherwise double-apply them; suppress by action hash against a short-lived set of locally originated hashes.
+**Paid.** Much less than first estimated, because the emitting side exists. A signal referring to an entry the local agent cannot yet fetch is normal and must be tolerated. Echo suppression is needed, since an agent receives signals for its own writes and would otherwise double-apply them; suppress by action hash against a short-lived set of locally originated hashes.
+
+**Version risk, and it is imminent.** Issue #193 upgrades `@holochain/client` to `0.21.0`, marked P1-critical. The client's signal payload field is named `payload` in the pinned 0.20.5 and `signal` on the client's `main` branch. Decoding in one place means that upgrade touches one file. Wiring signals ad hoc across the chat work first means it touches all of them.
 
 ## Alternatives considered
 
@@ -134,10 +162,12 @@ A signal carries hashes, not entities. Routing therefore has to fetch before emi
 
 ## Migration
 
-1. Define the signal payload contract with the zome side, in one document, before either side writes code.
-2. Emit from one zome only, `service_types`, in `post_commit`.
-3. Build `SignalServiceLive` and route `serviceType:*` events. Verify with two agents.
-4. Extend zome by zome. Administration last, since `StatusChanged` is the highest-value and highest-risk case.
+Frontend only for the first three steps, because the zomes already emit.
+
+1. Add `ZomeSignal` mirroring the Rust enum, and `SignalServiceLive`. Log decoded signals to the event log from [proposal 7](07-development-message-log.md) and ship nothing else. This alone proves the contract without changing behaviour.
+2. Route `service_types` signals into the store event vocabulary. Verify with two agents.
+3. Extend to the remaining five domains. Coarse status routing via `EntryUpdated` plus entry type.
+4. Optional Rust change: add `StatusChanged` to the `administration` zome only if step 3 proves too coarse in use.
 
 ## Verification
 

--- a/documentation/architecture/frontend-refactoring/05-conductor-signals.md
+++ b/documentation/architecture/frontend-refactoring/05-conductor-signals.md
@@ -1,0 +1,146 @@
+# 5. Signals as first-class input
+
+## Problem
+
+There is no signal handling in `ui/src`. `AppSignal`, `onSignal`, `client.on('signal'` all return zero matches. The application learns about DHT changes only by fetching.
+
+This is the cheapest proposal on the list precisely because nothing has been built yet. The default path, when signals become necessary, is an ad hoc callback in `HolochainClientService` that reaches into a store and mutates it, which is the action at a distance the event bus exists to prevent.
+
+## What the client actually gives you
+
+Verified against the pinned `@holochain/client` 0.20.5:
+
+```ts
+// lib/api/app/types.d.ts
+export type Signal =
+  | { type: SignalType.App;    value: AppSignal }
+  | { type: SignalType.System; value: SystemSignal };
+
+export type AppSignal = { cell_id: CellId; zome_name: string; payload: unknown };
+export type SignalCb = (signal: Signal) => void;
+
+export interface AppClient {
+  on<Name extends keyof AppEvents>(
+    eventName: Name | readonly Name[],
+    listener: SignalCb
+  ): UnsubscribeFunction;
+}
+```
+
+Three consequences for the design. The outer union is already discriminated, so no decoding is needed to route App versus System. The `payload` is `unknown` and msgpack-decoded by the client, so Schema decoding starts there and nowhere else. `on` returns an `UnsubscribeFunction`, which makes the subscription a natural scoped resource.
+
+**Pin deliberately.** This version names the field `payload`. The client's `main` branch renames it to `signal`. `holochain-open-dev`'s `ZomeClient.onSignal` reads `signal.value.payload`, matching 0.20.5. Any client upgrade must check this field name.
+
+**Signals are send-and-forget.** The Holochain docs state that they do not wait for receiver confirmation and do not store messages if the receiver is unavailable, and no ordering guarantees are documented. A signal is a hint that something changed, never a record of what the state now is.
+
+## Design
+
+```mermaid
+graph LR
+  CD[Conductor] -->|client.on signal| SS[SignalService scoped resource]
+  SS -->|Stream.async| DEC[Schema decode by zome + tag]
+  DEC -->|StoreEvents vocabulary| B[storeEventBus]
+  B --> CO[store-coordination]
+  CO --> ST[domain stores]
+  LOCAL[Local mutation] --> B
+```
+
+Local action and remote gossip arrive through one door. That is the whole idea.
+
+### The service
+
+```ts
+// ui/src/lib/services/signal.service.ts
+export interface SignalService {
+  readonly stream: Stream.Stream<DecodedSignal, SignalError>;
+}
+
+export class SignalServiceTag extends Context.Tag('SignalService')<
+  SignalServiceTag, SignalService
+>() {}
+
+export const SignalServiceLive = Layer.scoped(
+  SignalServiceTag,
+  E.gen(function* () {
+    const holochain = yield* HolochainClientServiceTag;
+    yield* E.promise(() => holochain.waitForConnection());
+    const client = holochain.client!;
+
+    const stream = Stream.async<DecodedSignal, SignalError>((emit) => {
+      const unsubscribe = client.on('signal', (signal) => {
+        if (signal.type !== SignalType.App) return;
+        emit.single(decodeAppSignal(signal.value));
+      });
+      return E.sync(unsubscribe);   // released with the scope
+    });
+
+    return SignalServiceTag.of({ stream });
+  })
+);
+```
+
+`Layer.scoped` is the point. The websocket subscription is acquired when the layer builds and released when its scope closes, which is what the runtime in [proposal 1](01-application-runtime.md) owns.
+
+### The payload contract
+
+The scaffolding tool's `post_commit` emits a shape that `holochain-open-dev` names `ActionCommittedSignal`, with variants `EntryCreated`, `EntryUpdated`, `EntryDeleted`, `LinkCreated`, `LinkDeleted`. The R&O zomes do not emit signals today, so the payload contract is ours to define. Define it deliberately rather than inheriting the scaffold's shape by accident:
+
+```ts
+// ui/src/lib/schemas/signal.schemas.ts
+export const RoSignal = S.Union(
+  S.Struct({ _tag: S.Literal('EntryCreated'), entry_type: S.String, action_hash: HashSchema }),
+  S.Struct({ _tag: S.Literal('EntryUpdated'), entry_type: S.String, action_hash: HashSchema, original: HashSchema }),
+  S.Struct({ _tag: S.Literal('EntryDeleted'), entry_type: S.String, action_hash: HashSchema }),
+  S.Struct({ _tag: S.Literal('StatusChanged'), entity: S.String, action_hash: HashSchema, status: S.String })
+);
+```
+
+`StatusChanged` is added because the administration flow is where remote changes matter most to this application: an admin accepting a user on another agent's machine should reach that user's UI without a page refresh.
+
+### Routing into the existing vocabulary
+
+```ts
+// ui/src/lib/stores/signal-routing.ts
+const toStoreEvent = (s: RoSignal): [keyof StoreEvents, unknown] | null => {
+  switch (s._tag) {
+    case 'StatusChanged':
+      return s.entity === 'user'
+        ? ['user:status:updated', { user: ... }]
+        : ['organization:status:updated', { organization: ... }];
+    ...
+  }
+};
+```
+
+A signal carries hashes, not entities. Routing therefore has to fetch before emitting, which means the routing step is itself an Effect and can fail. That failure must not tear down the stream; `Stream.catchAll` back into the stream, log, and continue.
+
+### Polling stays
+
+`holochain-open-dev/common` runs a 20 second poll alongside its signal subscriptions and documents signals as an optimization. Given signals are undelivered when the receiver is offline and carry no ordering guarantee, this design does the same: **signals reduce latency, they never replace fetching.** Cache expiry from [proposal 4a](04a-entity-lifecycle-states.md) remains the correctness mechanism.
+
+## Consequences
+
+**Gained.** Multi-agent flows become live. The existing typed `StoreEvents` map is reused rather than duplicated, so [proposal 2](02-store-coordination.md)'s routing table handles remote events with no new concepts. Because the subscription is a scoped resource, connection loss and reconnection have a defined shape.
+
+**Paid.** Backend work: the coordinator zomes must emit signals from `post_commit`, which does not happen today. A signal referring to an entry the local agent cannot yet fetch is normal and must be tolerated. Echo suppression is needed, since an agent receives signals for its own writes and would otherwise double-apply them; suppress by action hash against a short-lived set of locally originated hashes.
+
+## Alternatives considered
+
+**Callback into stores directly.** Fastest, and it recreates the untraceable handler graph that proposal 2 exists to remove.
+
+**`holochain-open-dev`'s `ZomeClient.onSignal`.** Good prior art for the role and zome filtering, but it is a Lit-oriented package (`lit ^3.0.2`, `@lit/context`, Shoelace) and would pull a component framework into a Svelte app for one method. Copy the filtering logic, not the dependency.
+
+**Skip signals, poll only.** Viable. It is what the app does today, and it is why the app is not live.
+
+## Migration
+
+1. Define the signal payload contract with the zome side, in one document, before either side writes code.
+2. Emit from one zome only, `service_types`, in `post_commit`.
+3. Build `SignalServiceLive` and route `serviceType:*` events. Verify with two agents.
+4. Extend zome by zome. Administration last, since `StatusChanged` is the highest-value and highest-risk case.
+
+## Verification
+
+- A two-agent Sweettest plus e2e run: agent A approves a service type, agent B's UI reflects it with no manual refresh.
+- A test that drops the websocket mid-stream and asserts the scoped subscription is released and re-acquired without duplicate handlers.
+- An echo test: agent A creates an offer and its own store applies the change exactly once.

--- a/documentation/architecture/frontend-refactoring/06-pure-state-modules.md
+++ b/documentation/architecture/frontend-refactoring/06-pure-state-modules.md
@@ -1,0 +1,131 @@
+# 6. Pure reducers under the runes
+
+## Problem
+
+Each store is a single file that owns three things at once: reactive references (`$state`), business state transitions, and Effect orchestration. `ui/README.md` documents 268 passing tests, read rather than rerun. The count is not the issue; reachability is. The state machines can only be exercised through the reactive layer, which means testing a transition requires a rune context, and testing a sequence of transitions requires driving it through async store methods.
+
+## Design
+
+Split each domain into two files.
+
+```
+ui/src/lib/stores/service-types/
+  state.ts                  # pure: plain objects, plain functions
+  serviceTypes.store.svelte.ts  # thin: runes + Effect orchestration
+```
+
+### The pure module
+
+```ts
+// ui/src/lib/stores/service-types/state.ts
+import type { EntityState } from '$lib/schemas/entity-state.schemas';
+
+export type ServiceTypesState = EntityState<UIServiceType, ServiceTypeError>;
+
+export type ServiceTypesEvent =
+  | { _tag: 'FetchStarted' }
+  | { _tag: 'FetchSucceeded'; items: readonly UIServiceType[]; at: number }
+  | { _tag: 'FetchFailed'; error: ServiceTypeError }
+  | { _tag: 'ExpiryElapsed'; at: number }
+  | { _tag: 'Created'; item: UIServiceType }
+  | { _tag: 'Approved'; hash: ActionHash }
+  | { _tag: 'Deleted'; hash: ActionHash };
+
+export const initial: ServiceTypesState = { _tag: 'Idle' };
+
+/** The entire state machine. No Svelte, no Effect, no I/O. */
+export function reduce(state: ServiceTypesState, event: ServiceTypesEvent): ServiceTypesState {
+  switch (event._tag) {
+    case 'FetchStarted':
+      return hasData(state) ? { _tag: 'Refreshing', data: state.data } : { _tag: 'Loading' };
+    case 'FetchSucceeded':
+      return { _tag: 'Success', data: event.items, fetchedAt: event.at };
+    case 'FetchFailed':
+      return hasData(state)
+        ? { _tag: 'Stale', data: state.data, expiredAt: event.error.at }
+        : { _tag: 'Failure', error: event.error };
+    ...
+  }
+}
+```
+
+### The rune wrapper
+
+```ts
+// ui/src/lib/stores/service-types/serviceTypes.store.svelte.ts
+function createServiceTypesStore() {
+  let state = $state.raw<ServiceTypesState>(initial);
+  const dispatch = (e: ServiceTypesEvent) => { state = reduce(state, e); };
+
+  const fetchAll = () =>
+    E.gen(function* () {
+      dispatch({ _tag: 'FetchStarted' });
+      const items = yield* service.getAllServiceTypes();
+      dispatch({ _tag: 'FetchSucceeded', items, at: Date.now() });
+      return items;
+    }).pipe(E.tapError((error) => E.sync(() => dispatch({ _tag: 'FetchFailed', error }))));
+
+  return { get state() { return state; }, get data() { return dataOf(state); }, fetchAll };
+}
+```
+
+`$state.raw` rather than `$state`, deliberately. The reducer returns a new object each time, so deep reactivity buys nothing and costs a proxy on every read.
+
+```mermaid
+graph TD
+  SVC[Service layer, Effect] -->|result| ORCH[Rune wrapper]
+  ORCH -->|event| RED[reduce: state, event -> state]
+  RED -->|new state| RUNE["$state.raw"]
+  RUNE --> C[Components]
+  TEST[Test: sequence of events] --> RED
+```
+
+### Testing shape
+
+```ts
+// no Svelte, no DOM, no conductor, no mocks
+test('a failed refresh keeps previous data and marks it stale', () => {
+  const final = [
+    { _tag: 'FetchStarted' },
+    { _tag: 'FetchSucceeded', items: [a, b], at: 1000 },
+    { _tag: 'FetchStarted' },
+    { _tag: 'FetchFailed', error: someError }
+  ].reduce(reduce, initial);
+
+  expect(final._tag).toBe('Stale');
+  expect(final.data).toEqual([a, b]);
+});
+```
+
+This is Foldkit's Story pattern without Foldkit: given a state, apply a sequence of events, assert on the result.
+
+## Consequences
+
+**Gained.** The state machine becomes reachable without a reactive context, which makes property testing viable: generate arbitrary event sequences, assert invariants hold. That is the strongest available check on [proposal 4a](04a-entity-lifecycle-states.md), and it is impossible today.
+
+**Paid.** Two files per domain instead of one, and a discipline that every state change goes through `dispatch`. Nine domains. This is real work and is best done alongside the remaining domain standardization rather than as its own campaign.
+
+**Constraint.** Svelte's docs are explicit that module-level `$state` can only be exported if it is never reassigned; the compiler wraps reads and writes within one file only, so an importer sees an object, not a value. The store's public surface must therefore stay getter-based, which it already is.
+
+**Not a hazard here.** Module-level state leaking between users under SSR is a real Svelte hazard, and this project ships `adapter-static`, so it does not apply. Worth remembering if the pattern is copied into a project with a server.
+
+## Alternatives considered
+
+**Keep one file, extract pure helpers.** Half the benefit, none of the discipline. The transitions drift back into the rune body under time pressure.
+
+**Adopt an existing Effect and Svelte binding.** There is none to adopt. `@effect/atom-svelte` does not exist; the Effect issue requesting it (#6486, opened 2026-07-18) has no maintainer response, and the earlier attempt (effect-smol PR #2443) was closed unmerged. Exactly one published package peers `effect ^3.0.0` with Svelte 5, `@unionlabs/effect-svelte`, which is marked experimental and whose README says of runtime lifecycle, "in lieu of a known alternative, it is suggested to initialize the runtime as a module singleton", which is what this codebase already does.
+
+**Note on the field.** There is an unsettled disagreement worth knowing: `svelte-effect-runtime`'s discipline doc asserts that `$effect` callbacks are synchronous by contract and can never run Effects, while `@unionlabs/effect-svelte` and `fgaudo/fridgy` both do exactly that. Nobody has arbitrated it. Prefer `runFork` plus explicit interrupt over awaiting inside `$effect`, which sidesteps the disagreement entirely.
+
+## Migration
+
+1. Service Types only. Extract `state.ts`, convert the store to dispatch, keep the public surface identical.
+2. Add the property test suite for that reducer.
+3. Measure: how many of the existing Service Types tests become redundant, and how many new cases the property test finds. Decide whether to continue based on that number rather than on principle.
+4. If continuing, one domain per pull request.
+
+## Verification
+
+- `state.ts` imports nothing from `svelte`, `effect`, or any service. Enforceable with a lint rule.
+- The reducer suite runs without `vitest` needing a DOM environment.
+- A property test asserting no event sequence produces a state carrying both data and an error.

--- a/documentation/architecture/frontend-refactoring/07-development-message-log.md
+++ b/documentation/architecture/frontend-refactoring/07-development-message-log.md
@@ -1,0 +1,118 @@
+# 7. A development message log
+
+## Problem
+
+The interesting bugs in a peer-to-peer application are ordering bugs across agents. When a user is accepted on agent A and the hREA agent fails to appear on agent B, the question is which events fired, in what order, and what each store held at the time. Today the answer is `console.log` archaeology, plus one legacy affordance:
+
+```ts
+// ui/src/lib/stores/storeEvents.ts
+emitStatusUpdate(event, payload, source = 'unknown'): void {
+  console.log(`🚀 Emitting status update event: ${String(event)} from ${source}`, payload);
+  this.emit(event, payload);
+}
+```
+
+That method exists for exactly two events and logs to a console that nobody can export. It is evidence the need is real and the current answer is inadequate.
+
+The typed `StoreEvents` map already makes a faithful log possible in a few dozen lines. This is the cheapest item on the list and the one most likely to pay for itself during proposal 5.
+
+## Design
+
+Not time travel. Just the log.
+
+```ts
+// ui/src/lib/stores/event-log.ts
+import { dev } from '$app/environment';
+import type { StoreEvents } from './storeEvents';
+
+export type LogEntry = {
+  readonly seq: number;
+  readonly at: number;
+  readonly event: keyof StoreEvents;
+  readonly payload: unknown;
+  readonly origin: 'local' | 'signal';
+  readonly slice?: unknown;      // snapshot of the affected store slice, dev only
+};
+
+const CAPACITY = 500;
+
+class EventLog {
+  private buffer: LogEntry[] = [];
+  private seq = 0;
+
+  record(event: keyof StoreEvents, payload: unknown, origin: LogEntry['origin'], slice?: unknown) {
+    if (!dev) return;
+    const entry = { seq: this.seq++, at: Date.now(), event, payload, origin, slice };
+    this.buffer.push(entry);
+    if (this.buffer.length > CAPACITY) this.buffer.shift();
+  }
+
+  entries(): readonly LogEntry[] { return this.buffer; }
+  clear() { this.buffer = []; this.seq = 0; }
+  export(): string { return JSON.stringify(this.buffer, replacer, 2); }
+}
+
+export const eventLog = new EventLog();
+```
+
+Wired at the one place every event already passes through:
+
+```ts
+// storeEvents.ts, inside emit()
+emit<K extends keyof StoreEvents>(event: K, payload: StoreEvents[K]): void {
+  eventLog.record(event, payload, currentOrigin());
+  ...
+}
+```
+
+Exposed for the browser console, which is where it will actually be used:
+
+```ts
+if (dev && typeof window !== 'undefined') {
+  (window as any).__roEventLog = eventLog;
+}
+```
+
+```mermaid
+graph LR
+  L[Local mutation] --> E[storeEventBus.emit]
+  S[Conductor signal] --> E
+  E --> LOG[eventLog ring buffer, dev only]
+  E --> H[handlers]
+  LOG --> EXP[JSON export]
+  EXP --> BUG[Attach to a bug report]
+```
+
+### Hash rendering
+
+`ActionHash` is a `Uint8Array` and serializes to a useless object. The `replacer` must call `encodeHashToBase64` on anything hash-shaped, or the export is unreadable, which is the same reason the existing `console.log` calls are hard to use.
+
+### Two-agent correlation
+
+A log is worth much more when two of them can be lined up. Each entry carries `at` from the local clock, which is enough to correlate manually across two browser windows on one machine, which is how the app is developed. Do not build clock synchronization. If ordering across agents needs to be provable rather than inspectable, that is a different tool.
+
+## Consequences
+
+**Gained.** A reproducible artifact to attach to a bug report. Direct support for [proposal 5](05-conductor-signals.md): the `origin` field answers "did this come from my own action or from the network", which is the first question in every signal bug, including echo suppression.
+
+**Paid.** Almost nothing. Guarded by `dev`, so it compiles out of production builds. The ring buffer is bounded. The one real cost is the slice snapshot, which is why `slice` is optional and off by default; deep-cloning a store's data on every event would be noticeable on list-heavy admin screens.
+
+**Superseded.** `emitStatusUpdate` and its emoji `console.log` should be deleted once this lands. It is the same idea, worse, for two events.
+
+## Alternatives considered
+
+**Full time travel, as Foldkit's DevTools provide.** Foldkit can replay because it has one Model and a pure `update`. Nine independent rune stores have no single snapshot to restore. Genuinely blocked, not merely expensive, unless [proposal 6](06-pure-state-modules.md) lands for every domain first, at which point replaying per domain becomes possible and this document can be revisited.
+
+**Redux DevTools protocol.** Would give a real UI for free. Rejected as a first step: the adapter work exceeds the value of a `console.table`, and the protocol assumes a single store.
+
+**A Svelte panel in the app.** More discoverable than the console, more code, and it renders inside the app whose state is under investigation. Console first.
+
+## Migration
+
+One pull request. Add `event-log.ts`, wire it in `emit`, expose it on `window` in dev, delete `emitStatusUpdate` and update its two call sites.
+
+## Verification
+
+- Emitting a known sequence in a test and asserting `eventLog.entries()` matches, in order, with correct `seq` values.
+- A production build containing no reference to `__roEventLog`, checked with `grep` over `ui/build`.
+- Hashes in the exported JSON render as base64 strings.

--- a/documentation/architecture/frontend-refactoring/08-implementation-plan.md
+++ b/documentation/architecture/frontend-refactoring/08-implementation-plan.md
@@ -12,7 +12,7 @@ It is valuable in pieces. Phases 0 and 1 together are 4.5 weeks and deliver six 
 
 ```mermaid
 graph LR
-  subgraph "Phase 0 · 2wk"
+  subgraph "Phase 0 · 2.2wk"
     A[7 event log]
     B[1 task runner]
   end
@@ -43,7 +43,7 @@ Only one edge is hard: coordination must land before the import boundary, becaus
 
 ## Phase 0. Instrumentation and safety net
 
-**2 weeks. No behaviour change. Ships independently.**
+**2.2 weeks. No behaviour change. Ships independently.**
 
 This phase inverts the original note's ordering, which put the event log last and opportunistic. It goes first because it costs half a week, is guarded by `dev` so it cannot reach production, and instruments every phase after it. Debugging Phase 3 without it means reading console output for ordering bugs across two agents.
 
@@ -53,13 +53,17 @@ This phase inverts the original note's ordering, which put the event log last an
 | 0.2 | `refactor(ui): replace emitStatusUpdate console logging with the event log` | 0.2wk | `stores/storeEvents.ts` + 2 call sites |
 | 0.3 | `feat(ui): add useEffectTask composable for cancellable component effects` | 0.5wk | `composables/ui/useEffectTask.svelte.ts` |
 | 0.4 | `refactor(ui): run component effects through useEffectTask (14 components)` | 0.8wk | 14 `.svelte` files, 21 call sites |
+| 0.5 | `ci(ui): add the architecture invariant check` | 0.2wk | `ui/scripts/check-invariants.sh`, CI workflow |
 
-**Gate.** All four claims must hold before Phase 1 starts.
+PR 0.5 lands the check script with only invariant 2 active, since that is the only one Phase 0 makes true. Each later phase adds its own line to the same script **in the pull request that makes it true**, never earlier and never later. A check added early is a broken build; a check added late is a rule that already drifted. This is the mechanism behind the programme's maintainability claim: the architecture stops depending on whoever remembers it.
+
+**Gate.** All five claims must hold before Phase 1 starts.
 
 - `grep -rE "run(Promise|Sync|Fork)" ui/src --include=*.svelte` returns 0.
 - A test mounts a component, starts a task, unmounts, and the fiber's exit is `Interrupted`.
 - A production build contains no reference to `__roEventLog`.
 - `bun test:unit` passes with no new failures.
+- `ui/scripts/check-invariants.sh` runs in CI and passes.
 
 ## Phase 1. Coordination
 
@@ -179,4 +183,6 @@ Total is about **13 weeks**: Phase 4's runtime step is removed, and Phase 3 halv
 
 Every PR title above is written to be pasted as an issue title. If these are filed, the natural shape is one GitHub issue per phase as a tracking issue, with the PR rows as its checklist, rather than 30 separate issues. That keeps the board readable at ten hours a week.
 
-The eight invariants in the [unified design](00-unified-refactoring-design.md) are the acceptance criteria for the programme as a whole. Each is mechanically checkable, so they can be a single CI job that starts failing loudly once the codebase is meant to satisfy them.
+The eight invariants in the [unified design](00-unified-refactoring-design.md) are the acceptance criteria for the programme as a whole, and the check script introduced in PR 0.5 is where they live. Five of the eight are lint or grep, so they cost almost nothing to run. The script grows one line per phase, in the PR that earns it.
+
+That growth is the honest progress metric for this programme. Not weeks elapsed, not documents written: how many of the eight rules a machine now enforces without anyone remembering to.

--- a/documentation/architecture/frontend-refactoring/08-implementation-plan.md
+++ b/documentation/architecture/frontend-refactoring/08-implementation-plan.md
@@ -4,7 +4,7 @@ Sequencing, effort, gates and pull-request breakdown for the [unified refactorin
 
 ## Calibration
 
-Requests and Offers gets roughly ten hours a week, from one person. Estimates below are in **weeks of that allocation**, not in ideal engineering weeks, and they include review and rework. The whole programme is about **14.5 weeks**, which is close to four months. That number is the most important line in this document, because it means the programme must be valuable in pieces or it should not start.
+Requests and Offers gets roughly ten hours a week, from one person. Estimates below are in **weeks of that allocation**, not in ideal engineering weeks, and they include review and rework. The whole programme is about **13 weeks**, which is close to three months. That number is the most important line in this document, because it means the programme must be valuable in pieces or it should not start.
 
 It is valuable in pieces. Phases 0 and 1 together are 4.5 weeks and deliver six of the eight invariants. Everything after that is optional in the sense that stopping there leaves a coherent codebase rather than a half-migration.
 
@@ -23,7 +23,7 @@ graph LR
   subgraph "Phase 2 · 4wk"
     E[4a lifecycle states]
   end
-  subgraph "Phase 3 · 3wk"
+  subgraph "Phase 3 · 1.5wk"
     F[5 signals]
   end
   subgraph "Phase 4 · 3.5wk"
@@ -110,16 +110,22 @@ The compatibility surface is what makes this safe: each store keeps `data` and `
 
 ## Phase 3. Liveness
 
-**3 weeks. Includes backend work. The only phase that touches Rust.**
+**1.5 weeks, frontend only. Revised down from 3 weeks after an audit correction.**
+
+All six domain coordinator zomes already emit a five-variant `Signal` enum from `post_commit`; only `misc`, which owns no entries, does not. The UI discards every one. The emitting half of this phase was built and never connected, so no Rust work is needed to start, and the payload contract is read from the existing enum rather than designed.
 
 | PR | Title | Est | Repo area |
 |---|---|---|---|
-| 3.1 | `docs: define the R&O signal payload contract` | 0.3wk | `documentation/` |
-| 3.2 | `feat(service_types): emit signals from post_commit` | 0.5wk | `dnas/` |
-| 3.3 | `feat(ui): add SignalService as a scoped Effect resource` | 0.7wk | `ui/services/` |
-| 3.4 | `feat(ui): route service type signals into the store event vocabulary` | 0.5wk | `ui/stores/` |
-| 3.5 | `test: two-agent signal propagation for service types` | 0.5wk | `tests/`, `ui/tests/e2e/` |
-| 3.6 | `feat: extend signals to requests, offers and administration` | 0.5wk | both |
+| 3.1 | `feat(ui): add SignalService as a scoped Effect resource` | 0.5wk | `ui/services/` |
+| 3.2 | `feat(ui): decode zome signals and record them in the event log` | 0.3wk | `ui/schemas/`, observation only, no behaviour change |
+| 3.3 | `feat(ui): route service type signals into the store event vocabulary` | 0.3wk | `ui/stores/` |
+| 3.4 | `test(e2e): two-agent signal propagation for service types` | 0.2wk | `ui/tests/e2e/` |
+| 3.5 | `feat(ui): extend signal routing to the remaining five domains` | 0.2wk | `ui/stores/` |
+| 3.6 | Optional: `feat(administration): add a StatusChanged signal variant` | 0.3wk | `dnas/`, only if 3.5 proves too coarse |
+
+PR 3.2 is deliberately observation-only: decode and log, change nothing. It proves the Rust-to-TypeScript contract against a running conductor before any store depends on it.
+
+**Version risk, and it is scheduled.** Issue #193 upgrades `@holochain/client` to `0.21.0`, P1-critical, and the signal payload field is renamed between 0.20 and 0.21. Decoding in one place makes that a one-file change. If the chat work wires signals ad hoc first, it becomes a sweep.
 
 **Design constraint, restated because it is easy to lose.** Signals reduce latency, they never replace fetching. Holochain signals are send-and-forget with no ordering guarantee and no delivery to an offline receiver. `holochain-open-dev/common` runs a 20 second poll alongside its signal subscriptions for exactly this reason. Cache expiry from Phase 2 remains the correctness mechanism.
 
@@ -167,7 +173,7 @@ The project is on v0.5.2 in alpha testing, with v0.6.0 in flight. Nothing in Pha
 | 3 | v0.7.0, DNA change and behaviour change |
 | 4 | v0.7.x, internal only |
 
-Total drops from about 15 weeks to about **14.5**, with Phase 4's runtime step removed.
+Total is about **13 weeks**: Phase 4's runtime step is removed, and Phase 3 halved once the audit found the zomes already emit signals.
 
 ## Tracking
 

--- a/documentation/architecture/frontend-refactoring/08-implementation-plan.md
+++ b/documentation/architecture/frontend-refactoring/08-implementation-plan.md
@@ -1,0 +1,176 @@
+# 8. Implementation plan
+
+Sequencing, effort, gates and pull-request breakdown for the [unified refactoring design](00-unified-refactoring-design.md).
+
+## Calibration
+
+Requests and Offers gets roughly ten hours a week, from one person. Estimates below are in **weeks of that allocation**, not in ideal engineering weeks, and they include review and rework. The whole programme is about **14.5 weeks**, which is close to four months. That number is the most important line in this document, because it means the programme must be valuable in pieces or it should not start.
+
+It is valuable in pieces. Phases 0 and 1 together are 4.5 weeks and deliver six of the eight invariants. Everything after that is optional in the sense that stopping there leaves a coherent codebase rather than a half-migration.
+
+## Dependency graph
+
+```mermaid
+graph LR
+  subgraph "Phase 0 · 2wk"
+    A[7 event log]
+    B[1 task runner]
+  end
+  subgraph "Phase 1 · 2.5wk"
+    C[2 coordination]
+    D[3 import boundary]
+  end
+  subgraph "Phase 2 · 4wk"
+    E[4a lifecycle states]
+  end
+  subgraph "Phase 3 · 3wk"
+    F[5 signals]
+  end
+  subgraph "Phase 4 · 3.5wk"
+    G[6 pure state]
+  end
+  A --> C
+  B --> C
+  C --> D
+  C --> F
+  E --> G
+  E -.-> I[4b validation status · deferred]
+  F -.-> I
+  G -.-> J[1 Phase 1 runtime · deferred]
+```
+
+Only one edge is hard: coordination must land before the import boundary, because breaking a cycle requires somewhere for the cross-domain write to go. Everything else is preference.
+
+## Phase 0. Instrumentation and safety net
+
+**2 weeks. No behaviour change. Ships independently.**
+
+This phase inverts the original note's ordering, which put the event log last and opportunistic. It goes first because it costs half a week, is guarded by `dev` so it cannot reach production, and instruments every phase after it. Debugging Phase 3 without it means reading console output for ordering bugs across two agents.
+
+| PR | Title | Est | Files |
+|---|---|---|---|
+| 0.1 | `feat(ui): add dev-only store event log with JSON export` | 0.5wk | `stores/event-log.ts`, `stores/storeEvents.ts` |
+| 0.2 | `refactor(ui): replace emitStatusUpdate console logging with the event log` | 0.2wk | `stores/storeEvents.ts` + 2 call sites |
+| 0.3 | `feat(ui): add useEffectTask composable for cancellable component effects` | 0.5wk | `composables/ui/useEffectTask.svelte.ts` |
+| 0.4 | `refactor(ui): run component effects through useEffectTask (14 components)` | 0.8wk | 14 `.svelte` files, 21 call sites |
+
+**Gate.** All four claims must hold before Phase 1 starts.
+
+- `grep -rE "run(Promise|Sync|Fork)" ui/src --include=*.svelte` returns 0.
+- A test mounts a component, starts a task, unmounts, and the fiber's exit is `Interrupted`.
+- A production build contains no reference to `__roEventLog`.
+- `bun test:unit` passes with no new failures.
+
+## Phase 1. Coordination
+
+**2.5 weeks. Behaviour-preserving. The highest value-per-line in the programme.**
+
+| PR | Title | Est | Notes |
+|---|---|---|---|
+| 1.1 | `feat(ui): add store-coordination module and initialize it in the root layout` | 0.3wk | Empty routing table, wired, no moves yet |
+| 1.2 | `refactor(ui): move hREA user and organization reactions into coordination` | 0.4wk | Extract `hreaStore.handle*` methods as they move |
+| 1.3 | `refactor(ui): move hREA taxonomy and proposal reactions into coordination` | 0.4wk | Remaining 11 of the 15 |
+| 1.4 | `refactor(ui): move production component subscriptions into coordination` | 0.4wk | 8 sites; `test-page` exempt |
+| 1.5 | `chore(ui): forbid storeEvents imports in components and routes` | 0.2wk | ESLint, with the `test-page` override |
+| 1.6 | `refactor(ui): break the administration and users store cycle` | 0.4wk | Decide direction first; administration depends on users |
+| 1.7 | `refactor(ui): break the administration and organizations store cycle` | 0.2wk | Same treatment |
+| 1.8 | `refactor(ui): move requests and offers display joins into composables` | 0.4wk | 4 imports; option B in proposal 3 |
+| 1.9 | `chore(ui): forbid store-to-store imports` | 0.1wk | Should pass on the first run |
+
+**Risk to watch.** PR 1.2 changes when the hREA reactions register: today at module import, afterwards at layout mount. Audit for boot-time emits first. If any exist, coordination initializes earlier rather than the move being abandoned.
+
+**Gate.**
+
+- `grep -rl "storeEventBus.on" ui/src/lib/components ui/src/routes` returns only `test-page` paths.
+- `grep -rn "from '\$lib/stores/.*\.store\.svelte'" ui/src/lib/stores/` returns nothing.
+- `bun run lint` passes with zero inline disables.
+- An import-order test: importing `administration` then `users`, and the reverse, produces identical behaviour.
+- Manual two-agent check: accepting a user still creates the hREA agent.
+
+**Stopping point.** Invariants 1, 2, 3, 4 and 7 hold. If the programme stops here it has paid for itself.
+
+## Phase 2. Representation
+
+**4 weeks. Nine domains. Incremental by construction.**
+
+| PR | Title | Est |
+|---|---|---|
+| 2.1 | `feat(ui): add EntityState schema and transition helpers` | 0.5wk |
+| 2.2 | `refactor(ui): hold service types state as EntityState` | 0.5wk |
+| 2.3 | `refactor(ui): match on entity state in service type components` | 0.5wk |
+| 2.4 to 2.10 | Same pair, per domain: requests, offers, users, organizations, administration, mediums of exchange, hREA | 2.5wk |
+
+The compatibility surface is what makes this safe: each store keeps `data` and `isBusy` as derived getters, so a converted store works with unconverted components. Delete the getters per domain as its components land.
+
+**Gate per domain**, not per phase.
+
+- A property test over that domain's transitions: no sequence yields a state with both data and an error, and a failed refresh always yields `Stale`.
+- A component test: a failed background refresh leaves the previously rendered rows on screen.
+- `grep -c "loading: boolean" ui/src/lib/stores/{domain}.store.svelte.ts` returns 0.
+
+## Phase 3. Liveness
+
+**3 weeks. Includes backend work. The only phase that touches Rust.**
+
+| PR | Title | Est | Repo area |
+|---|---|---|---|
+| 3.1 | `docs: define the R&O signal payload contract` | 0.3wk | `documentation/` |
+| 3.2 | `feat(service_types): emit signals from post_commit` | 0.5wk | `dnas/` |
+| 3.3 | `feat(ui): add SignalService as a scoped Effect resource` | 0.7wk | `ui/services/` |
+| 3.4 | `feat(ui): route service type signals into the store event vocabulary` | 0.5wk | `ui/stores/` |
+| 3.5 | `test: two-agent signal propagation for service types` | 0.5wk | `tests/`, `ui/tests/e2e/` |
+| 3.6 | `feat: extend signals to requests, offers and administration` | 0.5wk | both |
+
+**Design constraint, restated because it is easy to lose.** Signals reduce latency, they never replace fetching. Holochain signals are send-and-forget with no ordering guarantee and no delivery to an offline receiver. `holochain-open-dev/common` runs a 20 second poll alongside its signal subscriptions for exactly this reason. Cache expiry from Phase 2 remains the correctness mechanism.
+
+**Gate.**
+
+- Two-agent e2e: agent A approves a service type, agent B's UI reflects it with no manual refresh.
+- Dropping the websocket mid-stream releases and re-acquires the scoped subscription with no duplicate handlers.
+- Echo test: an agent's own write applies exactly once.
+- The event log from a two-agent session shows `origin: 'signal'` entries interleaved correctly.
+
+## Phase 4. Purity
+
+**3.5 weeks, and the only phase that should be re-decided rather than executed.**
+
+| PR | Title | Est |
+|---|---|---|
+| 4.1 | `refactor(ui): extract service types state into a pure reducer` | 0.7wk |
+| 4.2 | `test(ui): property tests for the service types reducer` | 0.3wk |
+| **4.3** | **Decision point, not a PR** | 0 |
+| 4.4 to 4.11 | One domain per PR, eight remaining | 2.5wk |
+| 4.12 | Not scheduled. See Deferred | 0 |
+
+**The decision point is the plan's main safeguard.** After 4.1 and 4.2, measure two numbers: how many existing Service Types tests became redundant, and how many real defects the property tests found that the example tests missed. Continue on those numbers. Continuing on principle is how a nine-domain migration stalls at four.
+
+**Gate.**
+
+- `state.ts` modules import nothing from `svelte`, `effect`, or any service, enforced by lint.
+- Reducer suites run without a DOM environment.
+- No new store-to-store or aggregating-tag dependencies appear.
+
+## Deferred
+
+**Proposal 1, Phase 1: the application runtime.** Not scheduled. This repository built `createAppRuntime()` with an aggregating `AppServicesTag` in 2025 and removed it in `e31c0324` on 2025-09-29, deleting roughly 2,530 net lines including an 898-line test file, on the stated grounds that the abstraction was complex and the simpler form kept full functionality. The design proposed in [01](01-application-runtime.md) is narrower than what was removed, since it never reintroduces the aggregating tag, but it is close enough to need a fresh reason. The research did not supply one: layers are already built once at module scope, so a `ManagedRuntime` would buy a policy seam and a disposal hook rather than the performance win it is usually sold for. Revisit if Phase 3's scoped websocket subscription turns out to want an owner with a defined disposal point. Phase 0's task runner is unaffected and stays scheduled.
+
+**4b, DHT validation status.** Not scheduled. It proposes states the network does not report: signals fire from `post_commit` at source-chain write time, and validation status is reachable only by calling `get_details` per record. Building it means a coordinator zome function per entry type, a polling scheduler with backoff, and six states to render. Revisit only if a user-facing requirement appears that the cheaper two-state approximation (`Pending` / `Settled`, using data the frontend already has) cannot serve.
+
+## Fit with the release train
+
+The project is on v0.5.2 in alpha testing, with v0.6.0 in flight. Nothing in Phases 0 through 2 changes user-visible behaviour, so all of it can land on `dev` alongside feature work. Phase 3 does change behaviour and touches the DNA, so it wants its own minor version.
+
+| Phase | Target |
+|---|---|
+| 0, 1 | v0.6.x patch releases, alongside feature work |
+| 2 | v0.6.x, one domain per patch |
+| 3 | v0.7.0, DNA change and behaviour change |
+| 4 | v0.7.x, internal only |
+
+Total drops from about 15 weeks to about **14.5**, with Phase 4's runtime step removed.
+
+## Tracking
+
+Every PR title above is written to be pasted as an issue title. If these are filed, the natural shape is one GitHub issue per phase as a tracking issue, with the PR rows as its checklist, rather than 30 separate issues. That keeps the board readable at ten hours a week.
+
+The eight invariants in the [unified design](00-unified-refactoring-design.md) are the acceptance criteria for the programme as a whole. Each is mechanically checkable, so they can be a single CI job that starts failing loudly once the codebase is meant to satisfy them.

--- a/documentation/architecture/frontend-refactoring/09-pipeline-alignment.md
+++ b/documentation/architecture/frontend-refactoring/09-pipeline-alignment.md
@@ -1,0 +1,37 @@
+# 9. Alignment with the committed pipeline
+
+Why this programme is worth doing now rather than later, mapped to the open issues and pull requests it serves. Every row is a link to work already agreed, not a hypothetical.
+
+## The finding that changed the plan
+
+**All six domain coordinator zomes already emit signals, and the frontend discards every one.** `requests`, `offers`, `users_organizations`, `administration`, `service_types` and `mediums_of_exchange` each implement `post_commit` and call `emit_signal` with the same five-variant `Signal` enum. Only `misc`, which owns no entries, does not. Meanwhile `ui/src` contains no signal handling at all.
+
+PR #181 states it from the other side: before that PR, "every coordinator zome only did local `post_commit` to `emit_signal`, a cache-invalidation bus for the agent's own UI".
+
+That bus was built and never connected. [Proposal 5](05-conductor-signals.md) is therefore not greenfield work; it is finishing a half-built path whose expensive half is done. Phase 3 drops from three weeks to 1.5, frontend only.
+
+## Mapping
+
+| Committed work | Proposals it depends on | What the architecture buys |
+|---|---|---|
+| Chat and messaging: PR #181 (merged signalling layer), PR #188 derived mailboxes, PR #172 stewarding draft, issues #91 and #51 | 5, then 2 and 1 | Conversations are membrane-isolated DNA clones, so each open conversation is a subscription with a real lifecycle: acquire on open, release on close, re-acquire on reconnect. `Layer.scoped` models that directly. An ad hoc `client.on` callback does not, and gets it wrong on the reconnect path. Routing messages through the same event vocabulary as local writes means the conversation store reads like every other store |
+| Stewarding drop: #197 case model, #198 flag intake, #199 steward queue and case screen, #200 propose-then-concur, #201 findings | 4a, 2, 3 | A tenth domain with a queue, a case screen and a conflict-of-interest read block. The queue is the clearest case for `Stale` and `Refreshing`, which `loading: boolean` cannot express. Stewarding will read users and administration, which is exactly how the third import cycle gets created. "Flag raised, case opened, steward notified" is one readable chain in coordination rather than three subscriptions in three factories |
+| `@holochain/client` 0.21.0: #193, P1-critical | 5 | The signal payload field is renamed between 0.20 and 0.21. One Schema decode point makes the upgrade a one-file change. Signals wired ad hoc across the chat work first make it a sweep |
+| Holochain 0.7 chain: #192 hdk 0.7, #194 kangaroo rebase, #195 network reset, #144 migration, #143 drift detection | 4a, 7 | Version drift is a state with several meanings, not a flag. The event log turns a failed migration into an exportable artifact instead of a description |
+| Restore and unarchive: #161 | 4a | Another status transition on requests and offers. Each one added to a boolean-plus-error store widens the gap between representable and legal states |
+
+## Three open bugs that are these designs, unbuilt
+
+**#134, update then navigate produces a Wasm deserialize error.** The tester wrote: "I got impatient, I clicked update on the Request then clicked View Requests like I was exiting the edit screen." That is an in-flight effect with no owner. `E.runPromise` returns a Promise and no fiber, so nothing can interrupt it when the view goes away. [Proposal 1's Phase 0](01-application-runtime.md) exists to close exactly this class, and it is the cheapest item in the programme.
+
+**#138, connection status reads Connected in airplane mode.** `ui/src/lib/services/connection.service.ts:83` computes `isConnected = hc.isConnected && hc.client !== null`. Neither operand changes when the network disappears, so the indicator reports an unrefuted assumption as a fact. This is [proposal 4a](04a-entity-lifecycle-states.md)'s argument in one line: a boolean cannot say "believed connected, last confirmed 40 seconds ago". The honest type is a union with a verification timestamp.
+
+**#133, request form links and organization fields do not persist on save.** P1-critical. Silent partial failure is the class that survives when nothing forces a component to handle every state, and when a store can be `loading: false` with stale data and a null error at the same time.
+
+## The counterweight, stated plainly
+
+Phases 0 and 1 are 4.5 weeks. The stewarding drop and the 0.7 upgrade chain are already committed work with P1 and P2 labels on them. Doing this first delays them by that much.
+
+The argument for doing it anyway is not that the refactor is more valuable than the features. It is that two new domains are about to be built, and each one built the current way is a debt paid twice: once now at feature speed, once later at retrofit speed. The two import cycles become four. The fifteen cross-domain subscriptions inside `hrea.store` acquire a sibling set inside a conversation store. The 21 uncancelled component calls become thirty, concentrated in chat and case screens, which are precisely the surfaces where users navigate fastest and where #134 already fired.
+
+A defensible middle path: take Phase 0 only, which is two weeks, closes #134, and instruments everything after it. Then reassess against the stewarding drop with real evidence rather than an argument.

--- a/documentation/architecture/frontend-refactoring/README.md
+++ b/documentation/architecture/frontend-refactoring/README.md
@@ -24,7 +24,7 @@ Foldkit is not a migration target, and the reason is harder than a judgment call
 
 Proposal 4 from the original note is split. Its lifecycle half is ordinary work with a clear payoff. Its `DhtStatus` half rests on an assumption the network does not support, and is filed separately as speculative.
 
-Proposal 1 is likewise split by its own history. Its task-runner half is scheduled. Its application-runtime half is deferred, because this repository built that abstraction in 2025 and removed it deliberately in `e31c0324`, and the research found no fresh reason to bring it back.
+Proposal 1 is likewise split by its own history. Its task-runner half is scheduled. Its application-runtime half is deferred: this repository built that abstraction in 2025 and reverted it in `e31c0324`. The maintainer's position is that the attempt failed and is worth retrying later on a more mature codebase, so [01](01-application-runtime.md) records three checkable conditions for reopening it rather than leaving it open indefinitely.
 
 ## Where to start reading
 
@@ -34,7 +34,11 @@ Proposal 1 is likewise split by its own history. Its task-runner half is schedul
 
 Phase 0 (7, then 1's task runner), Phase 1 (2, then 3), Phase 2 (4a per domain, Service Types first), Phase 3 (5), Phase 4 (6, then 1's runtime). 4b is deferred rather than scheduled.
 
-This inverts the original note's ordering in one place: the development message log moves from last and opportunistic to first, because it costs half a week, carries no production risk, and instruments every phase after it. Roughly 13 weeks in total at ten hours a week, of which the first 4.5 deliver six of the eight invariants.
+This inverts the original note's ordering in one place: the development message log moves from last and opportunistic to first, because it costs half a week, carries no production risk, and instruments every phase after it. Roughly 13 weeks in total at ten hours a week, of which the first 4.7 deliver six of the eight invariants.
+
+## The claim, in one line
+
+The step up is not in abstraction level. It is that eight architectural rules become checkable by lint, grep or a test, so the architecture stops depending on whoever remembers it. `ui/scripts/check-invariants.sh` arrives in Phase 0 and grows one line per phase, in the pull request that earns it. How many of the eight a machine enforces is the honest progress metric for the programme.
 
 ## Verified baseline (2026-08-22, `origin/main` and `dev` agree)
 

--- a/documentation/architecture/frontend-refactoring/README.md
+++ b/documentation/architecture/frontend-refactoring/README.md
@@ -1,6 +1,6 @@
 # Foldkit-derived design proposals for the Requests and Offers frontend
 
-Ten documents: one unified design, seven proposal designs (with proposal 4 split in two), and one implementation plan. Derived from the Foldkit comparison note and revised against research verified on 2026-08-22.
+Eleven documents: one unified design, seven proposal designs (with proposal 4 split in two), an implementation plan, and a mapping onto the committed pipeline. Derived from the Foldkit comparison note and revised against research verified on 2026-08-22.
 
 ## Framing
 
@@ -20,6 +20,7 @@ Foldkit is not a migration target, and the reason is harder than a judgment call
 | 6 | [Pure state modules](06-pure-state-modules.md) | Proposed | 4a |
 | 7 | [Development message log](07-development-message-log.md) | Proposed | 2 |
 | 8 | [Implementation plan](08-implementation-plan.md) | Proposed | 0 |
+| 9 | [Pipeline alignment](09-pipeline-alignment.md) | Proposed | 0, 8 |
 
 Proposal 4 from the original note is split. Its lifecycle half is ordinary work with a clear payoff. Its `DhtStatus` half rests on an assumption the network does not support, and is filed separately as speculative.
 
@@ -33,7 +34,7 @@ Proposal 1 is likewise split by its own history. Its task-runner half is schedul
 
 Phase 0 (7, then 1's task runner), Phase 1 (2, then 3), Phase 2 (4a per domain, Service Types first), Phase 3 (5), Phase 4 (6, then 1's runtime). 4b is deferred rather than scheduled.
 
-This inverts the original note's ordering in one place: the development message log moves from last and opportunistic to first, because it costs half a week, carries no production risk, and instruments every phase after it. Roughly 14.5 weeks in total at ten hours a week, of which the first 4.5 deliver six of the eight invariants.
+This inverts the original note's ordering in one place: the development message log moves from last and opportunistic to first, because it costs half a week, carries no production risk, and instruments every phase after it. Roughly 13 weeks in total at ten hours a week, of which the first 4.5 deliver six of the eight invariants.
 
 ## Verified baseline (2026-08-22, `origin/main` and `dev` agree)
 
@@ -44,7 +45,7 @@ This inverts the original note's ordering in one place: the development message 
 | `ManagedRuntime` occurrences | 0 |
 | `storeEventBus.on` sites | 42 total: 15 in `hrea.store`, 7 factory sites in `event-helpers.ts`, 12 in `components/hrea/test-page/`, 8 in production components and routes |
 | Store-to-store imports | 8, forming two cycles |
-| Signal handling (`AppSignal`, `client.on`) | none |
+| Signal handling in `ui/src` | none, while all six domain zomes emit from `post_commit` |
 | Stores | 9 (`administration`, `hrea`, `mediums_of_exchange`, `offers`, `organizations`, `requests`, `serviceTypes`, `users`, `weave`) |
 | `effect` | `^3.14.18` |
 | `@holochain/client` | `0.20.5` |

--- a/documentation/architecture/frontend-refactoring/README.md
+++ b/documentation/architecture/frontend-refactoring/README.md
@@ -1,0 +1,55 @@
+# Foldkit-derived design proposals for the Requests and Offers frontend
+
+Ten documents: one unified design, seven proposal designs (with proposal 4 split in two), and one implementation plan. Derived from the Foldkit comparison note and revised against research verified on 2026-08-22.
+
+## Framing
+
+Foldkit is not a migration target, and the reason is harder than a judgment call. Its `peerDependencies` carry an exact pin, `effect: 4.0.0-rc.109`. `effect@latest` on npm is 3.22.1 and `ui/package.json` declares `effect: ^3.14.18`. Adoption is impossible on the current stack at any effort level. What follows borrows ideas, never code.
+
+## The set
+
+| # | Document | Status | Depends on |
+|---|---|---|---|
+| 0 | [Unified refactoring design](00-unified-refactoring-design.md) | Proposed | keystone, read first |
+| 1 | [Application runtime](01-application-runtime.md) | Proposed | none |
+| 2 | [Store coordination module](02-store-coordination.md) | Proposed | none |
+| 3 | [Store import boundary](03-store-import-boundary.md) | Proposed | 2 |
+| 4a | [Entity lifecycle states](04a-entity-lifecycle-states.md) | Proposed | none |
+| 4b | [DHT validation status](04b-dht-validation-status.md) | Speculative | 4a, 5 |
+| 5 | [Conductor signals](05-conductor-signals.md) | Proposed | 2 |
+| 6 | [Pure state modules](06-pure-state-modules.md) | Proposed | 4a |
+| 7 | [Development message log](07-development-message-log.md) | Proposed | 2 |
+| 8 | [Implementation plan](08-implementation-plan.md) | Proposed | 0 |
+
+Proposal 4 from the original note is split. Its lifecycle half is ordinary work with a clear payoff. Its `DhtStatus` half rests on an assumption the network does not support, and is filed separately as speculative.
+
+Proposal 1 is likewise split by its own history. Its task-runner half is scheduled. Its application-runtime half is deferred, because this repository built that abstraction in 2025 and removed it deliberately in `e31c0324`, and the research found no fresh reason to bring it back.
+
+## Where to start reading
+
+[00-unified-refactoring-design.md](00-unified-refactoring-design.md) states the single thesis the seven share, the target architecture, the eight invariants, and what deliberately does not change. [08-implementation-plan.md](08-implementation-plan.md) sequences the work into five phases with gates and pull-request titles. The numbered documents are the detail behind each landing point.
+
+## Order
+
+Phase 0 (7, then 1's task runner), Phase 1 (2, then 3), Phase 2 (4a per domain, Service Types first), Phase 3 (5), Phase 4 (6, then 1's runtime). 4b is deferred rather than scheduled.
+
+This inverts the original note's ordering in one place: the development message log moves from last and opportunistic to first, because it costs half a week, carries no production risk, and instruments every phase after it. Roughly 14.5 weeks in total at ten hours a week, of which the first 4.5 deliver six of the eight invariants.
+
+## Verified baseline (2026-08-22, `origin/main` and `dev` agree)
+
+| Fact | Value |
+|---|---|
+| `runPromise` / `runSync` / `runFork` call sites in `ui/src` | 148 |
+| of which inside `.svelte` files | 21 |
+| `ManagedRuntime` occurrences | 0 |
+| `storeEventBus.on` sites | 42 total: 15 in `hrea.store`, 7 factory sites in `event-helpers.ts`, 12 in `components/hrea/test-page/`, 8 in production components and routes |
+| Store-to-store imports | 8, forming two cycles |
+| Signal handling (`AppSignal`, `client.on`) | none |
+| Stores | 9 (`administration`, `hrea`, `mediums_of_exchange`, `offers`, `organizations`, `requests`, `serviceTypes`, `users`, `weave`) |
+| `effect` | `^3.14.18` |
+| `@holochain/client` | `0.20.5` |
+| SvelteKit adapter | `adapter-static` |
+
+## Evidence sources
+
+Repository facts are counted from the working tree and from `git grep` against `origin/main`. External facts carry their source inline in each document. Foldkit's own published TodoMVC benchmark, its `runtime.ts` `resources` doctrine, Effect's layer-memoization docs, and the `holochain-open-dev/common` signals implementation are the four recurring citations.

--- a/documentation/architecture/frontend-refactoring/README.md
+++ b/documentation/architecture/frontend-refactoring/README.md
@@ -40,7 +40,9 @@ This inverts the original note's ordering in one place: the development message 
 
 The step up is not in abstraction level. It is that eight architectural rules become checkable by lint, grep or a test, so the architecture stops depending on whoever remembers it. `ui/scripts/check-invariants.sh` arrives in Phase 0 and grows one line per phase, in the pull request that earns it. How many of the eight a machine enforces is the honest progress metric for the programme.
 
-## Verified baseline (2026-08-22, `origin/main` and `dev` agree)
+## Verified baseline (2026-08-22, at `bc0c0ac5`)
+
+Counted at the commit this branch was cut from, `bc0c0ac5`, where `origin/main` and `dev` agree. The commit is named so the numbers stay checkable rather than decaying: re-running the counts on a later `dev` will give different values without any of them being wrong. As of `005ecc92` the first two rows read 150 and 22; every other row below is unchanged.
 
 | Fact | Value |
 |---|---|


### PR DESCRIPTION
> **SoushAI analysis.** Drafted by Soushi's AI assistant, reviewed and posted by @Soushi888.

## Context

A comparison between our 7-layer Effect-TS frontend and [Foldkit](https://foldkit.dev), a TypeScript framework built on Effect with an Elm-style single Model. The question was not whether to migrate, but what Foldkit answers more crisply than we do, and what we should take.

Foldkit is not adoptable here at any effort level: its `peerDependencies` pin `effect: 4.0.0-rc.109` exactly, while `ui/package.json` declares `^3.14.18` and `effect@latest` is 3.22.1. Everything in this PR borrows an idea, never a dependency.

**This PR adds documentation only. No code changes, no behaviour changes.** It exists so the implementation work can be stacked on top of it.

## What is in here

| Document | What it is |
|---|---|
| [00 Unified refactoring design](documentation/architecture/frontend-refactoring/00-unified-refactoring-design.md) | The keystone: thesis, target architecture, eight mechanically checkable invariants, what deliberately does not change, risk register |
| 01 to 07 | One design per proposal: verified evidence, design with code and diagrams, consequences, alternatives, migration, verification |
| [08 Implementation plan](documentation/architecture/frontend-refactoring/08-implementation-plan.md) | Five phases, gates per phase, PR-ready titles, effort in weeks of this project's real allocation |
| [09 Pipeline alignment](documentation/architecture/frontend-refactoring/09-pipeline-alignment.md) | Which committed issue or PR each proposal serves, and the counterweight |

## The thesis

The frontend coordinates itself implicitly. Nine stores reach into each other by import, react to each other through subscriptions registered inside store factories, run Effects at 148 scattered call sites, and describe every domain's state with the same three loosely related fields. Each is defensible alone. Together they mean no single file answers "what happens when a user is accepted", and no type prevents a state that cannot exist.

The programme makes coordination explicit along three axes and nothing else:

- **Execution**: where an Effect runs and who can cancel it
- **Coordination**: where cross-domain reactions live
- **Representation**: what a domain's state can legally be

## Audit findings that motivated it

All counted against `origin/main` and `dev`, which agree:

| Fact | Value |
|---|---|
| `runPromise` / `runSync` / `runFork` call sites in `ui/src` | 148, of which 21 inside `.svelte` |
| `storeEventBus.on` sites | 42: 15 in `hrea.store`, 7 factory sites, 12 in the hREA test page, 8 in production components |
| Store-to-store imports | 8, forming **two** cycles (`users` ↔ `administration`, `organizations` ↔ `administration`) |
| Signal handling in `ui/src` | none, while all six domain zomes emit from `post_commit` |
| Store state shape | `loading: boolean` plus a nullable error, in all 8 domains |

The 21 component call sites are the concrete bug class: `E.runPromise` returns a Promise and no fiber, so a modal that unmounts mid-fetch cannot interrupt its own work.

## The audit correction worth reading first

**All six domain coordinator zomes already emit signals, and the frontend discards every one.** `requests`, `offers`, `users_organizations`, `administration`, `service_types` and `mediums_of_exchange` each implement `post_commit` and call `emit_signal` with the same five-variant `Signal` enum. Only `misc`, which owns no entries, does not.

#181 says the same from the other side: before it, "every coordinator zome only did local `post_commit` to `emit_signal`, a cache-invalidation bus for the agent's own UI". That bus was built and never connected.

So the signals proposal is not greenfield. Its payload contract is the existing Rust enum, read rather than designed, `serde` tag and all. Phase 3 drops from 3 weeks to **1.5, frontend only**, and its first PR is deliberately observation-only: decode signals into the event log, change no behaviour, prove the Rust to TypeScript contract against a live conductor before any store depends on it.

## Why this is worth doing before the next two drops

Full mapping in [09](documentation/architecture/frontend-refactoring/09-pipeline-alignment.md). The short version:

| Committed work | Serves it |
|---|---|
| Chat and messaging (#181, #188, #172, #91, #51) | Conversations are DNA clones, so each open conversation is a resource with acquire, release and re-acquire on reconnect. `Layer.scoped` models that; a bare `client.on` callback gets the reconnect path wrong |
| Stewarding drop (#197 to #201) | A tenth domain with a queue and a case screen. It will read users and administration, which is how the third import cycle gets created. A queue is the clearest case for `Stale` and `Refreshing` |
| `@holochain/client` 0.21.0 (#193, P1-critical) | The signal payload field is renamed between 0.20 and 0.21. One decode point makes that a one-file change |
| Holochain 0.7 chain (#192, #194, #195, #144, #143) | Version drift is a state with several meanings, not a flag |

**Three open alpha-test bugs are these designs unbuilt.** #134, the update-then-navigate Wasm deserialize error, is an in-flight effect with no owner, which is exactly what Phase 0 closes. #138, "Connected" in airplane mode, is `isConnected = hc.isConnected && hc.client !== null` at `connection.service.ts:83`, a boolean reporting an unrefuted assumption as a fact. #133, form fields silently not persisting, is the class that survives when nothing forces a component to handle every state.

**The counterweight, stated plainly.** Phases 0 and 1 are 4.5 weeks, and the stewarding drop and 0.7 chain are already committed with P1 and P2 labels. Doing this first delays them. A defensible middle path is Phase 0 alone: 2.2 weeks, closes #134, instruments everything after it, and lands the invariant check.

## Two things deliberately filed as speculative

**DHT validation status.** The original idea was a `DhtStatus` union making explicit what the network guarantees. It does not guarantee it. Signals fire from `post_commit`, at source-chain write time. Validation status is reachable only through `RecordDetails.validation_status` (`"Valid" | "Rejected" | "Abandoned"`, in our pinned `@holochain/client` 0.20.5), which means calling `get_details` per record. Building it means a coordinator zome function per entry type plus a polling scheduler. `holochain-open-dev/common` hit the same wall and models three states with a 20 second poll instead.

**The application runtime.** We built this before. `58906914` introduced `createAppRuntime()` with an aggregating `AppServicesTag`; `e31c0324` removed it in September 2025, deleting roughly 2,530 net lines including an 898-line test file. The design here is narrower and never reintroduces the aggregating tag, but the audit found no fresh reason to bring the rest back either: layers are already built once at module scope, so a `ManagedRuntime` would buy a policy seam, not the performance win it is usually sold for. The cancellation half (a `useEffectTask` composable) stands on its own and stays scheduled.

## Cost, stated plainly

About 13 weeks at this project's ten hours a week. That is the most important number in the plan, and it is why the work is sequenced to be valuable in pieces: **Phases 0 and 1 are 4.7 weeks and deliver six of the eight invariants.** Stopping there leaves a coherent codebase rather than a half-migration.

## How the stack works

This PR is the base. Implementation PRs branch from `docs/frontend-refactoring-design` rather than from `dev`, so each one can cite its design document and reviewers can read the intent alongside the diff.

```
dev
 └── docs/frontend-refactoring-design      <- this PR
      └── feat/ui-store-event-log          <- 0.1, first implementation slice
           └── feat/ui-effect-task         <- 0.3
                └── refactor/ui-component-effect-cancellation  <- 0.4
```

Phase 0 in full, from [08](documentation/architecture/frontend-refactoring/08-implementation-plan.md):

- [ ] 0.1 `feat(ui): add dev-only store event log with JSON export`
- [ ] 0.2 `refactor(ui): replace emitStatusUpdate console logging with the event log`
- [ ] 0.3 `feat(ui): add useEffectTask composable for cancellable component effects`
- [ ] 0.4 `refactor(ui): run component effects through useEffectTask (14 components)`

The event log moves from last in the original ordering to first: half a week, `dev`-guarded so it carries no production risk, and it instruments every phase after it.

## Also fixed

`DOCUMENTATION_INDEX.md` pointed at `architecture/app-runtime.md`, deleted in `e31c0324`. That history is now recorded in 01 rather than dangling.

## What actually makes this hold: the invariants are checks, not prose

The step up here is not in abstraction level. It is that eight architectural rules become checkable by lint, grep or a test, so **the architecture stops depending on whoever remembers it**.

A documented convention decays exactly when it matters most: under deadline, in an unfamiliar domain, six months after the person who wrote it down, and above all in a codebase where one part-time maintainer carries the whole model in their head. Nothing in a document stops a store from importing a store. The reviewer either remembers or does not.

A rule expressed as a check is different in kind. It fires at the moment of violation, it addresses whoever is writing the code rather than whoever is reviewing it, and it survives the author forgetting it. That is the difference between a design that holds and a design that was once true.

| # | Invariant | Mechanism | Fails at |
|---|---|---|---|
| 1 | No store imports a store | ESLint `no-restricted-imports` | write time |
| 2 | No `.svelte` runs an Effect | grep | CI |
| 3 | No component imports `storeEvents` | ESLint | write time |
| 4 | Cross-domain reactions live only in coordination | follows from 1 and 3 | CI |
| 5 | `state.ts` imports no svelte, effect or service | ESLint | write time |
| 6 | No store exposes `loading: boolean` | grep | CI |
| 7 | Component effects are interrupted on teardown | unit test | `bun test:unit` |
| 8 | Local and remote change share one vocabulary | two-agent e2e | `bun test:e2e` |

Five of the eight are lint or grep, so they cost almost nothing to run. `ui/scripts/check-invariants.sh` lands as **PR 0.5 in Phase 0** with one line active, and grows one line per phase **in the pull request that earns it**: a check added early is a broken build, a check added late is a rule that already drifted.

**How many of the eight a machine enforces is the honest progress metric for this programme.** Not weeks elapsed, not documents written.

## On the application runtime, which we already tried

Recorded in [01](documentation/architecture/frontend-refactoring/01-application-runtime.md) rather than left implicit. `58906914` built `createAppRuntime()` with an aggregating `AppServicesTag`; `e31c0324` reverted it in September 2025, about 2,530 net lines including an 898-line test file.

That was the right call, and it was about ordering rather than the idea. A unified runtime asserts that the layers under it are stable enough to compose once and share everywhere. In 2025 they were not: services were still being standardized across eight domains, and the abstraction was carrying weight the layers below could not yet bear.

So it is deferred with a revisit condition rather than left open indefinitely. Reopen when all three hold:

1. Invariants 1 to 4 are enforced in CI, so a runtime would sit over an acyclic, single-entry layer graph rather than the current one
2. Pure state modules have landed for a majority of domains, so stores are thin wrappers rather than where orchestration lives
3. A concrete shared-policy need exists, most likely the signal subscription wanting an owner with a defined disposal point and a shared reconnection policy

And one thing a second attempt must not repeat: **no aggregating tag.** `AppServicesTag` collapsed nine explicit dependencies into one, which made every module depend on everything. Any future design that reintroduces a god-tag has reproduced what was reverted, whatever it is called.

The rest of the programme is orthogonal to that question, which is the point: getting execution, coordination and representation coherent first is what would make a second attempt reasonable later.

## Review notes

Read [00](documentation/architecture/frontend-refactoring/00-unified-refactoring-design.md) and [08](documentation/architecture/frontend-refactoring/08-implementation-plan.md); the rest is detail behind each landing point. The eight invariants in 00 are the acceptance criteria for the whole programme, and each is checkable by lint, grep or a test, so they can become a single CI job later.

Disagreement is the point of merging this as documentation first. Nothing is committed to until a Phase 0 PR lands on top.
