### PR TITLE
feat(messaging): cross-agent signal substrate for chat and notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4695,6 +4695,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "messaging"
+version = "0.0.1"
+dependencies = [
+ "hdk",
+ "serde",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/dnas/requests_and_offers/workdir/dna.yaml
+++ b/dnas/requests_and_offers/workdir/dna.yaml
@@ -65,3 +65,7 @@ coordinator:
       path: "../../../target/wasm32-unknown-unknown/release/mediums_of_exchange.wasm"
       dependencies:
         - name: mediums_of_exchange_integrity
+    - name: messaging
+      hash: ~
+      path: "../../../target/wasm32-unknown-unknown/release/messaging.wasm"
+      dependencies: []

--- a/dnas/requests_and_offers/zomes/coordinator/messaging/Cargo.toml
+++ b/dnas/requests_and_offers/zomes/coordinator/messaging/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "messaging"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "messaging"
+
+[dependencies]
+hdk = { workspace = true }
+serde = { workspace = true }

--- a/dnas/requests_and_offers/zomes/coordinator/messaging/src/lib.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/messaging/src/lib.rs
@@ -1,0 +1,85 @@
+use hdk::prelude::*;
+use std::collections::HashSet;
+
+/// Input from this agent's own UI: send `content` on `stream_id` to `agents`.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SendMessageInput {
+    pub stream_id: String,
+    pub content: String,
+    pub agents: Vec<AgentPubKey>,
+}
+
+/// The payload that crosses the wire to another agent via a remote signal.
+/// For the substrate proof `content` is plaintext. Under the messaging design
+/// it will carry ciphertext (see the messaging architecture note, persist-and-
+/// signal lifecycle). Serde derives are sufficient for the extern and signal
+/// boundaries on hdk 0.6; SerializedBytes is not required (cf. the misc zome).
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Message {
+    pub stream_id: String,
+    pub content: String,
+}
+
+/// Signals emitted to this agent's own UI. A received remote signal becomes a
+/// `Signal::Message`; `from` is the sender, read from call provenance.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type")]
+pub enum Signal {
+    Message {
+        stream_id: String,
+        content: String,
+        from: AgentPubKey,
+    },
+}
+
+/// Grant any agent the right to call `recv_remote_signal` on this zome, which
+/// is what makes cross-agent delivery possible. `create_cap_grant` commits it
+/// as a Private entry on this agent's own source chain (verified in hdk 0.6.0
+/// capability.rs), so it is never gossiped.
+///
+/// The grant is Unrestricted by necessity: you cannot know your correspondents
+/// in advance. Filtering unsolicited or abusive signals is an application-layer
+/// concern, not a substrate one.
+#[hdk_extern]
+pub fn init(_: ()) -> ExternResult<InitCallbackResult> {
+    // GrantedFunctions::Listed takes a HashSet<(ZomeName, FunctionName)> in
+    // 0.6.0 (not the BTreeSet older references use). Type is inferred from the
+    // Listed(..) use below, so no explicit annotation is needed.
+    let mut fns = HashSet::new();
+    fns.insert((zome_info()?.name, "recv_remote_signal".into()));
+    let functions = GrantedFunctions::Listed(fns);
+    create_cap_grant(ZomeCallCapGrant {
+        tag: "".into(),
+        access: CapAccess::Unrestricted,
+        functions,
+    })?;
+    Ok(InitCallbackResult::Pass)
+}
+
+/// Called by this agent's own UI. Pushes `content` to each recipient's node via
+/// a remote signal. Delivery is best-effort and requires the recipient to be
+/// online; durability is added later, when messages are persisted as entries.
+#[hdk_extern]
+pub fn send_message(input: SendMessageInput) -> ExternResult<()> {
+    send_remote_signal(
+        Message {
+            stream_id: input.stream_id,
+            content: input.content,
+        },
+        input.agents,
+    )
+}
+
+/// Called remotely by a sending agent, permitted by the init cap grant.
+/// Re-emits the message to this agent's own UI, tagged with the sender.
+#[hdk_extern]
+pub fn recv_remote_signal(message: Message) -> ExternResult<()> {
+    let info = call_info()?;
+    let signal = Signal::Message {
+        stream_id: message.stream_id,
+        content: message.content,
+        from: info.provenance,
+    };
+    emit_signal(signal)
+}

