### PR TITLE
fix(#56): resolve status history from any hash in the update chain

### DIFF
--- a/dnas/requests_and_offers/zomes/coordinator/administration/src/status.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/administration/src/status.rs
@@ -4,8 +4,8 @@ use hdk::prelude::*;
 use status::*;
 use utils::{
   errors::{AdministrationError, CommonError, StatusError},
-  find_original_action_hash, get_all_revisions_for_entry, resolve_chain_root, EntityActionHash,
-  EntityAgent, OriginalActionHash, PreviousActionHash,
+  find_original_action_hash, get_all_revisions_for_entry, EntityActionHash, EntityAgent,
+  OriginalActionHash, PreviousActionHash,
 };
 
 use crate::administration::check_if_agent_is_administrator;
@@ -262,6 +262,7 @@ pub fn check_if_entity_is_accepted(input: EntityActionHash) -> ExternResult<bool
 /// ordered by their position in the `StatusUpdates` link chain.
 #[hdk_extern]
 pub fn get_all_revisions_for_status(original_status_hash: ActionHash) -> ExternResult<Vec<Record>> {
+  // get_all_revisions_for_entry resolves any hash in the chain to its root.
   let records = get_all_revisions_for_entry(
     OriginalActionHash(original_status_hash),
     LinkTypes::StatusUpdates,
@@ -373,8 +374,15 @@ pub fn update_entity_status(input: UpdateEntityActionHash) -> ExternResult<Recor
     // the EntityStatus link rotates to point at the latest revision, so that is the
     // hash the client reads back. Anchoring there would scatter revision links
     // across the chain and truncate the history read by get_all_revisions_for_status.
+    //
+    // Resolve from status_previous_action_hash, which update_entry has just proven
+    // to exist, and propagate rather than swallow: a mid-chain anchor written on a
+    // failed resolution is a permanent hole in the history, not a retryable read.
+    let resolved_status_root =
+      find_original_action_hash(input.status_previous_action_hash.0.clone())?;
+
     create_link(
-      resolve_chain_root(input.status_previous_action_hash.0.clone()),
+      resolved_status_root,
       action_hash.clone(),
       LinkTypes::StatusUpdates,
       (),

--- a/tests/sweettest/tests/administration/status_management.rs
+++ b/tests/sweettest/tests/administration/status_management.rs
@@ -200,3 +200,164 @@ async fn user_status_management_and_suspension_workflow() {
         "Bob should be accepted after unsuspension"
     );
 }
+
+/// Regression test for #56.
+///
+/// `get_all_revisions_for_status` used to query StatusUpdates links anchored at
+/// whatever hash the caller supplied. Those links are anchored to the original
+/// Create, so a mid-chain hash returned a partial history and raised no error.
+///
+/// The test above never exposed this: it passes the original Create hash on
+/// every call, so it builds a correctly anchored chain and passes either way.
+/// Here the third update deliberately supplies a mid-chain hash, mirroring what
+/// the frontend used to send, and the history is then read from three different
+/// points in the chain. All three must agree.
+#[tokio::test(flavor = "multi_thread")]
+async fn status_history_resolves_from_any_hash_in_the_chain() {
+    let (conductors, alice, bob) = setup_two_agents_with_alice_as_progenitor().await;
+
+    conductors[0]
+        .call::<_, Record>(&alice.zome("users_organizations"), "create_user", sample_user("Alice"))
+        .await;
+    conductors[1]
+        .call::<_, Record>(&bob.zome("users_organizations"), "create_user", sample_user("Bob"))
+        .await;
+
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    let alice_links: Vec<Link> = conductors[0]
+        .call(&alice.zome("users_organizations"), "get_agent_user", alice.agent_pubkey().clone())
+        .await;
+    let bob_links: Vec<Link> = conductors[1]
+        .call(&bob.zome("users_organizations"), "get_agent_user", bob.agent_pubkey().clone())
+        .await;
+
+    let alice_user_hash = alice_links[0].target.clone().into_action_hash().unwrap();
+    let bob_user_hash = bob_links[0].target.clone().into_action_hash().unwrap();
+
+    conductors[0]
+        .call::<_, bool>(
+            &alice.zome("administration"),
+            "add_administrator",
+            EntityActionHashAgents {
+                entity: ENTITY_NETWORK.to_string(),
+                entity_original_action_hash: alice_user_hash.clone(),
+                agent_pubkeys: vec![alice.agent_pubkey().clone()],
+            },
+        )
+        .await;
+
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    // hash_0: the Create. Bob gets a pending status when his user is created.
+    let initial: Option<Record> = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "get_latest_status_record_for_entity",
+            serde_json::json!({
+                "entity": ENTITY_USERS,
+                "entity_original_action_hash": bob_user_hash
+            }),
+        )
+        .await;
+    let create_hash = initial
+        .expect("Bob should have a status record")
+        .signed_action
+        .hashed
+        .hash
+        .clone();
+
+    // Helper: read the latest status action hash for Bob.
+    async fn latest_hash(
+        conductors: &SweetConductorBatch,
+        alice: &SweetCell,
+        bob_user_hash: &ActionHash,
+    ) -> ActionHash {
+        let record: Option<Record> = conductors[0]
+            .call(
+                &alice.zome("administration"),
+                "get_latest_status_record_for_entity",
+                serde_json::json!({
+                    "entity": ENTITY_USERS,
+                    "entity_original_action_hash": bob_user_hash
+                }),
+            )
+            .await;
+        record.unwrap().signed_action.hashed.hash.clone()
+    }
+
+    // Update 1: pending -> accepted. Correct anchor supplied.
+    conductors[0]
+        .call::<_, Record>(
+            &alice.zome("administration"),
+            "update_entity_status",
+            UpdateEntityStatusInput {
+                entity: ENTITY_USERS.to_string(),
+                entity_original_action_hash: bob_user_hash.clone(),
+                status_original_action_hash: create_hash.clone(),
+                status_previous_action_hash: create_hash.clone(),
+                new_status: accepted_status(),
+            },
+        )
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    let hash_1 = latest_hash(&conductors, &alice, &bob_user_hash).await;
+
+    // Update 2: accepted -> rejected. Correct anchor supplied.
+    conductors[0]
+        .call::<_, Record>(
+            &alice.zome("administration"),
+            "update_entity_status",
+            UpdateEntityStatusInput {
+                entity: ENTITY_USERS.to_string(),
+                entity_original_action_hash: bob_user_hash.clone(),
+                status_original_action_hash: create_hash.clone(),
+                status_previous_action_hash: hash_1.clone(),
+                new_status: rejected_status("second revision"),
+            },
+        )
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    let hash_2 = latest_hash(&conductors, &alice, &bob_user_hash).await;
+
+    // Update 3: rejected -> accepted, supplying hash_2 as the "original".
+    // This is what the frontend used to send. The coordinator must resolve it
+    // back to create_hash before anchoring the StatusUpdates link, or this
+    // revision is orphaned and no read can recover it.
+    conductors[0]
+        .call::<_, Record>(
+            &alice.zome("administration"),
+            "update_entity_status",
+            UpdateEntityStatusInput {
+                entity: ENTITY_USERS.to_string(),
+                entity_original_action_hash: bob_user_hash.clone(),
+                status_original_action_hash: hash_2.clone(),
+                status_previous_action_hash: hash_2.clone(),
+                new_status: accepted_status(),
+            },
+        )
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    let hash_3 = latest_hash(&conductors, &alice, &bob_user_hash).await;
+
+    // get_all_revisions_for_entry prepends the original record to the linked
+    // revisions, so one Create plus three updates is four records.
+    const EXPECTED: usize = 4;
+
+    for (label, hash) in [
+        ("latest hash (mid-chain, as the frontend sends)", hash_3.clone()),
+        ("original Create hash", create_hash.clone()),
+        ("intermediate hash", hash_1.clone()),
+    ] {
+        let revisions: Vec<Record> = conductors[0]
+            .call(&alice.zome("administration"), "get_all_revisions_for_status", hash)
+            .await;
+
+        assert_eq!(
+            revisions.len(),
+            EXPECTED,
+            "reading the status history from the {} should return the full chain",
+            label
+        );
+    }
+}

--- a/ui/src/lib/stores/administration.store.svelte.ts
+++ b/ui/src/lib/stores/administration.store.svelte.ts
@@ -1580,23 +1580,14 @@ export const createAdministrationStore = (): E.Effect<
                     )
                 ),
                 E.flatMap((latestStatusRecord) => {
-                  // Find the original status action hash
-                  const findOriginalStatusHash = (record: HolochainRecord): ActionHash => {
-                    const action = record.signed_action.hashed.content;
-                    if (action.type === 'Update') {
-                      return action.original_action_address;
-                    } else {
-                      return record.signed_action.hashed.hash;
-                    }
-                  };
-
-                  const originalStatusHash = findOriginalStatusHash(latestStatusRecord);
+                  // The backend resolves any hash in the update chain back to the
+                  // original Create, so the latest record's own hash is enough.
+                  const originalStatusHash = latestStatusRecord.signed_action.hashed.hash;
                   console.log(
                     `🔍 Original status hash for ${entity.name}: ${originalStatusHash.toString().slice(0, 8)}`
                   );
 
                   return pipe(
-                    // Get all revisions from backend (may be incomplete due to backend limitation)
                     administrationService.getAllRevisionsForStatus(originalStatusHash),
                     E.tap((backendRecords) => {
                       console.log(
@@ -1659,8 +1650,7 @@ export const createAdministrationStore = (): E.Effect<
               AdministrationError.fromError(e, ERROR_CONTEXTS.GET_ALL_REVISIONS_FOR_STATUS)
             )
           );
-        }),
-        E.provideService(HolochainClientServiceTag, holochainClientService)
+        })
       );
 
     // ========================================================================

