### PR TITLE
fix(users): disclose that profile contact details are visible to members

### DIFF
--- a/ui/src/lib/components/users/UserForm.svelte
+++ b/ui/src/lib/components/users/UserForm.svelte
@@ -346,6 +346,10 @@
     </div>
   </div>
 
+  <p class="text-sm text-surface-600 dark:text-surface-400">
+    Your email and phone number are stored on the shared network and visible to all its members.
+  </p>
+
   <label class="label text-lg">
     Email* :
     <input type="email" class="input" name="email" value={user?.email || ''} required />


### PR DESCRIPTION
Draft pending a review slot.

Profile email and phone are public entry fields, readable by every member of the network. The form did not say so. One line above the contact fields now does. Wording is placeholder for Anita.

Surfaced while confirming the users schema for #219.