--- a/dnas/requests_and_offers/zomes/coordinator/messaging/src/lib.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/messaging/src/lib.rs
@@ -41,6 +41,10 @@ pub enum Signal {
 /// The grant is Unrestricted by necessity: you cannot know your correspondents
 /// in advance. Filtering unsolicited or abusive signals is an application-layer
 /// concern, not a substrate one.
+///
+/// NOTE: init runs lazily, on a cell's first zome call. A recipient must have
+/// been called at least once (e.g. `ping`) before a remote signal will be
+/// authorised, otherwise the grant does not yet exist and the signal is dropped.
 #[hdk_extern]
 pub fn init(_: ()) -> ExternResult<InitCallbackResult> {
     // GrantedFunctions::Listed takes a HashSet<(ZomeName, FunctionName)> in
@@ -55,6 +59,14 @@ pub fn init(_: ()) -> ExternResult<InitCallbackResult> {
         functions,
     })?;
     Ok(InitCallbackResult::Pass)
+}
+
+/// Trivial health-check. Also serves to force `init` to run on a freshly
+/// installed cell, committing the cap grant so this agent can receive remote
+/// signals. Callers priming a recipient should call this before a signal is sent.
+#[hdk_extern]
+pub fn ping(_: ()) -> ExternResult<String> {
+    Ok("pong".to_string())
 }
 
 /// Called by this agent's own UI. Pushes `content` to each recipient's node via

--- a/tests/sweettest/Cargo.toml
+++ b/tests/sweettest/Cargo.toml
@@ -74,3 +74,7 @@ path = "tests/offers.rs"
 [[test]]
 name = "mediums_of_exchange"
 path = "tests/mediums_of_exchange.rs"
+
+[[test]]
+name = "messaging"
+path = "tests/messaging.rs"