--- a/ui/src/routes/admin/organizations/status-history/+page.svelte
+++ b/ui/src/routes/admin/organizations/status-history/+page.svelte
@@ -1,33 +1,38 @@
 <script lang="ts">
   import StatusTable from '$lib/components/shared/status/StatusTable.svelte';
   import administrationStore from '$lib/stores/administration.store.svelte';
+  import { storeEventBus } from '$lib/stores/storeEvents';
   import { ConicGradient, type ConicStop } from '@skeletonlabs/skeleton';
   import { Effect as E } from 'effect';
+  import { onMount, onDestroy } from 'svelte';
 
   const { allOrganizationsStatusesHistory } = $derived(administrationStore);
   let isLoading = $state(true);
+
+  let unsubscribeOrgStatus: (() => void) | null = null;
 
   const conicStops: ConicStop[] = [
     { color: 'transparent', start: 0, end: 0 },
     { color: 'rgb(var(--color-secondary-500))', start: 75, end: 50 }
   ];
 
-  async function loadStatusHistory() {
-    try {
-      // If status history is empty, trigger a fetch
-      if (allOrganizationsStatusesHistory.length === 0) {
-        E.runFork(administrationStore.fetchAllOrganizationsStatusHistory());
-      }
-      console.log('Organizations status history:', allOrganizationsStatusesHistory);
-    } catch (error) {
-      console.error('Failed to load organizations status history:', error);
-    } finally {
-      isLoading = false;
-    }
+  function loadStatusHistory() {
+    E.runFork(administrationStore.fetchAllOrganizationsStatusHistory());
   }
 
-  $effect(() => {
+  onMount(() => {
+    // Refetch whenever an organisation status changes, so the table does not
+    // need a page refresh to show a new revision.
+    unsubscribeOrgStatus = storeEventBus.on('organization:status:updated', () => {
+      loadStatusHistory();
+    });
+
     loadStatusHistory();
+    isLoading = false;
+  });
+
+  onDestroy(() => {
+    if (unsubscribeOrgStatus) unsubscribeOrgStatus();
   });
 </script>
 

--- a/ui/src/routes/admin/users/status-history/+page.svelte
+++ b/ui/src/routes/admin/users/status-history/+page.svelte
@@ -23,8 +23,10 @@
     // Listen for organization status updates
     unsubscribeOrgStatus = storeEventBus.on('organization:status:updated', () => {
       console.log('🔄 TDD: Organization status updated - refreshing status history');
-      E.runFork(administrationStore.fetchAllUsersStatusHistory());
+      E.runFork(administrationStore.fetchAllOrganizationsStatusHistory());
     });
+
+    E.runFork(administrationStore.fetchAllUsersStatusHistory());
   });
 
   // Cleanup subscriptions
@@ -32,15 +34,6 @@
     console.log('🔄 TDD: Cleaning up status update event listeners');
     if (unsubscribeUserStatus) unsubscribeUserStatus();
     if (unsubscribeOrgStatus) unsubscribeOrgStatus();
-  });
-
-  // Initialize data fetch on mount
-  $effect(() => {
-    console.log('🔄 TDD: Users status history page mounted');
-
-    // Always fetch status history when page mounts to ensure fresh data
-    console.log('🔄 TDD: Triggering initial fetch...');
-    E.runFork(administrationStore.fetchAllUsersStatusHistory());
   });
 
   // Reactive effect to log changes in status history array


