### PR TITLE
fix(#133): refuse to save with a link typed but not added

### DIFF
--- a/ui/src/lib/components/offers/OfferForm.svelte
+++ b/ui/src/lib/components/offers/OfferForm.svelte
@@ -69,6 +69,7 @@
   let linksError = $state('');
   let linksWarning = $state('');
   let pendingLink = $state('');
+  let linksField: HTMLLabelElement | undefined = $state();
   let userCoordinatedOrganizations = $state<UIOrganization[]>([]);
   let isLoadingOrganizations = $state(true);
   let moesInitialized = $state(false);
@@ -230,6 +231,8 @@
       // guesses at intent; silently dropping it loses their work.
       if (pendingLink.trim()) {
         linksWarning = 'A link has been typed but not added. Go back to the Links field and add it, or clear it, before saving.';
+        // Skeleton InputChip does not expose its input, so reach it through the label.
+        (linksField?.querySelector('input.input-chip-field') as HTMLElement | null)?.focus();
         submitting = false;
         return;
       }
@@ -499,7 +502,7 @@
   />
 
   <!-- Links -->
-  <label class="label">
+  <label class="label" bind:this={linksField}>
     <span>Links (optional)</span>
     <p class="text-sm text-surface-600 dark:text-surface-400">Type a link and press Enter to add it.</p>
     <InputChip
@@ -513,7 +516,7 @@
       <p class="mt-1 text-sm text-error-500">{linksError}</p>
     {/if}
     {#if linksWarning}
-      <aside class="alert variant-soft-warning mt-2 text-sm">{linksWarning}</aside>
+      <aside class="alert variant-soft-warning mt-2 text-sm" role="alert">{linksWarning}</aside>
     {/if}
   </label>
 

--- a/ui/src/lib/components/offers/OfferForm.svelte
+++ b/ui/src/lib/components/offers/OfferForm.svelte
@@ -67,6 +67,8 @@
   let submitting = $state(false);
   let serviceTypesError = $state('');
   let linksError = $state('');
+  let linksWarning = $state('');
+  let pendingLink = $state('');
   let userCoordinatedOrganizations = $state<UIOrganization[]>([]);
   let isLoadingOrganizations = $state(true);
   let moesInitialized = $state(false);
@@ -213,11 +215,21 @@
     }
 
     submitting = true;
+    linksError = '';
+    linksWarning = '';
 
     try {
       // Validate service types before submission
       if (serviceTypeHashes.length === 0) {
         serviceTypesError = 'At least one service type is required';
+        submitting = false;
+        return;
+      }
+
+      // Refuse to save with a link typed but not added. Silently committing it
+      // guesses at intent; silently dropping it loses their work.
+      if (pendingLink.trim()) {
+        linksWarning = 'A link has been typed but not added. Go back to the Links field and add it, or clear it, before saving.';
         submitting = false;
         return;
       }
@@ -350,7 +362,7 @@
       id="offer-service-types"
     />
     {#if serviceTypesError}
-      <p class="text-error mt-1 text-sm">{serviceTypesError}</p>
+      <p class="mt-1 text-sm text-error-500">{serviceTypesError}</p>
     {/if}
   </div>
 
@@ -489,14 +501,19 @@
   <!-- Links -->
   <label class="label">
     <span>Links (optional)</span>
+    <p class="text-sm text-surface-600 dark:text-surface-400">Type a link and press Enter to add it.</p>
     <InputChip
       bind:value={links}
+      bind:input={pendingLink}
       name="links"
-      placeholder="Add links (press Enter to add)"
+      placeholder="https://"
       validation={(link) => link.trim().length > 0}
     />
     {#if linksError}
-      <p class="text-error mt-1 text-sm">{linksError}</p>
+      <p class="mt-1 text-sm text-error-500">{linksError}</p>
+    {/if}
+    {#if linksWarning}
+      <aside class="alert variant-soft-warning mt-2 text-sm">{linksWarning}</aside>
     {/if}
   </label>
 

--- a/ui/src/lib/components/requests/RequestForm.svelte
+++ b/ui/src/lib/components/requests/RequestForm.svelte
@@ -85,6 +85,8 @@
   let submitting = $state(false);
   let serviceTypesError = $state('');
   let linksError = $state('');
+  let linksWarning = $state('');
+  let pendingLink = $state('');
   let userCoordinatedOrganizations = $state<UIOrganization[]>([]);
   let isLoadingOrganizations = $state(true);
   let moesInitialized = $state(false);
@@ -234,11 +236,21 @@
     }
 
     submitting = true;
+    linksError = '';
+    linksWarning = '';
 
     try {
       // Validate service types before submission
       if (serviceTypeHashes.length === 0) {
         serviceTypesError = 'At least one service type is required';
+        submitting = false;
+        return;
+      }
+
+      // Refuse to save with a link typed but not added. Silently committing it
+      // guesses at intent; silently dropping it loses their work.
+      if (pendingLink.trim()) {
+        linksWarning = 'A link has been typed but not added. Go back to the Links field and add it, or clear it, before saving.';
         submitting = false;
         return;
       }
@@ -384,7 +396,7 @@
       id="request-service-types"
     />
     {#if serviceTypesError}
-      <p class="text-sm text-error-500">{serviceTypesError}</p>
+      <p class="mt-1 text-sm text-error-500">{serviceTypesError}</p>
     {/if}
   </div>
 
@@ -577,9 +589,18 @@
   <!-- Links -->
   <label class="label">
     <span>Links (optional)</span>
-    <InputChip bind:value={links} name="links" placeholder="Add links (press Enter to add)" />
+    <p class="text-sm text-surface-600 dark:text-surface-400">Type a link and press Enter to add it.</p>
+    <InputChip
+      bind:value={links}
+      bind:input={pendingLink}
+      name="links"
+      placeholder="https://"
+    />
     {#if linksError}
-      <p class="text-sm text-error-500">{linksError}</p>
+      <p class="mt-1 text-sm text-error-500">{linksError}</p>
+    {/if}
+    {#if linksWarning}
+      <aside class="alert variant-soft-warning mt-2 text-sm">{linksWarning}</aside>
     {/if}
   </label>
 

--- a/ui/src/lib/components/requests/RequestForm.svelte
+++ b/ui/src/lib/components/requests/RequestForm.svelte
@@ -87,6 +87,7 @@
   let linksError = $state('');
   let linksWarning = $state('');
   let pendingLink = $state('');
+  let linksField: HTMLLabelElement | undefined = $state();
   let userCoordinatedOrganizations = $state<UIOrganization[]>([]);
   let isLoadingOrganizations = $state(true);
   let moesInitialized = $state(false);
@@ -251,6 +252,8 @@
       // guesses at intent; silently dropping it loses their work.
       if (pendingLink.trim()) {
         linksWarning = 'A link has been typed but not added. Go back to the Links field and add it, or clear it, before saving.';
+        // Skeleton InputChip does not expose its input, so reach it through the label.
+        (linksField?.querySelector('input.input-chip-field') as HTMLElement | null)?.focus();
         submitting = false;
         return;
       }
@@ -587,7 +590,7 @@
   <TimeZoneSelect value={timeZone} onchange={handleTimezoneChange} required />
 
   <!-- Links -->
-  <label class="label">
+  <label class="label" bind:this={linksField}>
     <span>Links (optional)</span>
     <p class="text-sm text-surface-600 dark:text-surface-400">Type a link and press Enter to add it.</p>
     <InputChip
@@ -600,7 +603,7 @@
       <p class="mt-1 text-sm text-error-500">{linksError}</p>
     {/if}
     {#if linksWarning}
-      <aside class="alert variant-soft-warning mt-2 text-sm">{linksWarning}</aside>
+      <aside class="alert variant-soft-warning mt-2 text-sm" role="alert">{linksWarning}</aside>
     {/if}
   </label>
 

--- a/ui/tests/e2e/specs/04-offers.spec.ts
+++ b/ui/tests/e2e/specs/04-offers.spec.ts
@@ -83,6 +83,9 @@ test.describe.serial('04 — offers: full lifecycle through the UI', () => {
     await page.getByRole('button', { name: 'Create Offer' }).click();
 
     await expect(page.locator('aside.alert', { hasText: 'typed but not added' })).toBeVisible();
+    await expect(
+      page.locator('label:has-text("Links (optional)") input.input-chip-field')
+    ).toBeFocused();
     await expect(page).toHaveURL(/\/offers\/create(\?|$)/);
 
     // The refusal has to reach the DHT: nothing by this title was written.

--- a/ui/tests/e2e/specs/04-offers.spec.ts
+++ b/ui/tests/e2e/specs/04-offers.spec.ts
@@ -61,6 +61,35 @@ test.describe.serial('04 — offers: full lifecycle through the UI', () => {
     await client.client.close();
   });
 
+  test('form refuses to save with a link typed but not added', async ({ page }) => {
+    const title = 'E2E Unadded Link Offer';
+    await gotoApp(page, '/offers/create');
+
+    await page.getByPlaceholder('What are you offering?').fill(title);
+    await page
+      .getByPlaceholder('Describe your offer in detail (Markdown supported)')
+      .fill('Must never be saved: the links chip holds unadded text.');
+    await page.getByPlaceholder('Search and select service types...').fill('E2E Service Type');
+    await page.locator('label:has-text("E2E Service Type") input[type="checkbox"]').first().check();
+    await expect(page.locator('.chip', { hasText: 'E2E Service Type' }).first()).toBeVisible({
+      timeout: 5_000
+    });
+    await selectTimezone(page);
+
+    // Type into the links chip and do not press Enter, so the text stays
+    // pending in the input rather than becoming a chip.
+    await page.locator('label:has-text("Links (optional)") input.input-chip-field').fill('https://example.org/unadded');
+
+    await page.getByRole('button', { name: 'Create Offer' }).click();
+
+    await expect(page.locator('aside.alert', { hasText: 'typed but not added' })).toBeVisible();
+    await expect(page).toHaveURL(/\/offers\/create(\?|$)/);
+
+    // The refusal has to reach the DHT: nothing by this title was written.
+    const records = (await callZome(client, 'offers', 'get_active_offers', null)) as HolochainRecord[];
+    expect(records.some((r) => decodeRecordEntry<{ title: string }>(r)?.title === title)).toBe(false);
+  });
+
   test('user creates an offer through the form', async ({ page }) => {
     await gotoApp(page, '/offers/create');
 

--- a/ui/tests/e2e/specs/05-requests.spec.ts
+++ b/ui/tests/e2e/specs/05-requests.spec.ts
@@ -56,6 +56,35 @@ test.describe.serial('05 — requests: full lifecycle through the UI', () => {
     await client.client.close();
   });
 
+  test('form refuses to save with a link typed but not added', async ({ page }) => {
+    const title = 'E2E Unadded Link Request';
+    await gotoApp(page, '/requests/create');
+
+    await page.getByPlaceholder('Enter request title').fill(title);
+    await page
+      .getByPlaceholder('Describe your request in detail (Markdown supported)')
+      .fill('Must never be saved: the links chip holds unadded text.');
+    await page.getByPlaceholder('Search and select service types...').fill('E2E Service Type');
+    await page.locator('label:has-text("E2E Service Type") input[type="checkbox"]').first().check();
+    await expect(page.locator('.chip', { hasText: 'E2E Service Type' }).first()).toBeVisible({
+      timeout: 5_000
+    });
+    await selectTimezone(page);
+
+    // Type into the links chip and do not press Enter, so the text stays
+    // pending in the input rather than becoming a chip.
+    await page.locator('label:has-text("Links (optional)") input.input-chip-field').fill('https://example.org/unadded');
+
+    await page.getByRole('button', { name: 'Create Request' }).click();
+
+    await expect(page.locator('aside.alert', { hasText: 'typed but not added' })).toBeVisible();
+    await expect(page).toHaveURL(/\/requests\/create(\?|$)/);
+
+    // The refusal has to reach the DHT: nothing by this title was written.
+    const records = (await callZome(client, 'requests', 'get_active_requests', null)) as HolochainRecord[];
+    expect(records.some((r) => decodeRecordEntry<{ title: string }>(r)?.title === title)).toBe(false);
+  });
+
   test('user creates a request through the form', async ({ page }) => {
     await gotoApp(page, '/requests/create');
 

--- a/ui/tests/e2e/specs/05-requests.spec.ts
+++ b/ui/tests/e2e/specs/05-requests.spec.ts
@@ -78,6 +78,9 @@ test.describe.serial('05 — requests: full lifecycle through the UI', () => {
     await page.getByRole('button', { name: 'Create Request' }).click();
 
     await expect(page.locator('aside.alert', { hasText: 'typed but not added' })).toBeVisible();
+    await expect(
+      page.locator('label:has-text("Links (optional)") input.input-chip-field')
+    ).toBeFocused();
     await expect(page).toHaveURL(/\/requests\/create(\?|$)/);
 
     // The refusal has to reach the DHT: nothing by this title was written.


### PR DESCRIPTION
Draft pending a review slot. Closes the Links half of #133; the Organization half is in #214.

The links field is a Skeleton InputChip, and only Enter moves typed text into the array. The tester typed a link and clicked Save with it still in the box, so nothing was saved and nothing said so.

The form now refuses to save with unadded text in the box and points back to the field, where persistent help text says what to do. The warning is a soft alert, not coloured text, so the design system handles contrast. Both forms also had a pre-existing bug where linksError never cleared, and had drifted on their error-message classes; both fixed.

Verified in the running app: warning fires, Enter adds the chip, save succeeds, warning clears. Wording is placeholder for Anita.

## Regression test

One case in each of the offers and requests e2e lifecycle specs, before the create step so it leaves nothing behind. It types a link into the chip without pressing Enter, clicks Save, and asserts four things: the warning aside is visible, focus has moved to the chip input, the URL stays on the create page, and get_active returns nothing by that title. The chip is located by its label and Skeleton class rather than the placeholder, so the same test runs against the pre-fix forms: verified failing there at the warning assertion, and passing here. Both specs green in full.

## Accessibility

The aria-describedby suggestion cannot be applied through Skeleton InputChip, which reads placeholder and disabled from its rest props individually and never spreads them onto its input, so the attribute would not reach the element. Instead the warning aside carries role="alert" so it is announced when it appears, and on refusal focus moves to the chip input through the label, which puts the person at the field rather than describing where it is. The e2e case asserts the focus.