--- a/tests/sweettest/tests/messaging.rs
+++ b/tests/sweettest/tests/messaging.rs
@@ -1,0 +1,113 @@
+//! Messaging zome substrate test.
+//!
+//! Proves the cross-agent signal path end to end: Alice calls `send_message`
+//! addressed to Bob, and Bob's conductor receives the emitted signal with the
+//! correct content and a `from` field set to Alice via call provenance.
+//!
+//! Both cells are primed with a `ping` call first, because `init` runs lazily
+//! on a cell's first zome call, and it is `init` that commits the cap grant
+//! authorising `recv_remote_signal`. Without priming Bob, his grant would not
+//! exist when Alice's signal arrives and it would be silently dropped.
+//!
+//! canonical `remote_signal_test` does); `RUST_LOG` alone is not enough.
+
+use holochain::prelude::*;
+use requests_and_offers_sweettest::common::*;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Mirror of the messaging zome's `SendMessageInput` (camelCase to match the zome).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SendMessageInput {
+    stream_id: String,
+    content: String,
+    agents: Vec<AgentPubKey>,
+}
+
+/// Mirror of the messaging zome's `Signal` (internally tagged on `type`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+enum MessagingSignal {
+    Message {
+        stream_id: String,
+        content: String,
+        from: AgentPubKey,
+    },
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn send_message_delivers_remote_signal_to_recipient() {
+    // Turn on conductor tracing so RUST_LOG=info actually surfaces logs.
+
+    let (conductors, alice, bob) = setup_two_agents().await;
+
+    // Prime both cells so their `init` runs and the cap grant for
+    // `recv_remote_signal` is committed before any signal is sent.
+    let alice_ping: String = conductors[0]
+        .call(&alice.zome("messaging"), "ping", ())
+        .await;
+    let bob_ping: String = conductors[1]
+        .call(&bob.zome("messaging"), "ping", ())
+        .await;
+    println!("PRIME: alice ping = {alice_ping:?}, bob ping = {bob_ping:?}");
+
+    // Give the cap grants and peer connections a moment to settle.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Subscribe Bob before Alice sends.
+    let mut bob_signals =
+        conductors[1].subscribe_to_app_signals("requests_and_offers".to_string());
+
+    let stream_id = "alice-bob".to_string();
+    let content = "hello bob".to_string();
+
+    println!("SEND: alice -> bob ({})", bob.agent_pubkey());
+    let _: () = conductors[0]
+        .call(
+            &alice.zome("messaging"),
+            "send_message",
+            SendMessageInput {
+                stream_id: stream_id.clone(),
+                content: content.clone(),
+                agents: vec![bob.agent_pubkey().clone()],
+            },
+        )
+        .await;
+    println!("SEND: send_message returned ok");
+
+    let received: MessagingSignal = tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            match bob_signals.recv().await.expect("Bob signal channel error") {
+                Signal::App { signal, .. } => {
+                    match signal.into_inner().decode::<MessagingSignal>() {
+                        Ok(msg) => {
+                            println!("RECV: bob decoded a MessagingSignal");
+                            break msg;
+                        }
+                        Err(e) => println!("RECV: bob got an app signal we could not decode: {e:?}"),
+                    }
+                }
+                other => println!("RECV: bob got a non-app signal: {other:?}"),
+            }
+        }
+    })
+    .await
+    .expect("Timed out waiting for Bob to receive the message signal");
+
+    match received {
+        MessagingSignal::Message {
+            stream_id: got_stream,
+            content: got_content,
+            from,
+        } => {
+            assert_eq!(got_stream, stream_id, "stream_id should round-trip");
+            assert_eq!(got_content, content, "content should round-trip");
+            assert_eq!(
+                &from,
+                alice.agent_pubkey(),
+                "sender should be Alice, taken from call provenance"
+            );
+        }
+    }
+}

--- a/tests/sweettest/tests/messaging.rs
+++ b/tests/sweettest/tests/messaging.rs
@@ -1,15 +1,18 @@
 //! Messaging zome substrate test.
 //!
-//! Proves the cross-agent signal path end to end: Alice calls `send_message`
-//! addressed to Bob, and Bob's conductor receives the emitted signal with the
-//! correct content and a `from` field set to Alice via call provenance.
+//! Proves cross-agent signal delivery end to end: Alice's `send_message` reaches
+//! Bob as a `Signal::Message` with the correct content and a `from` field set to
+//! Alice via call provenance. Two conductors are used so the signal genuinely
+//! crosses the network rather than short-circuiting within one node.
 //!
-//! Both cells are primed with a `ping` call first, because `init` runs lazily
-//! on a cell's first zome call, and it is `init` that commits the cap grant
+//! Both cells are primed with a `ping` call first, because `init` runs lazily on
+//! a cell's first zome call, and it is `init` that commits the cap grant
 //! authorising `recv_remote_signal`. Without priming Bob, his grant would not
 //! exist when Alice's signal arrives and it would be silently dropped.
 //!
-//! canonical `remote_signal_test` does); `RUST_LOG` alone is not enough.
+//! The zome's own `Signal` and `SendMessageInput` types cannot be imported
+//! (coordinator crates require a wasm target), so they are mirrored here with a
+//! matching serde shape, exactly as `common/mirrors.rs` does for entry types.
 
 use holochain::prelude::*;
 use requests_and_offers_sweettest::common::*;
