### PR TITLE
fix(#138): report network reachability, not conductor liveness

### DIFF
--- a/ui/src/lib/components/network/NetworkStatusPopup.svelte
+++ b/ui/src/lib/components/network/NetworkStatusPopup.svelte
@@ -39,6 +39,9 @@
   );
   const finalLastPingTime = $derived(lastPingTime ?? connectionContext?.lastPingTime() ?? null);
   const finalPingError = $derived(pingError ?? connectionContext?.pingError?.() ?? null);
+  const conductorStatus = $derived(connectionContext?.conductorStatus?.() ?? 'connected');
+  const peersReachable = $derived(connectionContext?.peersReachable?.() ?? 0);
+  const peersKnown = $derived(connectionContext?.peersKnown?.() ?? null);
   const finalNetworkSeed = $derived(networkSeed ?? connectionContext?.networkSeed?.() ?? null);
   const finalNetworkInfo = $derived(networkInfo ?? connectionContext?.networkInfo?.() ?? null);
 
@@ -67,6 +70,10 @@
         return 'Checking...';
       case 'disconnected':
         return 'Disconnected';
+      case 'alone':
+        return 'Online, no peers';
+      case 'offline':
+        return 'Offline';
       case 'error':
         return 'Error';
       default:
@@ -114,6 +121,12 @@
     if (status === 'connected' && finalLastPingTime) {
       const timeStr = finalLastPingTime.toLocaleTimeString();
       lines.push(`${baseText} (verified at ${timeStr})`);
+      lines.push(
+        peersKnown === null
+          ? `Peers: ${peersReachable} reachable`
+          : `Peers: ${peersReachable} of ${peersKnown} reachable`
+      );
+      lines.push(`Conductor: ${conductorStatus}`);
 
       // Add network seed information if available
       if (finalNetworkSeed) {
@@ -129,6 +142,20 @@
       lines.push(`🌐 Bootstrap Server: ${networkConfig.bootstrapUrl}`);
       lines.push(`📡 Signal Server: ${networkConfig.signalUrl}`);
 
+      return lines;
+    }
+
+    if (status === 'alone') {
+      lines.push(`${baseText}`);
+      lines.push(`You can reach the network, but no other peers are online right now.`);
+      lines.push(`Conductor: ${conductorStatus}`);
+      return lines;
+    }
+
+    if (status === 'offline') {
+      lines.push(`${baseText}`);
+      lines.push(`No route to the network. Your local data is still available.`);
+      lines.push(`Conductor: ${conductorStatus}`);
       return lines;
     }
 

--- a/ui/src/lib/components/shared/NavBar.svelte
+++ b/ui/src/lib/components/shared/NavBar.svelte
@@ -120,6 +120,10 @@
         return '🟡';
       case 'disconnected':
         return '🟠';
+      case 'alone':
+        return '🟡';
+      case 'offline':
+        return '🔴';
       case 'error':
         return '🔴';
       default:
@@ -135,6 +139,10 @@
         return 'Checking...';
       case 'disconnected':
         return 'Disconnected';
+      case 'alone':
+        return 'Online, no peers';
+      case 'offline':
+        return 'Offline';
       case 'error':
         return 'Error';
       default:

--- a/ui/src/lib/context/connection-status.context.svelte.ts
+++ b/ui/src/lib/context/connection-status.context.svelte.ts
@@ -3,11 +3,20 @@ import { getContext, setContext } from 'svelte';
 /**
  * Connection status context for sharing connection state across layouts
  */
-export type ConnectionStatus = 'checking' | 'connected' | 'disconnected' | 'error';
+export type ConnectionStatus =
+  | 'checking'
+  | 'connected'
+  | 'alone'
+  | 'offline'
+  | 'disconnected'
+  | 'error';
 export type AdminLoadingStatus = 'pending' | 'loading' | 'loaded' | 'failed';
 
 export interface ConnectionStatusContext {
   connectionStatus: () => ConnectionStatus;
+  conductorStatus?: () => 'connected' | 'disconnected';
+  peersReachable?: () => number;
+  peersKnown?: () => number | null;
   lastPingTime: () => Date | null;
   pingError: () => string | null;
   adminLoadingStatus?: () => AdminLoadingStatus;

--- a/ui/src/lib/errors/error-contexts.ts
+++ b/ui/src/lib/errors/error-contexts.ts
@@ -196,6 +196,8 @@ export const MEDIUM_OF_EXCHANGE_CONTEXTS = {
 // Holochain client contexts
 export const HOLOCHAIN_CLIENT_CONTEXTS = {
   CONNECT: 'Failed to connect to Holochain',
+  CONNECTION_TIMEOUT: 'Timed out waiting for the Holochain connection',
+  CONNECTION_FAILED: 'Holochain connection attempt failed',
   CALL_ZOME: 'Failed to call zome function',
   GET_DNA_INFO: 'Failed to get DNA info',
   GET_AGENT_INFO: 'Failed to get agent info',

--- a/ui/src/lib/services/HolochainClientService.svelte.ts
+++ b/ui/src/lib/services/HolochainClientService.svelte.ts
@@ -6,6 +6,8 @@ import {
   type PeerMetaInfoResponse
 } from '@holochain/client';
 import { countKnownPeers } from '$lib/utils/network-status';
+import { HolochainClientError } from '$lib/errors/holochain-client.errors';
+import { HOLOCHAIN_CLIENT_CONTEXTS } from '$lib/errors/error-contexts';
 import { Context, Layer } from 'effect';
 import weaveStore from '$lib/stores/weave.store.svelte';
 
@@ -51,7 +53,7 @@ export interface HolochainClientService {
   readonly isConnecting: boolean;
 
   connectClient(): Promise<void>;
-  waitForConnection(): Promise<void>;
+  waitForConnection(timeoutMs?: number): Promise<void>;
 
   getAppInfo(): Promise<AppInfoResponse>;
   getPeerMetaInfo(): Promise<PeerMetaInfoResponse>;
@@ -190,22 +192,54 @@ function createHolochainClientService(): HolochainClientService {
   }
 
   /**
-   * Waits for the client to be connected before proceeding.
-   * If not connected, will attempt to establish a connection.
+   * Waits for the client to be connected, starting a connection if none is in
+   * flight. Rejects with a HolochainClientError whose context is
+   * CONNECTION_TIMEOUT once timeoutMs has elapsed, or CONNECTION_FAILED when an
+   * attempt ends without a connection, so a caller can tell slow from failed.
    */
-  async function waitForConnection(): Promise<void> {
+  async function waitForConnection(timeoutMs = 60_000): Promise<void> {
     if (isConnected) return;
 
+    const deadline = Date.now() + timeoutMs;
+    const timeoutError = () =>
+      HolochainClientError.create(
+        HOLOCHAIN_CLIENT_CONTEXTS.CONNECTION_TIMEOUT,
+        HOLOCHAIN_CLIENT_CONTEXTS.CONNECTION_TIMEOUT,
+        'waitForConnection'
+      );
+
     if (isConnecting) {
-      // Wait for existing connection to complete
       while (isConnecting) {
+        if (Date.now() >= deadline) throw timeoutError();
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
       if (isConnected) return;
+      throw HolochainClientError.create(
+        HOLOCHAIN_CLIENT_CONTEXTS.CONNECTION_FAILED,
+        HOLOCHAIN_CLIENT_CONTEXTS.CONNECTION_FAILED,
+        'waitForConnection'
+      );
     }
 
-    if (!isConnected) {
-      await connectClient();
+    // If the deadline wins, the attempt keeps running in the background and
+    // the next caller reads its outcome from the state flags.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const expiry = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(timeoutError()), Math.max(0, deadline - Date.now()));
+    });
+    const attempt = connectClient();
+    attempt.catch(() => undefined);
+    try {
+      await Promise.race([attempt, expiry]);
+    } catch (error) {
+      if (error instanceof HolochainClientError) throw error;
+      throw HolochainClientError.fromError(
+        error,
+        HOLOCHAIN_CLIENT_CONTEXTS.CONNECTION_FAILED,
+        'waitForConnection'
+      );
+    } finally {
+      clearTimeout(timer);
     }
   }
 

--- a/ui/src/lib/services/HolochainClientService.svelte.ts
+++ b/ui/src/lib/services/HolochainClientService.svelte.ts
@@ -5,6 +5,7 @@ import {
   AppWebsocket,
   type PeerMetaInfoResponse
 } from '@holochain/client';
+import { countKnownPeers } from '$lib/utils/network-status';
 import { Context, Layer } from 'effect';
 import weaveStore from '$lib/stores/weave.store.svelte';
 
@@ -30,14 +31,15 @@ export interface NetworkInfo {
 /**
  * What the conductor can see of the network right now.
  *
- * hasRoute: this node has at least one URL it can be reached at. The signal
- *   server provides these, so false means no route to the network at all.
  * reachable: live transport connections to other peers.
- * known: peers this node has heard of via gossip, excluding itself. Null when
+ * known: distinct other agents this node has heard of via gossip. Null when
  *   the client is not an AppWebsocket, since agentInfo is not on AppClient.
+ *
+ * Whether the machine has a network at all is not the conductor's to say: its
+ * view of its own reachable addresses is cached, not live. Callers should read
+ * navigator.onLine for that.
  */
 export interface NetworkPeerStatus {
-  hasRoute: boolean;
   reachable: number;
   known: number | null;
 }
@@ -280,7 +282,6 @@ function createHolochainClientService(): HolochainClientService {
     }
 
     const stats = await client.dumpNetworkStats();
-    const hasRoute = stats.peer_urls.length > 0;
     const reachable = stats.connections.length;
 
     // agentInfo is only on AppWebsocket, not the generic AppClient interface.
@@ -288,11 +289,10 @@ function createHolochainClientService(): HolochainClientService {
     let known: number | null = null;
     if (client instanceof AppWebsocket) {
       const agentInfos = await client.agentInfo({ dna_hashes: null });
-      // The list includes this node's own agent.
-      known = Math.max(0, agentInfos.length - 1);
+      known = countKnownPeers(agentInfos);
     }
 
-    return { hasRoute, reachable, known };
+    return { reachable, known };
   }
 
   async function getPeerMetaInfo(): Promise<PeerMetaInfoResponse> {

--- a/ui/src/lib/services/HolochainClientService.svelte.ts
+++ b/ui/src/lib/services/HolochainClientService.svelte.ts
@@ -27,6 +27,21 @@ export interface NetworkInfo {
   roleName: string;
 }
 
+/**
+ * What the conductor can see of the network right now.
+ *
+ * hasRoute: this node has at least one URL it can be reached at. The signal
+ *   server provides these, so false means no route to the network at all.
+ * reachable: live transport connections to other peers.
+ * known: peers this node has heard of via gossip, excluding itself. Null when
+ *   the client is not an AppWebsocket, since agentInfo is not on AppClient.
+ */
+export interface NetworkPeerStatus {
+  hasRoute: boolean;
+  reachable: number;
+  known: number | null;
+}
+
 export interface HolochainClientService {
   readonly appId: string;
   readonly client: AppClient | null;
@@ -38,6 +53,7 @@ export interface HolochainClientService {
 
   getAppInfo(): Promise<AppInfoResponse>;
   getPeerMetaInfo(): Promise<PeerMetaInfoResponse>;
+  getNetworkPeerStatus(): Promise<NetworkPeerStatus>;
 
   callZome(
     zomeName: ZomeName,
@@ -258,6 +274,27 @@ function createHolochainClientService(): HolochainClientService {
     })) as NetworkInfo;
   }
 
+  async function getNetworkPeerStatus(): Promise<NetworkPeerStatus> {
+    if (!client) {
+      throw new Error('Client not connected');
+    }
+
+    const stats = await client.dumpNetworkStats();
+    const hasRoute = stats.peer_urls.length > 0;
+    const reachable = stats.connections.length;
+
+    // agentInfo is only on AppWebsocket, not the generic AppClient interface.
+    // In Weave the frame shows network state itself, so unknown is acceptable.
+    let known: number | null = null;
+    if (client instanceof AppWebsocket) {
+      const agentInfos = await client.agentInfo({ dna_hashes: null });
+      // The list includes this node's own agent.
+      known = Math.max(0, agentInfos.length - 1);
+    }
+
+    return { hasRoute, reachable, known };
+  }
+
   async function getPeerMetaInfo(): Promise<PeerMetaInfoResponse> {
     if (!client) {
       throw new Error('Client not connected');
@@ -439,6 +476,7 @@ function createHolochainClientService(): HolochainClientService {
     waitForConnection,
     getAppInfo,
     getPeerMetaInfo,
+    getNetworkPeerStatus,
     callZome,
     verifyConnection,
     getNetworkSeed,

--- a/ui/src/lib/utils/network-status.ts
+++ b/ui/src/lib/utils/network-status.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure helpers for turning conductor network data into a connection state.
+ *
+ * Kept free of Svelte and Holochain client imports so they can be unit
+ * tested without mocking either.
+ */
+
+export type NetworkConnectionState = 'offline' | 'alone' | 'connected';
+
+export interface NetworkSignals {
+  /** What the OS reports. navigator.onLine in a browser or Electron. */
+  online: boolean;
+  /** Live transport connections to other peers, from dumpNetworkStats. */
+  reachable: number;
+}
+
+/**
+ * Derive the headline state.
+ *
+ * offline: the OS says there is no network. Nothing else matters.
+ * alone: online, but no other peer is reachable right now.
+ * connected: at least one peer reachable.
+ *
+ * The conductor cannot tell us it is isolated: its own view of its reachable
+ * addresses is cached, not live. The OS can, so that is the source for offline.
+ */
+export function deriveConnectionStatus(signals: NetworkSignals): NetworkConnectionState {
+  if (signals.online === false) return 'offline';
+  if (signals.reachable <= 0) return 'alone';
+  return 'connected';
+}
+
+/** Shape of the inner JSON in each agentInfo string from the conductor. */
+export interface ParsedAgentInfo {
+  agent?: string;
+  space?: string;
+  expiresAt?: string;
+  isTombstone?: boolean;
+}
+
+/**
+ * Parse one agentInfo string. The conductor returns each as JSON whose
+ * agentInfo field is itself a JSON string. Returns null on anything malformed.
+ */
+export function parseAgentInfo(raw: string): ParsedAgentInfo | null {
+  try {
+    const outer = JSON.parse(raw);
+    const inner = typeof outer?.agentInfo === 'string' ? JSON.parse(outer.agentInfo) : outer;
+    if (inner === null || typeof inner !== 'object') return null;
+    return inner as ParsedAgentInfo;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Count other peers this node knows about.
+ *
+ * The list from agentInfo has one entry per agent per DNA, so a two-agent app
+ * with two DNAs yields four entries. Deduplicating by agent key gives the
+ * number of distinct agents regardless of how many DNAs they appear in.
+ * Tombstoned and expired entries are agents that have left, so they are
+ * dropped. The local agent is always present once, hence the subtraction.
+ */
+export function countKnownPeers(rawAgentInfos: string[], now: Date = new Date()): number {
+  const agents = new Set<string>();
+  const nowMs = now.getTime();
+
+  for (const raw of rawAgentInfos) {
+    const info = parseAgentInfo(raw);
+    if (info === null || typeof info.agent !== 'string') continue;
+    if (info.isTombstone === true) continue;
+    if (typeof info.expiresAt === 'string') {
+      const expires = Number(info.expiresAt);
+      // Kitsune2 timestamps are microseconds; treat as expired if in the past.
+      if (Number.isFinite(expires) && expires / 1000 < nowMs) continue;
+    }
+    agents.add(info.agent);
+  }
+
+  return Math.max(0, agents.size - 1);
+}

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -26,6 +26,7 @@
   import NavBar from '$lib/components/shared/NavBar.svelte';
   import { setConnectionStatusContext } from '$lib/context/connection-status.context.svelte';
   import { connectToHolochain, isHolochainConnected } from '$lib/utils/holochain-client.utils';
+  import { deriveConnectionStatus } from '$lib/utils/network-status';
   import { runEffect } from '$lib/utils/effect';
   import { getCounterpartRoute } from '$lib/services/navigation.utils';
   import { initializeToast } from '@/lib/utils/toast';
@@ -363,13 +364,10 @@
       const status = await hc.getNetworkPeerStatus();
       peersReachable = status.reachable;
       peersKnown = status.known;
-      if (!status.hasRoute) {
-        connectionStatus = 'offline';
-      } else if (status.reachable === 0) {
-        connectionStatus = 'alone';
-      } else {
-        connectionStatus = 'connected';
-      }
+      connectionStatus = deriveConnectionStatus({
+        online: navigator.onLine,
+        reachable: status.reachable
+      });
       lastPingTime = new Date();
       pingError = null;
     } catch (error) {
@@ -386,7 +384,14 @@
     }
     pollNetworkStatus();
     const interval = setInterval(pollNetworkStatus, 15000);
-    return () => clearInterval(interval);
+    // The OS tells us straight away when the network comes or goes.
+    window.addEventListener('online', pollNetworkStatus);
+    window.addEventListener('offline', pollNetworkStatus);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener('online', pollNetworkStatus);
+      window.removeEventListener('offline', pollNetworkStatus);
+    };
   });
 </script>
 

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -45,9 +45,12 @@
   let connectionError = $state<string | null>(null);
 
   // Connection status tracking
-  let connectionStatus = $state<'disconnected' | 'checking' | 'connected' | 'error'>(
-    'disconnected'
-  );
+  let connectionStatus = $state<
+    'disconnected' | 'checking' | 'connected' | 'alone' | 'offline' | 'error'
+  >('disconnected');
+  let conductorStatus = $state<'connected' | 'disconnected'>('disconnected');
+  let peersReachable = $state<number>(0);
+  let peersKnown = $state<number | null>(null);
   let lastPingTime = $state<Date | null>(null);
   let pingError = $state<string | null>(null);
   let initializationStatus = $state<'pending' | 'initializing' | 'complete' | 'failed'>('pending');
@@ -102,6 +105,9 @@
   // Set connection status context for child layouts (initial setup)
   setConnectionStatusContext({
     connectionStatus: () => connectionStatus,
+    conductorStatus: () => conductorStatus,
+    peersReachable: () => peersReachable,
+    peersKnown: () => peersKnown,
     lastPingTime: () => lastPingTime,
     pingError: () => pingError,
     adminLoadingStatus: () => {
@@ -339,24 +345,54 @@
     initializeAsync();
   });
 
-  // Set connection status for other components with reactive updates
+  // Conductor liveness: the websocket between this UI and its conductor.
+  // It does not change when the internet goes away, since the conductor is
+  // on localhost. This gates the app; network state only informs the indicator.
   $effect(() => {
-    const connected = isHolochainConnected();
+    conductorStatus = isHolochainConnected() ? 'connected' : 'disconnected';
+  });
 
-    // Log connection status changes
-    if (connectionStatus !== (connected ? 'connected' : 'disconnected')) {
-      console.log(`🔗 Connection status updated: ${connected ? 'connected' : 'disconnected'}`);
+  // Network reachability: what the conductor can see of other peers.
+  // This is what users mean by Connected. Polled, since nothing pushes it.
+  async function pollNetworkStatus() {
+    if (!isHolochainConnected()) {
+      connectionStatus = 'disconnected';
+      return;
     }
+    try {
+      const status = await hc.getNetworkPeerStatus();
+      peersReachable = status.reachable;
+      peersKnown = status.known;
+      if (!status.hasRoute) {
+        connectionStatus = 'offline';
+      } else if (status.reachable === 0) {
+        connectionStatus = 'alone';
+      } else {
+        connectionStatus = 'connected';
+      }
+      lastPingTime = new Date();
+      pingError = null;
+    } catch (error) {
+      pingError = error instanceof Error ? error.message : String(error);
+      connectionStatus = 'error';
+    }
+  }
 
-    // Update reactive state (context is already set with functions that return current values)
-    connectionStatus = connected ? 'connected' : 'disconnected';
-    lastPingTime = connected ? new Date() : lastPingTime;
+  // Skipped in Weave, where Moss shows network state in its own frame.
+  $effect(() => {
+    if (weaveStore.isWeaveContext) {
+      connectionStatus = conductorStatus;
+      return;
+    }
+    pollNetworkStatus();
+    const interval = setInterval(pollNetworkStatus, 15000);
+    return () => clearInterval(interval);
   });
 </script>
 
 <svelte:window onkeydown={handleKeyboardEvent} />
 
-{#if connectionStatus !== 'connected' || initializationStatus === 'initializing'}
+{#if conductorStatus !== 'connected' || initializationStatus === 'initializing'}
   <div class="flex min-h-screen flex-col items-center justify-center space-y-6 p-8">
     <div class="text-center">
       {#if initializationStatus === 'initializing'}

--- a/ui/tests/unit/services/HolochainClientService.connection.test.ts
+++ b/ui/tests/unit/services/HolochainClientService.connection.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { HOLOCHAIN_CLIENT_CONTEXTS } from '../../../src/lib/errors/error-contexts';
+
+vi.mock('@holochain/client', () => ({
+  AppWebsocket: { connect: vi.fn() },
+  AdminWebsocket: { connect: vi.fn() }
+}));
+
+type Service = typeof import('../../../src/lib/services/HolochainClientService.svelte').default;
+
+// Resolves to the rejection reason, or the string 'resolved' if the promise
+// settled successfully, so a test can await either outcome without try/catch.
+const outcomeOf = (p: Promise<unknown>): Promise<unknown> =>
+  p.then(
+    () => 'resolved',
+    (e: unknown) => e
+  );
+
+// vi.resetModules gives the service its own copy of the error class, so
+// instanceof cannot be used across that boundary; the tag survives it.
+const isClientError = (error: unknown): error is { _tag: string; context?: string } =>
+  typeof error === 'object' &&
+  error !== null &&
+  '_tag' in error &&
+  (error as { _tag: unknown })._tag === 'HolochainClientError';
+
+const contextOf = (error: unknown): string | undefined =>
+  isClientError(error) ? error.context : undefined;
+
+describe('waitForConnection', () => {
+  let service: Service;
+  let connect: Mock;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const client = await import('@holochain/client');
+    connect = client.AppWebsocket.connect as unknown as Mock;
+    connect.mockReset();
+    service = (await import('../../../src/lib/services/HolochainClientService.svelte')).default;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects with CONNECTION_TIMEOUT when the attempt never settles', async () => {
+    connect.mockReturnValue(new Promise(() => undefined));
+
+    const outcome = outcomeOf(service.waitForConnection(1_000));
+    await vi.advanceTimersByTimeAsync(1_100);
+
+    const error = await outcome;
+    expect(isClientError(error)).toBe(true);
+    expect(contextOf(error)).toBe(HOLOCHAIN_CLIENT_CONTEXTS.CONNECTION_TIMEOUT);
+  });
+
+  it('rejects with CONNECTION_FAILED when every attempt fails', async () => {
+    connect.mockRejectedValue(new Error('connection refused'));
+
+    const outcome = outcomeOf(service.waitForConnection(120_000));
+    await vi.runAllTimersAsync();
+
+    const error = await outcome;
+    expect(isClientError(error)).toBe(true);
+    expect(contextOf(error)).toBe(HOLOCHAIN_CLIENT_CONTEXTS.CONNECTION_FAILED);
+  });
+
+  it('rejects with CONNECTION_FAILED when the attempt it was waiting on fails', async () => {
+    connect.mockRejectedValue(new Error('connection refused'));
+
+    const first = outcomeOf(service.waitForConnection(120_000));
+    const second = outcomeOf(service.waitForConnection(120_000));
+    await vi.runAllTimersAsync();
+
+    expect(contextOf(await first)).toBe(HOLOCHAIN_CLIENT_CONTEXTS.CONNECTION_FAILED);
+    expect(contextOf(await second)).toBe(HOLOCHAIN_CLIENT_CONTEXTS.CONNECTION_FAILED);
+  });
+
+  it('resolves when the attempt succeeds', async () => {
+    connect.mockResolvedValue({ appInfo: vi.fn() });
+
+    const outcome = outcomeOf(service.waitForConnection(1_000));
+    await vi.runAllTimersAsync();
+
+    expect(await outcome).toBe('resolved');
+  });
+});

--- a/ui/tests/unit/services/hrea.service.test.ts
+++ b/ui/tests/unit/services/hrea.service.test.ts
@@ -73,7 +73,8 @@ const createMockHolochainClientService = () => ({
     })
   ),
   getNetworkPeers: vi.fn(() => Promise.resolve(['peer1', 'peer2', 'peer3'])),
-  isGroupProgenitor: vi.fn(() => Promise.resolve(false))
+  isGroupProgenitor: vi.fn(() => Promise.resolve(false)),
+  getNetworkPeerStatus: vi.fn()
 });
 
 const createServiceTestRunner = (

--- a/ui/tests/unit/services/serviceTypes.service.test.ts
+++ b/ui/tests/unit/services/serviceTypes.service.test.ts
@@ -44,7 +44,8 @@ const createMockHolochainClientService = () => ({
     })
   ),
   getNetworkPeers: vi.fn(() => Promise.resolve(['peer1', 'peer2', 'peer3'])),
-  isGroupProgenitor: vi.fn(() => Promise.resolve(false))
+  isGroupProgenitor: vi.fn(() => Promise.resolve(false)),
+  getNetworkPeerStatus: vi.fn()
 });
 
 /**

--- a/ui/tests/unit/stores/serviceTypes.store.test.ts
+++ b/ui/tests/unit/stores/serviceTypes.store.test.ts
@@ -42,7 +42,8 @@ const createMockHolochainClientService = () => ({
     })
   ),
   getNetworkPeers: vi.fn(() => Promise.resolve(['peer1', 'peer2', 'peer3'])),
-  isGroupProgenitor: vi.fn(() => Promise.resolve(false))
+  isGroupProgenitor: vi.fn(() => Promise.resolve(false)),
+  getNetworkPeerStatus: vi.fn()
 });
 
 describe('ServiceTypesStore', () => {

--- a/ui/tests/unit/utils/network-status.test.ts
+++ b/ui/tests/unit/utils/network-status.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveConnectionStatus,
+  parseAgentInfo,
+  countKnownPeers
+} from '../../../src/lib/utils/network-status';
+
+describe('deriveConnectionStatus', () => {
+  it('is offline when the OS reports no network, whatever the peer count', () => {
+    expect(deriveConnectionStatus({ online: false, reachable: 0 })).toBe('offline');
+    expect(deriveConnectionStatus({ online: false, reachable: 3 })).toBe('offline');
+  });
+
+  it('is alone when online with no reachable peers', () => {
+    expect(deriveConnectionStatus({ online: true, reachable: 0 })).toBe('alone');
+  });
+
+  it('is connected when online with at least one reachable peer', () => {
+    expect(deriveConnectionStatus({ online: true, reachable: 1 })).toBe('connected');
+    expect(deriveConnectionStatus({ online: true, reachable: 12 })).toBe('connected');
+  });
+});
+
+// Build an agentInfo string the way the conductor returns them: outer JSON
+// whose agentInfo field is itself a JSON string.
+function agentInfoString(inner: Record<string, unknown>): string {
+  return JSON.stringify({ agentInfo: JSON.stringify(inner), signature: 'sig' });
+}
+
+describe('parseAgentInfo', () => {
+  it('unwraps the double-encoded shape', () => {
+    const raw = agentInfoString({ agent: 'A', space: 'S' });
+    expect(parseAgentInfo(raw)).toEqual({ agent: 'A', space: 'S' });
+  });
+
+  it('accepts an already-flat object', () => {
+    expect(parseAgentInfo(JSON.stringify({ agent: 'A' }))).toEqual({ agent: 'A' });
+  });
+
+  it('returns null for malformed input', () => {
+    expect(parseAgentInfo('not json')).toBeNull();
+    expect(parseAgentInfo(JSON.stringify({ agentInfo: 'not json' }))).toBeNull();
+    expect(parseAgentInfo('null')).toBeNull();
+  });
+});
+
+describe('countKnownPeers', () => {
+  const far = String(Date.now() * 1000 + 60 * 60 * 1_000_000); // an hour ahead, microseconds
+
+  it('counts distinct agents minus self, across DNAs', () => {
+    // Two agents, each in two DNAs: four entries, two agents, one other peer.
+    const infos = [
+      agentInfoString({ agent: 'me', space: 'dna1', expiresAt: far }),
+      agentInfoString({ agent: 'me', space: 'dna2', expiresAt: far }),
+      agentInfoString({ agent: 'bob', space: 'dna1', expiresAt: far }),
+      agentInfoString({ agent: 'bob', space: 'dna2', expiresAt: far })
+    ];
+    expect(countKnownPeers(infos)).toBe(1);
+  });
+
+  it('is zero when only the local agent is present', () => {
+    expect(countKnownPeers([agentInfoString({ agent: 'me', expiresAt: far })])).toBe(0);
+  });
+
+  it('is zero for an empty list', () => {
+    expect(countKnownPeers([])).toBe(0);
+  });
+
+  it('drops tombstoned agents', () => {
+    const infos = [
+      agentInfoString({ agent: 'me', expiresAt: far }),
+      agentInfoString({ agent: 'gone', expiresAt: far, isTombstone: true })
+    ];
+    expect(countKnownPeers(infos)).toBe(0);
+  });
+
+  it('drops expired agents', () => {
+    const past = String(1_000_000); // early 1970, microseconds
+    const infos = [
+      agentInfoString({ agent: 'me', expiresAt: far }),
+      agentInfoString({ agent: 'stale', expiresAt: past })
+    ];
+    expect(countKnownPeers(infos)).toBe(0);
+  });
+
+  it('ignores entries it cannot parse', () => {
+    const infos = [agentInfoString({ agent: 'me', expiresAt: far }), 'garbage', agentInfoString({ agent: 'bob', expiresAt: far })];
+    expect(countKnownPeers(infos)).toBe(1);
+  });
+});


### PR DESCRIPTION
Draft pending a review slot. Fixes #138.

The indicator read the state of the websocket to the local conductor, which does not change when the internet goes away. It now reads what the conductor can see of other peers, and takes Offline from the OS.

Three states: Connected with a peer count, Alone when online with nobody else reachable, Offline when the machine has no network. The full-screen guard now gates on conductor liveness only, so an offline user still sees their local data.

Two commits. The first used peer_urls from dumpNetworkStats as a route signal; testing against a real wifi toggle showed it is cached, not live. The second takes Offline from navigator.onLine instead, and fixes the known-peer count, which read 3 on a two-agent sandbox because agentInfo returns one entry per agent per DNA.

Logic lives in a pure utility with 12 unit tests. Verified in the running app: wifi off flips to Offline within a second, wifi on recovers, count reads 1 of 1. Skipped in Weave, where Moss shows network state in its frame. Wording is placeholder for Anita.

## Added after review

Two commits on top of the reviewed change.

**#226 folded in**, as the review suggested. `waitForConnection` now rejects with a typed `HolochainClientError`: context `CONNECTION_TIMEOUT` once its deadline passes, `CONNECTION_FAILED` when an attempt ends without a connection, including the case where the caller was waiting on an attempt started elsewhere. The fall-through connection attempt is kept, bounded by the same deadline. Default is 60 seconds; the e2e gate can pass its own. Four unit tests run against the real service rather than a stub. Closes #226.

**Mock repair.** Three tests build their own service mock and lacked `getNetworkPeerStatus`, which this branch added to the interface, so svelte-check was reporting them. Stubbed in each. The pattern recurs and will be filed separately.

Verification after both: 593 unit tests passing across 32 files, svelte-check 0 errors.
