### PR TITLE
fix(#115): read the organisation back onto requests and offers

### DIFF
--- a/ui/src/lib/components/offers/OfferForm.svelte
+++ b/ui/src/lib/components/offers/OfferForm.svelte
@@ -14,6 +14,7 @@
   } from '$lib/types/holochain';
   import usersStore from '$lib/stores/users.store.svelte';
   import organizationsStore from '$lib/stores/organizations.store.svelte';
+  import { encodeHashToBase64 } from '@holochain/client';
   import { createMockedOffers } from '$lib/utils/mocks';
   import { shouldShowMockButtons } from '$lib/services/devFeatures.service';
   import TimeZoneSelect from '$lib/components/shared/TimeZoneSelect.svelte';
@@ -73,6 +74,18 @@
   let userCoordinatedOrganizations = $state<UIOrganization[]>([]);
   let isLoadingOrganizations = $state(true);
   let moesInitialized = $state(false);
+
+  // Derived state.
+  // ActionHash is a Uint8Array, so compare the encoded form rather than the
+  // object: two arrays holding the same bytes are not the same object.
+  const publishedOrganizationName = $derived.by(() => {
+    if (!selectedOrganizationHash) return undefined;
+    const target = encodeHashToBase64(selectedOrganizationHash);
+    const match = userCoordinatedOrganizations.find(
+      (org) => org.original_action_hash && encodeHashToBase64(org.original_action_hash) === target
+    );
+    return match?.name;
+  });
 
   // Handle timezone change
   function handleTimezoneChange(value: string | undefined) {
@@ -523,7 +536,21 @@
   <!-- Organization selection -->
   <label class="label">
     <span>Organization (optional)</span>
-    {#if isLoadingOrganizations}
+    {#if mode === 'edit'}
+      {#if isLoadingOrganizations}
+        <div class="flex items-center gap-2">
+          <span class="loading loading-spinner loading-sm"></span>
+          <span class="text-sm">Loading organizations...</span>
+        </div>
+      {:else}
+        <p class="text-sm">
+          {publishedOrganizationName ?? 'No organization'}
+        </p>
+      {/if}
+      <p class="text-surface-500 text-xs">
+        This cannot be changed after a listing is published.
+      </p>
+    {:else if isLoadingOrganizations}
       <div class="flex items-center gap-2">
         <span class="loading loading-spinner loading-sm"></span>
         <span class="text-sm">Loading organizations...</span>

--- a/ui/src/lib/components/offers/OfferForm.svelte
+++ b/ui/src/lib/components/offers/OfferForm.svelte
@@ -14,7 +14,6 @@
   } from '$lib/types/holochain';
   import usersStore from '$lib/stores/users.store.svelte';
   import organizationsStore from '$lib/stores/organizations.store.svelte';
-  import { encodeHashToBase64 } from '@holochain/client';
   import { createMockedOffers } from '$lib/utils/mocks';
   import { shouldShowMockButtons } from '$lib/services/devFeatures.service';
   import TimeZoneSelect from '$lib/components/shared/TimeZoneSelect.svelte';
@@ -72,20 +71,12 @@
   let pendingLink = $state('');
   let linksField: HTMLLabelElement | undefined = $state();
   let userCoordinatedOrganizations = $state<UIOrganization[]>([]);
+  let publishedOrganization = $state<UIOrganization | null>(null);
+  let isLoadingPublishedOrganization = $state(mode === 'edit');
   let isLoadingOrganizations = $state(true);
   let moesInitialized = $state(false);
 
-  // Derived state.
-  // ActionHash is a Uint8Array, so compare the encoded form rather than the
-  // object: two arrays holding the same bytes are not the same object.
-  const publishedOrganizationName = $derived.by(() => {
-    if (!selectedOrganizationHash) return undefined;
-    const target = encodeHashToBase64(selectedOrganizationHash);
-    const match = userCoordinatedOrganizations.find(
-      (org) => org.original_action_hash && encodeHashToBase64(org.original_action_hash) === target
-    );
-    return match?.name;
-  });
+  const publishedOrganizationName = $derived(publishedOrganization?.name);
 
   // Handle timezone change
   function handleTimezoneChange(value: string | undefined) {
@@ -100,6 +91,7 @@
   // Load user's coordinated organizations and MoEs immediately
   $effect(() => {
     loadCoordinatedOrganizations();
+    loadPublishedOrganization();
     loadMediumsOfExchange();
   });
 
@@ -124,6 +116,21 @@
       (moe) => moe.exchange_type === 'currency'
     );
   });
+
+  // In edit mode the listing may belong to an organization the viewer does
+  // not coordinate, so resolve it by hash rather than from the coordinated list.
+  async function loadPublishedOrganization() {
+    try {
+      if (mode !== 'edit' || !selectedOrganizationHash) return;
+      publishedOrganization = await runEffect(
+        organizationsStore.getOrganizationByActionHash(selectedOrganizationHash)
+      );
+    } catch (error) {
+      console.error('Error loading published organization:', error);
+    } finally {
+      isLoadingPublishedOrganization = false;
+    }
+  }
 
   async function loadCoordinatedOrganizations() {
     try {
@@ -537,7 +544,7 @@
   <label class="label">
     <span>Organization (optional)</span>
     {#if mode === 'edit'}
-      {#if isLoadingOrganizations}
+      {#if isLoadingPublishedOrganization}
         <div class="flex items-center gap-2">
           <span class="loading loading-spinner loading-sm"></span>
           <span class="text-sm">Loading organizations...</span>

--- a/ui/src/lib/components/requests/RequestForm.svelte
+++ b/ui/src/lib/components/requests/RequestForm.svelte
@@ -15,7 +15,6 @@
   } from '$lib/types/holochain';
   import usersStore from '$lib/stores/users.store.svelte';
   import organizationsStore from '$lib/stores/organizations.store.svelte';
-  import { encodeHashToBase64 } from '@holochain/client';
   import { createMockedRequests } from '$lib/utils/mocks';
   import { shouldShowMockButtons } from '$lib/services/devFeatures.service';
   import TimeZoneSelect from '$lib/components/shared/TimeZoneSelect.svelte';
@@ -90,20 +89,12 @@
   let pendingLink = $state('');
   let linksField: HTMLLabelElement | undefined = $state();
   let userCoordinatedOrganizations = $state<UIOrganization[]>([]);
+  let publishedOrganization = $state<UIOrganization | null>(null);
+  let isLoadingPublishedOrganization = $state(mode === 'edit');
   let isLoadingOrganizations = $state(true);
   let moesInitialized = $state(false);
 
-  // Derived state.
-  // ActionHash is a Uint8Array, so compare the encoded form rather than the
-  // object: two arrays holding the same bytes are not the same object.
-  const publishedOrganizationName = $derived.by(() => {
-    if (!selectedOrganizationHash) return undefined;
-    const target = encodeHashToBase64(selectedOrganizationHash);
-    const match = userCoordinatedOrganizations.find(
-      (org) => org.original_action_hash && encodeHashToBase64(org.original_action_hash) === target
-    );
-    return match?.name;
-  });
+  const publishedOrganizationName = $derived(publishedOrganization?.name);
 
   // Handle timezone change
   function handleTimezoneChange(value: string | undefined) {
@@ -118,6 +109,7 @@
   // Load user's coordinated organizations and MoEs immediately
   $effect(() => {
     loadCoordinatedOrganizations();
+    loadPublishedOrganization();
     loadMediumsOfExchange();
   });
 
@@ -141,6 +133,21 @@
       (moe) => moe.exchange_type === 'currency'
     );
   });
+
+  // In edit mode the listing may belong to an organization the viewer does
+  // not coordinate, so resolve it by hash rather than from the coordinated list.
+  async function loadPublishedOrganization() {
+    try {
+      if (mode !== 'edit' || !selectedOrganizationHash) return;
+      publishedOrganization = await E.runPromise(
+        organizationsStore.getOrganizationByActionHash(selectedOrganizationHash)
+      );
+    } catch (error) {
+      console.error('Error loading published organization:', error);
+    } finally {
+      isLoadingPublishedOrganization = false;
+    }
+  }
 
   async function loadCoordinatedOrganizations() {
     try {
@@ -625,7 +632,7 @@
     <label class="label">
       <span>Organization (optional)</span>
       {#if mode === 'edit'}
-        {#if isLoadingOrganizations}
+        {#if isLoadingPublishedOrganization}
           <div class="flex items-center gap-2">
             <span class="loading loading-spinner loading-sm"></span>
             <span class="text-sm">Loading organizations...</span>

--- a/ui/src/lib/components/requests/RequestForm.svelte
+++ b/ui/src/lib/components/requests/RequestForm.svelte
@@ -15,6 +15,7 @@
   } from '$lib/types/holochain';
   import usersStore from '$lib/stores/users.store.svelte';
   import organizationsStore from '$lib/stores/organizations.store.svelte';
+  import { encodeHashToBase64 } from '@holochain/client';
   import { createMockedRequests } from '$lib/utils/mocks';
   import { shouldShowMockButtons } from '$lib/services/devFeatures.service';
   import TimeZoneSelect from '$lib/components/shared/TimeZoneSelect.svelte';
@@ -91,6 +92,18 @@
   let userCoordinatedOrganizations = $state<UIOrganization[]>([]);
   let isLoadingOrganizations = $state(true);
   let moesInitialized = $state(false);
+
+  // Derived state.
+  // ActionHash is a Uint8Array, so compare the encoded form rather than the
+  // object: two arrays holding the same bytes are not the same object.
+  const publishedOrganizationName = $derived.by(() => {
+    if (!selectedOrganizationHash) return undefined;
+    const target = encodeHashToBase64(selectedOrganizationHash);
+    const match = userCoordinatedOrganizations.find(
+      (org) => org.original_action_hash && encodeHashToBase64(org.original_action_hash) === target
+    );
+    return match?.name;
+  });
 
   // Handle timezone change
   function handleTimezoneChange(value: string | undefined) {
@@ -611,7 +624,21 @@
   <div class="flex flex-col">
     <label class="label">
       <span>Organization (optional)</span>
-      {#if isLoadingOrganizations}
+      {#if mode === 'edit'}
+        {#if isLoadingOrganizations}
+          <div class="flex items-center gap-2">
+            <span class="loading loading-spinner loading-sm"></span>
+            <span class="text-sm">Loading organizations...</span>
+          </div>
+        {:else}
+          <p class="text-sm">
+            {publishedOrganizationName ?? 'No organization'}
+          </p>
+        {/if}
+        <p class="text-surface-500 text-xs">
+          This cannot be changed after a listing is published.
+        </p>
+      {:else if isLoadingOrganizations}
         <div class="flex items-center gap-2">
           <span class="loading loading-spinner loading-sm"></span>
           <span class="text-sm">Loading organizations...</span>

--- a/ui/src/lib/services/zomes/requests.service.ts
+++ b/ui/src/lib/services/zomes/requests.service.ts
@@ -50,6 +50,9 @@ export interface RequestsService {
   readonly getMediumsOfExchangeForRequest: (
     requestHash: ActionHash
   ) => E.Effect<ActionHash[], RequestError>;
+  readonly getRequestOrganization: (
+    requestHash: ActionHash
+  ) => E.Effect<ActionHash | null, RequestError>;
 }
 
 export class RequestsServiceTag extends Context.Tag('RequestsService')<
@@ -188,6 +191,11 @@ export const RequestsServiceLive: Layer.Layer<
         entity: 'request'
       });
 
+    const getRequestOrganization = (
+      requestHash: ActionHash
+    ): E.Effect<ActionHash | null, RequestError> =>
+      wrapZomeCall('requests', 'get_request_organization', requestHash);
+
     return RequestsServiceTag.of({
       createRequest,
       getLatestRequestRecord,
@@ -204,7 +212,8 @@ export const RequestsServiceLive: Layer.Layer<
       getMyListings,
       getRequestsByTag,
       getServiceTypesForRequest,
-      getMediumsOfExchangeForRequest
+      getMediumsOfExchangeForRequest,
+      getRequestOrganization
     });
   })
 );

--- a/ui/src/lib/stores/offers.store.svelte.ts
+++ b/ui/src/lib/stores/offers.store.svelte.ts
@@ -166,15 +166,19 @@ const createEnhancedUIOffer = (
       mediumOfExchangeHashes: pipe(
         offersService.getMediumsOfExchangeForOffer(offerHash),
         E.orElse(() => E.succeed([] as ActionHash[]))
+      ),
+      organization: pipe(
+        offersService.getOfferOrganization(offerHash),
+        E.orElse(() => E.succeed(null))
       )
     }),
-    E.flatMap(({ userProfile, serviceTypeHashes, mediumOfExchangeHashes }) => {
+    E.flatMap(({ userProfile, serviceTypeHashes, mediumOfExchangeHashes, organization }) => {
       const additionalData = {
         serviceTypeHashes,
         mediumOfExchangeHashes,
         creator: userProfile?.original_action_hash, // Only set if user profile exists
         authorPubKey, // Keep AgentPubKey separately for fallback comparison
-        organization: undefined // No organization support yet in this simplified flow
+        organization: organization ?? undefined
       };
 
       const entity = createUIOffer(record, additionalData);

--- a/ui/src/lib/stores/offers.store.svelte.ts
+++ b/ui/src/lib/stores/offers.store.svelte.ts
@@ -167,6 +167,8 @@ const createEnhancedUIOffer = (
         offersService.getMediumsOfExchangeForOffer(offerHash),
         E.orElse(() => E.succeed([] as ActionHash[]))
       ),
+      // A failed read shows as no organization, matching the fallbacks above.
+      // Deliberate on this read path: the listing still renders without it.
       organization: pipe(
         offersService.getOfferOrganization(offerHash),
         E.orElse(() => E.succeed(null))

--- a/ui/src/lib/stores/requests.store.svelte.ts
+++ b/ui/src/lib/stores/requests.store.svelte.ts
@@ -175,6 +175,8 @@ const processRecord = (
         requestsService.getMediumsOfExchangeForRequest(requestHash),
         E.orElse(() => E.succeed([] as ActionHash[]))
       ),
+      // A failed read shows as no organization, matching the fallbacks above.
+      // Deliberate on this read path: the listing still renders without it.
       organization: pipe(
         requestsService.getRequestOrganization(requestHash),
         E.orElse(() => E.succeed(null))

--- a/ui/src/lib/stores/requests.store.svelte.ts
+++ b/ui/src/lib/stores/requests.store.svelte.ts
@@ -174,22 +174,27 @@ const processRecord = (
       mediumOfExchangeHashes: pipe(
         requestsService.getMediumsOfExchangeForRequest(requestHash),
         E.orElse(() => E.succeed([] as ActionHash[]))
+      ),
+      organization: pipe(
+        requestsService.getRequestOrganization(requestHash),
+        E.orElse(() => E.succeed(null))
       )
     }),
-    E.flatMap(({ userProfile, serviceTypeHashes, mediumOfExchangeHashes }) =>
+    E.flatMap(({ userProfile, serviceTypeHashes, mediumOfExchangeHashes, organization }) =>
       E.succeed({
         userProfile: userProfile,
         serviceTypeHashes,
-        mediumOfExchangeHashes
+        mediumOfExchangeHashes,
+        organization
       })
     ),
-    E.flatMap(({ userProfile, serviceTypeHashes, mediumOfExchangeHashes }) => {
+    E.flatMap(({ userProfile, serviceTypeHashes, mediumOfExchangeHashes, organization }) => {
       const additionalData = {
         serviceTypeHashes,
         mediumOfExchangeHashes,
         creator: userProfile?.original_action_hash, // Only set if user profile exists
         authorPubKey, // Keep AgentPubKey separately for fallback comparison
-        organization: undefined // No organization support yet in this simplified flow
+        organization: organization ?? undefined
       };
 
       const entity = createUIRequest(record, additionalData);

--- a/ui/tests/mocks/services.mock.ts
+++ b/ui/tests/mocks/services.mock.ts
@@ -154,7 +154,8 @@ export const createMockRequestsServiceLayer = async (): Promise<
     getMyListings: vi.fn().mockReturnValue(E.succeed([mockRecord])),
     getRequestsByTag: vi.fn().mockReturnValue(E.succeed([mockRecord])),
     getServiceTypesForRequest: vi.fn().mockReturnValue(E.succeed([])),
-    getMediumsOfExchangeForRequest: vi.fn().mockReturnValue(E.succeed([]))
+    getMediumsOfExchangeForRequest: vi.fn().mockReturnValue(E.succeed([])),
+    getRequestOrganization: vi.fn().mockReturnValue(E.succeed(null))
   };
 
   return Layer.succeed(RequestsServiceTag, mockRequestsService);


### PR DESCRIPTION
Fixes #115.

## What was wrong

`create_request` and `create_offer` build bidirectional `OrganizationRequests` and `RequestOrganization` links, and both zomes expose a read endpoint for them: `get_request_organization` and `get_offer_organization`.

Neither was ever called. `processRecord` in both stores fetched the creator, service types and mediums of exchange, then hardcoded the organisation as `undefined`, with a comment saying organisation was not supported yet in that flow.

So the chosen organisation was written to the DHT correctly and the UI simply never asked for it. Editing and reloading did not help because nothing on the read path had ever looked.

## Changes

Requests needed `getRequestOrganization` adding to the service, following the shape of `getOrganizationRequestsRecords`. Offers already had `getOfferOrganization` declared, implemented and exported, with nothing calling it.

Both stores now fetch it alongside the other lookups in `processRecord` and fall back to `null` on failure, matching how the neighbouring calls tolerate absence.

## Not fixed here

Neither `UpdateRequestInput` nor its offers equivalent has an organisation field, in the zome struct as well as the client, so an organisation cannot be changed after a listing is created. Fixing that means a zome signature change plus link rotation on update, and a product decision about whether reassignment should be allowed at all. Raised separately rather than folded in here.

This is also part of what #133 reports. That issue describes both Links and Organization clearing on edit; the organisation half is the update-path gap above, and the links half has a different cause again, since `links` is already in the update payload.

## Verification

- `svelte-check`: 0 errors, 0 warnings across the project
- Tested in the running app with two agents: created an organisation, created a request on its behalf, and the organisation shows on the listing in both agents runtimes and persists across reloads


## After review

**Note 1, fixed here.** `publishedOrganizationName` looked the name up in `userCoordinatedOrganizations`, the create-mode list of organisations the viewer may publish under, so a listing under any other organisation showed "No organization" with the hash still correct. The form now resolves the published organisation by hash through `getOrganizationByActionHash`, cache then DHT with no coordination filter, and the edit-mode spinner waits on that load rather than on the coordinated list. Checked with two agents in the running app: the name resolves for the author, and the administrator case turns out to be unreachable through the UI since there is no path to another member's edit page, and an organisation has a single coordinator with no way to lapse, so the other case cannot arise either. The fix is therefore defensive: the name is resolved from the listing itself rather than from who is viewing, so it stays correct if either constraint changes.

**Note 2, commented.** Both stores now say the `E.orElse` fallback to null on the organisation read is deliberate and matches its neighbours.

**Mock repair.** `getRequestOrganization` was missing from the shared services mock; stubbed, and the wider pattern is #235.

Rebased onto dev after #216 landed in the same two forms; merged clean. svelte-check 0 errors 0 warnings, offers and requests e2e specs 14 passed.