@@ -38,21 +41,18 @@ enum MessagingSignal {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn send_message_delivers_remote_signal_to_recipient() {
-    // Turn on conductor tracing so RUST_LOG=info actually surfaces logs.
-
     let (conductors, alice, bob) = setup_two_agents().await;
 
     // Prime both cells so their `init` runs and the cap grant for
     // `recv_remote_signal` is committed before any signal is sent.
-    let alice_ping: String = conductors[0]
+    let _: String = conductors[0]
         .call(&alice.zome("messaging"), "ping", ())
         .await;
-    let bob_ping: String = conductors[1]
+    let _: String = conductors[1]
         .call(&bob.zome("messaging"), "ping", ())
         .await;
-    println!("PRIME: alice ping = {alice_ping:?}, bob ping = {bob_ping:?}");
 
-    // Give the cap grants and peer connections a moment to settle.
+    // Let the cap grants and peer connections settle.
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     // Subscribe Bob before Alice sends.
@@ -62,7 +62,6 @@ async fn send_message_delivers_remote_signal_to_recipient() {
     let stream_id = "alice-bob".to_string();
     let content = "hello bob".to_string();
 
-    println!("SEND: alice -> bob ({})", bob.agent_pubkey());
     let _: () = conductors[0]
         .call(
             &alice.zome("messaging"),
@@ -74,21 +73,20 @@ async fn send_message_delivers_remote_signal_to_recipient() {
             },
         )
         .await;
-    println!("SEND: send_message returned ok");
 
+    // Bob should receive the remote signal, decodable as our Message. The timeout
+    // turns a silent non-delivery into a loud failure rather than a hang.
     let received: MessagingSignal = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             match bob_signals.recv().await.expect("Bob signal channel error") {
                 Signal::App { signal, .. } => {
-                    match signal.into_inner().decode::<MessagingSignal>() {
-                        Ok(msg) => {
-                            println!("RECV: bob decoded a MessagingSignal");
-                            break msg;
-                        }
-                        Err(e) => println!("RECV: bob got an app signal we could not decode: {e:?}"),
+                    if let Ok(msg) = signal.into_inner().decode::<MessagingSignal>() {
+                        break msg;
                     }
+                    // Some other app-signal shape; keep waiting.
                 }
-                other => println!("RECV: bob got a non-app signal: {other:?}"),
+                // System signals are irrelevant here; keep waiting.
+                Signal::System(_) => {}
             }
         }
     })

--- a/workdir/dna.yaml
+++ b/workdir/dna.yaml
@@ -65,3 +65,7 @@ coordinator:
       path: "../target/wasm32-unknown-unknown/release/mediums_of_exchange.wasm"
       dependencies:
         - name: mediums_of_exchange_integrity
+    - name: messaging
+      hash: ~
+      path: "../target/wasm32-unknown-unknown/release/messaging.wasm"
+      dependencies: []


### PR DESCRIPTION
Adds the cross-agent signalling layer that #12 requires and that #91 (chat) and #51 (notifications) depend on.

Before this, the app had no cross-agent signalling at all: every coordinator zome only did local `post_commit` to `emit_signal`, a cache-invalidation bus for the agent's own UI. This adds the missing half.

## What it adds

- A coordinator-only `messaging` zome, mirroring the `misc` zome pattern. No integrity pair, since ephemeral signals are not entries.
- `init` commits an Unrestricted cap grant authorising `recv_remote_signal`.
- `send_message`, `recv_remote_signal`, a `ping` health-check, and a `Signal::Message` variant.
- Registration in both DNA manifests.
- A two-conductor Sweettest at `tests/sweettest/tests/messaging.rs` proving the signal crosses the network.

## Scope

Substrate only. It sends plaintext over an ephemeral signal; the persisted conversation layer is deliberately not here.

This PR carries no design argument. How conversations persist is settled separately in #188, which owns `documentation/architecture/chat-system.md`. Signals are how a peer learns something arrived, whichever way messages are stored, so this stands on its own either way.

## Relationship to #181

This supersedes #181, which is now closed. That PR carried nine documentation commits adopting membrane-isolated conversation clones as the design of record — a position #188 reverses. Merging it would have installed the superseded design into the architecture docs for #188 to then reverse. The six code commits here are cherry-picked from the same branch; the diff touches no documentation files.

## Verification

Rebased onto current `dev` and re-tested: `cargo test --test messaging` passes, 88s, two conductors.