### PR DESCRIPTION
Closes #56.

Stacked on #184: the base is `fix/chain-root-identity`, and this rebases onto `dev` once #184 merges.

## What this delivers

**Regression test.** `status_history_resolves_from_any_hash_in_the_chain` builds a Create plus three updates, supplies a mid-chain hash, and reads the history from three points in the chain, expecting four records each time. The existing test in that file supplies the Create hash throughout; this one supplies a revision, so the resolution rule is what is under test.

**Write-path hardening.** `update_entity_status` resolves the StatusUpdates anchor with `find_original_action_hash(status_previous_action_hash)?`. Same source as #184, propagating rather than swallowing: a failed resolution on this write would otherwise anchor mid-chain permanently, where a failed read can retry.

**Client-side half of the rule.** `findOriginalStatusHash` is removed from the administration store. It read `Update.original_action_address`, which coincides with the Create for a single update and diverges from two. The hash of the latest record is passed and the backend resolves it. Also removes a `provideService` for `HolochainClientServiceTag` that satisfied a requirement this function does not have; every `AdministrationService` method declares `never` in its R channel.

**Status-history pages.** The organisations page subscribes to `organization:status:updated` and fetches from `onMount`, matching `ActionBar` and `UserDetailsModal`. The users page handler for that event now calls the organisations fetch.

## Verification

Full sweettest suite on #184 plus this branch: twelve of thirteen binaries green. The two failures in `service_types_status` reproduce on `dev` and are independent of both PRs; tracked separately.

The regression test also passes on #184 alone. The write-path hardening is not exercised by sweettest, which awaits consistency and so never produces the resolution failure it guards against.

`svelte-check`: 0 errors, 0 warnings. Manually tested before the rebase: four revisions displayed, updating without reload, on both Users and Organisations.

Two acceptance criteria are not met as written: testing in this repo is sweettest rather than Tryorama, and `bun run check` reports eslint errors that are identical on `dev`.
