### PR TITLE
fix(#217): close the timezone list on selection

### DIFF
--- a/ui/src/lib/components/shared/TimeZoneSelect.svelte
+++ b/ui/src/lib/components/shared/TimeZoneSelect.svelte
@@ -25,7 +25,7 @@
   const popupTarget = `tz-popup-${id ?? Math.random().toString(36).slice(2, 10)}`;
 
   const popupSettings: PopupSettings = {
-    event: 'focus-click',
+    event: 'focus-blur',
     target: popupTarget,
     placement: 'bottom-start',
     closeQuery: ''
@@ -207,6 +207,8 @@
       <li>
         <button
           type="button"
+          role="option"
+          aria-selected={detectedTimezone === value}
           class="w-full rounded px-3 py-2 text-left text-sm variant-soft-primary hover:variant-filled-primary"
           onmousedown={(e) => e.preventDefault()}
           onclick={() => handleItemClick(detectedTimezone)}

--- a/ui/src/lib/components/shared/TimeZoneSelect.svelte
+++ b/ui/src/lib/components/shared/TimeZoneSelect.svelte
@@ -208,6 +208,7 @@
         <button
           type="button"
           class="w-full rounded px-3 py-2 text-left text-sm variant-soft-primary hover:variant-filled-primary"
+          onmousedown={(e) => e.preventDefault()}
           onclick={() => handleItemClick(detectedTimezone)}
         >
           <span class="block text-xs opacity-75">Detected from your browser</span>


### PR DESCRIPTION
Draft pending a review slot. Fixes #217.

The popup was configured with event: focus-click, which closes only on a click outside. Every selection path already calls inputEl.blur(), which only closes the popup in focus-blur mode. One-word switch; click, Enter, Escape and Tab now all close the list.

Also: aria-expanded now agrees with what is on screen, and the detected-timezone button gains role=option and aria-selected so the listbox contains only options.

Verified: all six paths close, reopen and reselect works.