### PR TITLE
feat(#51): notifications zome pair with interest markers as first consumer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5046,6 +5046,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "notifications"
+version = "0.0.1"
+dependencies = [
+ "hdk",
+ "notifications_integrity",
+ "serde",
+ "utils",
+]
+
+[[package]]
+name = "notifications_integrity"
+version = "0.0.1"
+dependencies = [
+ "hdi",
+ "holochain_serialized_bytes",
+ "serde",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,12 @@ path = "dnas/requests_and_offers/zomes/coordinator/administration"
 [workspace.dependencies.administration_integrity]
 path = "dnas/requests_and_offers/zomes/integrity/administration"
 
+[workspace.dependencies.notifications]
+path = "dnas/requests_and_offers/zomes/coordinator/notifications"
+
+[workspace.dependencies.notifications_integrity]
+path = "dnas/requests_and_offers/zomes/integrity/notifications"
+
 [workspace.dependencies.users_organizations]
 path = "dnas/requests_and_offers/zomes/coordinator/users_organizations"
 

--- a/dnas/requests_and_offers/workdir/dna.yaml
+++ b/dnas/requests_and_offers/workdir/dna.yaml
@@ -9,6 +9,10 @@ integrity:
       hash: ~
       path: "../../../target/wasm32-unknown-unknown/release/administration_integrity.wasm"
       dependencies: ~
+    - name: notifications_integrity
+      hash: ~
+      path: "../../../target/wasm32-unknown-unknown/release/notifications_integrity.wasm"
+      dependencies: ~
     - name: offers_integrity
       hash: ~
       path: "../../../target/wasm32-unknown-unknown/release/offers_integrity.wasm"
@@ -41,6 +45,11 @@ coordinator:
       path: "../../../target/wasm32-unknown-unknown/release/administration.wasm"
       dependencies:
         - name: administration_integrity
+    - name: notifications
+      hash: ~
+      path: "../../../target/wasm32-unknown-unknown/release/notifications.wasm"
+      dependencies:
+        - name: notifications_integrity
     - name: requests
       hash: ~
       path: "../../../target/wasm32-unknown-unknown/release/requests.wasm"

--- a/dnas/requests_and_offers/zomes/coordinator/notifications/Cargo.toml
+++ b/dnas/requests_and_offers/zomes/coordinator/notifications/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "notifications"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "notifications"
+
+[dependencies]
+utils = { workspace = true }
+hdk = { workspace = true }
+serde = { workspace = true }
+notifications_integrity = { workspace = true }

--- a/dnas/requests_and_offers/zomes/coordinator/notifications/src/lib.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/notifications/src/lib.rs
@@ -1,0 +1,253 @@
+use hdk::prelude::*;
+use std::collections::HashSet;
+use notifications_integrity::*;
+use utils::{
+  errors::{CommonError, UsersError}, external_local_call, find_original_action_hash,
+  get_all_revisions_for_entry, EntityActionHash, OriginalActionHash,
+};
+
+/// Rate limits. DNA properties in the next revision; constants for the draft.
+/// See NOTIFICATION_ARCHITECTURE.md section 11.
+const UNCONNECTED_PER_DAY: usize = 10;
+const CONNECTED_PER_DAY: usize = 100;
+const DAY_MICROS: i64 = 24 * 60 * 60 * 1_000_000;
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateNotificationInput {
+  pub kind: NotificationKind,
+  pub recipient: AgentPubKey,
+  pub subject: Option<AnyLinkableHash>,
+  pub payload: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RetractNotificationInput {
+  pub original_action_hash: ActionHash,
+  pub previous_action_hash: ActionHash,
+}
+
+/// Mirrors messaging::SendMessageInput without a crate dependency.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct SendMessageInput {
+  stream_id: String,
+  content: String,
+  agents: Vec<AgentPubKey>,
+}
+
+const SIGNAL_STREAM: &str = "notifications";
+
+fn my_user_hash() -> ExternResult<Option<ActionHash>> {
+  let me = agent_info()?.agent_initial_pubkey;
+  let links: Vec<Link> = external_local_call("get_agent_user", "users_organizations", me)?;
+  Ok(links.first().and_then(|l| l.target.clone().into_action_hash()))
+}
+
+fn ensure_accepted() -> ExternResult<()> {
+  let Some(user_hash) = my_user_hash()? else {
+    return Err(UsersError::UserProfileRequired.into());
+  };
+  let accepted: bool = external_local_call(
+    "check_if_entity_is_accepted",
+    "administration",
+    EntityActionHash {
+      entity: "users".to_string(),
+      entity_original_action_hash: OriginalActionHash(user_hash),
+    },
+  )?;
+  if !accepted {
+    return Err(CommonError::InvalidData("only accepted members may notify".to_string()).into());
+  }
+  Ok(())
+}
+
+fn latest_notification(original: ActionHash) -> ExternResult<Option<(Record, Notification)>> {
+  let mut revisions = get_all_revisions_for_entry(
+    OriginalActionHash(original),
+    LinkTypes::NotificationUpdates,
+  )?;
+  // Link order is not guaranteed; the latest revision is the newest action.
+  revisions.sort_by_key(|r| r.action().timestamp());
+  let Some(record) = revisions.into_iter().last() else {
+    return Ok(None);
+  };
+  let entry: Option<Notification> = record
+    .entry()
+    .to_app_option()
+    .map_err(CommonError::Serialize)?;
+  Ok(entry.map(|n| (record, n)))
+}
+
+fn inbox_links(agent: AgentPubKey) -> ExternResult<Vec<Link>> {
+  let filter = LinkTypes::RecipientInbox
+    .try_into_filter()
+    .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+  get_links(LinkQuery::new(agent, filter), GetStrategy::Network)
+}
+
+/// Every agent holding an Open InterestMarker addressed to me. One inbox walk.
+/// Two markers, one each way, are a connection; see section 12.
+fn connected_peers() -> ExternResult<HashSet<AgentPubKey>> {
+  let me = agent_info()?.agent_initial_pubkey;
+  let mut peers = HashSet::new();
+  for link in inbox_links(me)? {
+    let Some(hash) = link.target.into_action_hash() else { continue };
+    if let Some((_, n)) = latest_notification(hash)? {
+      if n.kind == NotificationKind::InterestMarker && n.state == NotificationState::Open {
+        peers.insert(n.actor);
+      }
+    }
+  }
+  Ok(peers)
+}
+
+#[hdk_extern]
+pub fn is_connected(other: AgentPubKey) -> ExternResult<bool> {
+  Ok(connected_peers()?.contains(&other))
+}
+
+/// Counts this agent's own Notification creates in the last 24 hours, from the
+/// local source chain. Connected tier: only sends to `to`. Unconnected tier:
+/// sends to every recipient this agent is not connected to, so pings to
+/// connected peers do not draw on the stranger budget.
+fn my_recent_count(to: &AgentPubKey, peers: &HashSet<AgentPubKey>) -> ExternResult<usize> {
+  let connected = peers.contains(to);
+  let now = sys_time()?.as_micros();
+  let filter = ChainQueryFilter::new()
+    .entry_type(UnitEntryTypes::Notification.try_into()?)
+    .include_entries(true)
+    .action_type(ActionType::Create);
+  let mut count = 0usize;
+  for record in query(filter)? {
+    if now - record.action().timestamp().as_micros() > DAY_MICROS {
+      continue;
+    }
+    let entry: Option<Notification> = record.entry().to_app_option().map_err(CommonError::Serialize)?;
+    let Some(n) = entry else { continue };
+    let Recipient::Agent(ref recipient) = n.recipient else { continue };
+    if connected {
+      if recipient == to {
+        count += 1;
+      }
+    } else if !peers.contains(recipient) {
+      count += 1;
+    }
+  }
+  Ok(count)
+}
+
+fn already_open_on(subject: &Option<AnyLinkableHash>, to: &AgentPubKey) -> ExternResult<bool> {
+  let me = agent_info()?.agent_initial_pubkey;
+  for link in inbox_links(to.clone())? {
+    let Some(hash) = link.target.into_action_hash() else { continue };
+    if let Some((_, n)) = latest_notification(hash)? {
+      if n.actor == me && n.subject == *subject && n.state == NotificationState::Open {
+        return Ok(true);
+      }
+    }
+  }
+  Ok(false)
+}
+
+#[hdk_extern]
+pub fn create_notification(input: CreateNotificationInput) -> ExternResult<Record> {
+  ensure_accepted()?;
+  let me = agent_info()?.agent_initial_pubkey;
+  if input.recipient == me {
+    return Err(CommonError::InvalidData("cannot notify yourself".to_string()).into());
+  }
+  if already_open_on(&input.subject, &input.recipient)? {
+    return Err(CommonError::InvalidData("an open notification on this subject already exists".to_string()).into());
+  }
+  let peers = connected_peers()?;
+  let limit = if peers.contains(&input.recipient) { CONNECTED_PER_DAY } else { UNCONNECTED_PER_DAY };
+  if my_recent_count(&input.recipient, &peers)? >= limit {
+    return Err(CommonError::InvalidData("notification rate limit reached".to_string()).into());
+  }
+
+  let notification = Notification {
+    kind: input.kind,
+    recipient: Recipient::Agent(input.recipient.clone()),
+    subject: input.subject.clone(),
+    actor: me,
+    state: NotificationState::Open,
+    payload: input.payload,
+    created_at: sys_time()?,
+  };
+  let hash = create_entry(&EntryTypes::Notification(notification))?;
+
+  create_link(input.recipient.clone(), hash.clone(), LinkTypes::RecipientInbox, ())?;
+  if let Some(subject) = input.subject {
+    create_link(subject, hash.clone(), LinkTypes::SubjectNotifications, ())?;
+  }
+
+  // Live-signal layer: best effort, and absent until #213 lands. The DHT
+  // entry is the source of truth either way.
+  let signal = SendMessageInput {
+    stream_id: SIGNAL_STREAM.to_string(),
+    content: hash.to_string(),
+    agents: vec![input.recipient],
+  };
+  if let Err(e) = external_local_call::<_, ()>("send_message", "messaging", signal) {
+    warn!("notification signal not sent: {:?}", e);
+  }
+
+  get(hash, GetOptions::default())?.ok_or(CommonError::RecordNotFound("notification".to_string()).into())
+}
+
+/// Every Open notification addressed to me, latest revision of each.
+#[hdk_extern]
+pub fn get_my_notifications(_: ()) -> ExternResult<Vec<Record>> {
+  let me = agent_info()?.agent_initial_pubkey;
+  let mut out = Vec::new();
+  for link in inbox_links(me)? {
+    let Some(hash) = link.target.into_action_hash() else { continue };
+    if let Some((record, n)) = latest_notification(hash)? {
+      if n.state == NotificationState::Open {
+        out.push(record);
+      }
+    }
+  }
+  Ok(out)
+}
+
+/// Notifications I have marked seen, as original action hashes.
+#[hdk_extern]
+pub fn get_seen_notification_hashes(_: ()) -> ExternResult<Vec<ActionHash>> {
+  let filter = ChainQueryFilter::new()
+    .entry_type(UnitEntryTypes::SeenMarker.try_into()?)
+    .include_entries(true);
+  let mut out = Vec::new();
+  for record in query(filter)? {
+    let entry: Option<SeenMarker> = record.entry().to_app_option().map_err(CommonError::Serialize)?;
+    if let Some(m) = entry {
+      out.push(m.notification_hash);
+    }
+  }
+  Ok(out)
+}
+
+#[hdk_extern]
+pub fn mark_seen(notification_hash: ActionHash) -> ExternResult<ActionHash> {
+  let original = find_original_action_hash(notification_hash)?;
+  create_entry(&EntryTypes::SeenMarker(SeenMarker { notification_hash: original.0 }))
+}
+
+/// Actor withdraws. State update plus an update-chain link, never a delete.
+#[hdk_extern]
+pub fn retract_notification(input: RetractNotificationInput) -> ExternResult<Record> {
+  let me = agent_info()?.agent_initial_pubkey;
+  let original = find_original_action_hash(input.original_action_hash)?;
+  let Some((_, current)) = latest_notification(original.0.clone())? else {
+    return Err(CommonError::RecordNotFound("notification".to_string()).into());
+  };
+  if current.actor != me {
+    return Err(UsersError::NotAuthor.into());
+  }
+  let updated = Notification { state: NotificationState::Retracted, ..current };
+  let new_hash = update_entry(input.previous_action_hash, &EntryTypes::Notification(updated))?;
+  create_link(original.0, new_hash.clone(), LinkTypes::NotificationUpdates, ())?;
+  get(new_hash, GetOptions::default())?.ok_or(CommonError::RecordNotFound("notification".to_string()).into())
+}

--- a/dnas/requests_and_offers/zomes/integrity/notifications/Cargo.toml
+++ b/dnas/requests_and_offers/zomes/integrity/notifications/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "notifications_integrity"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "notifications_integrity"
+
+[dependencies]
+hdi = { workspace = true }
+holochain_serialized_bytes = { workspace = true }
+serde = { workspace = true }

--- a/dnas/requests_and_offers/zomes/integrity/notifications/src/lib.rs
+++ b/dnas/requests_and_offers/zomes/integrity/notifications/src/lib.rs
@@ -1,0 +1,136 @@
+use hdi::prelude::*;
+
+/// Upper bound on the payload, in bytes. Sealed payloads will be larger than
+/// their plaintext; this leaves headroom under lair's 8KB per-call ceiling.
+pub const MAX_PAYLOAD_BYTES: usize = 4096;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "type", content = "value")]
+pub enum Recipient {
+  Agent(AgentPubKey),
+  Role(String),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum NotificationKind {
+  InterestMarker,
+  Flag,
+  JoinRequest,
+  StatusChange,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum NotificationState {
+  Open,
+  Resolved,
+  Retracted,
+  Dismissed,
+  Upheld,
+}
+
+/// One durable record of "something happened", addressed to a recipient.
+/// See NOTIFICATION_ARCHITECTURE.md section 4. `payload` is plaintext in this
+/// draft and will be sealed to the recipient in the next revision.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct Notification {
+  pub kind: NotificationKind,
+  pub recipient: Recipient,
+  pub subject: Option<AnyLinkableHash>,
+  pub actor: AgentPubKey,
+  pub state: NotificationState,
+  pub payload: String,
+  pub created_at: Timestamp,
+}
+
+/// Recipient-authored, private. Marks a notification as seen by this agent.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct SeenMarker {
+  pub notification_hash: ActionHash,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+  Notification(Notification),
+  #[entry_type(visibility = "private")]
+  SeenMarker(SeenMarker),
+}
+
+#[derive(Serialize, Deserialize)]
+#[hdk_link_types]
+pub enum LinkTypes {
+  /// Recipient agent key -> notification action hash. The recipient's inbox.
+  RecipientInbox,
+  /// Subject hash -> notification action hash. Everything about a thing.
+  SubjectNotifications,
+  /// Original action hash -> revision action hash. Same shape as StatusUpdates.
+  NotificationUpdates,
+}
+
+#[hdk_extern]
+pub fn genesis_self_check(_data: GenesisSelfCheckData) -> ExternResult<ValidateCallbackResult> {
+  Ok(ValidateCallbackResult::Valid)
+}
+
+pub fn validate_agent_joining(
+  _agent_pub_key: AgentPubKey,
+  _membrane_proof: &Option<MembraneProof>,
+) -> ExternResult<ValidateCallbackResult> {
+  Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_notification_fields(
+  author: &AgentPubKey,
+  n: &Notification,
+) -> ExternResult<ValidateCallbackResult> {
+  if n.actor != *author {
+    return Ok(ValidateCallbackResult::Invalid(
+      "notification actor must be the action author".into(),
+    ));
+  }
+  if let Recipient::Agent(ref r) = n.recipient {
+    if *r == n.actor {
+      return Ok(ValidateCallbackResult::Invalid(
+        "notification recipient must differ from actor".into(),
+      ));
+    }
+  }
+  if n.payload.len() > MAX_PAYLOAD_BYTES {
+    return Ok(ValidateCallbackResult::Invalid("notification payload too large".into()));
+  }
+  Ok(ValidateCallbackResult::Valid)
+}
+
+/// Link deletion is refused for every link type. Retraction is a state update
+/// on the entry, never removal of the index; the same stance as bucket links
+/// elsewhere in the app.
+fn refuse_link_delete() -> ExternResult<ValidateCallbackResult> {
+  Ok(ValidateCallbackResult::Invalid(
+    "notification links are not deletable; retract the notification instead".into(),
+  ))
+}
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+  match op.flattened::<EntryTypes, LinkTypes>()? {
+    FlatOp::StoreEntry(store_entry) => match store_entry {
+      OpEntry::CreateEntry { app_entry, action } => match app_entry {
+        EntryTypes::Notification(n) => validate_notification_fields(&action.author, &n),
+        EntryTypes::SeenMarker(_) => Ok(ValidateCallbackResult::Valid),
+      },
+      OpEntry::UpdateEntry { app_entry, action, .. } => match app_entry {
+        // Admin resolutions (Dismissed, Upheld) will need must_get on the
+        // original plus an admin check; coordinator-enforced in this draft.
+        EntryTypes::Notification(n) => validate_notification_fields(&action.author, &n),
+        EntryTypes::SeenMarker(_) => Ok(ValidateCallbackResult::Valid),
+      },
+      _ => Ok(ValidateCallbackResult::Valid),
+    },
+    FlatOp::RegisterDeleteLink { .. } => refuse_link_delete(),
+    _ => Ok(ValidateCallbackResult::Valid),
+  }
+}

--- a/tests/sweettest/Cargo.toml
+++ b/tests/sweettest/Cargo.toml
@@ -74,3 +74,7 @@ path = "tests/offers.rs"
 [[test]]
 name = "mediums_of_exchange"
 path = "tests/mediums_of_exchange.rs"
+
+[[test]]
+name = "notifications"
+path = "tests/notifications.rs"

--- a/tests/sweettest/src/common/conductors.rs
+++ b/tests/sweettest/src/common/conductors.rs
@@ -235,3 +235,41 @@ pub async fn setup_two_agents_with_alice_as_progenitor() -> (
 
     (conductors, cell_alice, cell_bob)
 }
+
+/// Three conductors with Alice as progenitor. Carol is a third, unconnected
+/// agent for tests that need a stranger.
+///
+/// Returns `(conductors, cell_alice, cell_bob, cell_carol)`.
+pub async fn setup_three_agents_with_alice_as_progenitor() -> (
+    SweetConductorBatch,
+    SweetCell,
+    SweetCell,
+    SweetCell,
+) {
+    let mut conductors =
+        SweetConductorBatch::from_config_rendezvous(3, SweetConductorConfig::standard()).await;
+
+    let alice_key = SweetAgents::one(conductors[0].keystore()).await;
+    let dna = build_dna(alice_key.to_string()).await;
+
+    let alice_app = conductors[0]
+        .setup_app_for_agent("requests_and_offers", alice_key, &[dna.clone()])
+        .await
+        .expect("Failed to install app for Alice");
+    let bob_app = conductors[1]
+        .setup_app("requests_and_offers", &[dna.clone()])
+        .await
+        .expect("Failed to install app for Bob");
+    let carol_app = conductors[2]
+        .setup_app("requests_and_offers", &[dna])
+        .await
+        .expect("Failed to install app for Carol");
+
+    conductors.exchange_peer_info().await;
+
+    let (cell_alice,) = alice_app.into_tuple();
+    let (cell_bob,) = bob_app.into_tuple();
+    let (cell_carol,) = carol_app.into_tuple();
+
+    (conductors, cell_alice, cell_bob, cell_carol)
+}

--- a/tests/sweettest/tests/notifications.rs
+++ b/tests/sweettest/tests/notifications.rs
@@ -1,0 +1,210 @@
+//! Notifications zome test. Draft for #51, built from NOTIFICATION_ARCHITECTURE.md.
+//!
+//! Exercises the four things compilation cannot prove: the cross-zome eligibility
+//! calls, the inbox link and revision read, the rate-cap chain query, and the
+//! connection pair logic. The live signal is not asserted; on this branch the
+//! messaging zome is absent and the coordinator warns and continues, by design.
+//!
+//! The zome's input types are mirrored here with matching serde shape, as the
+//! messaging test does, because coordinator crates require a wasm target.
+
+use holochain::prelude::*;
+use holochain::sweettest::*;
+use requests_and_offers_sweettest::common::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateNotificationInput {
+    kind: String,
+    recipient: AgentPubKey,
+    subject: Option<AnyLinkableHash>,
+    payload: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RetractNotificationInput {
+    original_action_hash: ActionHash,
+    previous_action_hash: ActionHash,
+}
+
+fn marker(to: &AgentPubKey, subject: Option<AnyLinkableHash>, text: &str) -> CreateNotificationInput {
+    CreateNotificationInput {
+        kind: "InterestMarker".to_string(),
+        recipient: to.clone(),
+        subject,
+        payload: text.to_string(),
+    }
+}
+
+async fn user_hash(conductor: &SweetConductor, cell: &SweetCell) -> ActionHash {
+    let links: Vec<Link> = conductor
+        .call(&cell.zome("users_organizations"), "get_agent_user", cell.agent_pubkey().clone())
+        .await;
+    links[0].target.clone().into_action_hash().unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn interest_marker_lifecycle_and_cap() {
+    let (conductors, alice, bob, carol) = setup_three_agents_with_alice_as_progenitor().await;
+
+    conductors[0]
+        .call::<_, Record>(&alice.zome("users_organizations"), "create_user", sample_user("Alice"))
+        .await;
+    conductors[1]
+        .call::<_, Record>(&bob.zome("users_organizations"), "create_user", sample_user("Bob"))
+        .await;
+    await_consistency_s(15, [&alice, &bob, &carol]).await.unwrap();
+
+    let alice_user = user_hash(&conductors[0], &alice).await;
+    let bob_user = user_hash(&conductors[1], &bob).await;
+
+    conductors[0]
+        .call::<_, bool>(
+            &alice.zome("administration"),
+            "add_administrator",
+            EntityActionHashAgents {
+                entity: ENTITY_NETWORK.to_string(),
+                entity_original_action_hash: alice_user.clone(),
+                agent_pubkeys: vec![alice.agent_pubkey().clone()],
+            },
+        )
+        .await;
+    await_consistency_s(15, [&alice, &bob, &carol]).await.unwrap();
+
+    accept_entity(&conductors[0], &alice, ENTITY_USERS, alice_user.clone()).await;
+    accept_entity(&conductors[0], &alice, ENTITY_USERS, bob_user.clone()).await;
+    await_consistency_s(15, [&alice, &bob, &carol]).await.unwrap();
+
+    // 1. Alice marks interest in Bob's listing. Subject is Bob's user hash here,
+    //    standing in for a listing; the zome does not care what it points at.
+    let subject: AnyLinkableHash = bob_user.clone().into();
+    let created: Record = conductors[0]
+        .call(
+            &alice.zome("notifications"),
+            "create_notification",
+            marker(bob.agent_pubkey(), Some(subject.clone()), "keen to help with this"),
+        )
+        .await;
+    let marker_hash = created.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob, &carol]).await.unwrap();
+
+    // 2. Bob's inbox has exactly one.
+    let inbox: Vec<Record> = conductors[1]
+        .call(&bob.zome("notifications"), "get_my_notifications", ())
+        .await;
+    assert_eq!(inbox.len(), 1, "Bob should see one open notification");
+
+    // 3. A duplicate on the same subject is refused.
+    let dup: Result<Record, _> = conductors[0]
+        .call_fallible(
+            &alice.zome("notifications"),
+            "create_notification",
+            marker(bob.agent_pubkey(), Some(subject.clone()), "again"),
+        )
+        .await;
+    assert!(dup.is_err(), "duplicate open marker on the same subject should be refused");
+
+    // 4. Bob marks it seen.
+    let _: ActionHash = conductors[1]
+        .call(&bob.zome("notifications"), "mark_seen", marker_hash.clone())
+        .await;
+    let seen: Vec<ActionHash> = conductors[1]
+        .call(&bob.zome("notifications"), "get_seen_notification_hashes", ())
+        .await;
+    assert_eq!(seen, vec![marker_hash.clone()], "seen list should hold the original hash");
+
+    // 5. Alice retracts; Bob's inbox empties. This is the revision read.
+    let _: Record = conductors[0]
+        .call(
+            &alice.zome("notifications"),
+            "retract_notification",
+            RetractNotificationInput {
+                original_action_hash: marker_hash.clone(),
+                previous_action_hash: marker_hash.clone(),
+            },
+        )
+        .await;
+    await_consistency_s(15, [&alice, &bob, &carol]).await.unwrap();
+    let inbox: Vec<Record> = conductors[1]
+        .call(&bob.zome("notifications"), "get_my_notifications", ())
+        .await;
+    assert_eq!(inbox.len(), 0, "retracted notification should not appear");
+
+    // 6. Cap, unconnected tier. One create so far; nine more create-and-retract
+    //    pairs bring the 24h count to ten. The eleventh must be refused.
+    for i in 0..9 {
+        let r: Record = conductors[0]
+            .call(
+                &alice.zome("notifications"),
+                "create_notification",
+                marker(bob.agent_pubkey(), None, &format!("ping {i}")),
+            )
+            .await;
+        let h = r.signed_action.hashed.hash.clone();
+        let _: Record = conductors[0]
+            .call(
+                &alice.zome("notifications"),
+                "retract_notification",
+                RetractNotificationInput { original_action_hash: h.clone(), previous_action_hash: h },
+            )
+            .await;
+    }
+    let eleventh: Result<Record, _> = conductors[0]
+        .call_fallible(
+            &alice.zome("notifications"),
+            "create_notification",
+            marker(bob.agent_pubkey(), None, "one too many"),
+        )
+        .await;
+    assert!(eleventh.is_err(), "eleventh unconnected marker in 24h should be refused");
+
+    // 7. Bob reciprocates. Connection is directional: Alice now holds an open
+    //    marker from Bob, so Alice is connected to Bob; Alice's markers to Bob
+    //    are all retracted, so Bob is not connected to Alice.
+    let _: Record = conductors[1]
+        .call(
+            &bob.zome("notifications"),
+            "create_notification",
+            marker(alice.agent_pubkey(), None, "likewise"),
+        )
+        .await;
+    await_consistency_s(15, [&alice, &bob, &carol]).await.unwrap();
+
+    let alice_to_bob: bool = conductors[0]
+        .call(&alice.zome("notifications"), "is_connected", bob.agent_pubkey().clone())
+        .await;
+    let bob_to_alice: bool = conductors[1]
+        .call(&bob.zome("notifications"), "is_connected", alice.agent_pubkey().clone())
+        .await;
+    assert!(alice_to_bob, "Alice should see Bob's open marker and be connected");
+    assert!(!bob_to_alice, "Bob should not be connected; Alice's markers are retracted");
+
+    // 8. Connected tier: Alice's ten sends to Bob are under the connected
+    //    allowance, so one more is now permitted where it was refused above.
+    let twelfth: Result<Record, _> = conductors[0]
+        .call_fallible(
+            &alice.zome("notifications"),
+            "create_notification",
+            marker(bob.agent_pubkey(), None, "now we are connected"),
+        )
+        .await;
+    assert!(twelfth.is_ok(), "connected tier should permit the marker the unconnected tier refused");
+
+    // 9. Connected sends do not draw on the stranger budget. Alice has sent
+    //    Bob eleven markers in the window, but Bob is connected, so her
+    //    unconnected count is zero and a first marker to Carol is allowed.
+    //    Carol needs no profile: only the actor must be accepted.
+    let to_stranger: Result<Record, _> = conductors[0]
+        .call_fallible(
+            &alice.zome("notifications"),
+            "create_notification",
+            marker(carol.agent_pubkey(), None, "hello, stranger"),
+        )
+        .await;
+    assert!(
+        to_stranger.is_ok(),
+        "sends to a connected peer should not count against the stranger budget"
+    );
+}

--- a/workdir/dna.yaml
+++ b/workdir/dna.yaml
@@ -13,6 +13,10 @@ integrity:
       hash: ~
       path: "../target/wasm32-unknown-unknown/release/administration_integrity.wasm"
       dependencies: ~
+    - name: notifications_integrity
+      hash: ~
+      path: "../target/wasm32-unknown-unknown/release/notifications_integrity.wasm"
+      dependencies: ~
     - name: requests_integrity
       hash: ~
       path: "../target/wasm32-unknown-unknown/release/requests_integrity.wasm"
@@ -41,6 +45,11 @@ coordinator:
       path: "../target/wasm32-unknown-unknown/release/administration.wasm"
       dependencies:
         - name: administration_integrity
+    - name: notifications
+      hash: ~
+      path: "../target/wasm32-unknown-unknown/release/notifications.wasm"
+      dependencies:
+        - name: notifications_integrity
     - name: requests
       hash: ~
       path: "../target/wasm32-unknown-unknown/release/requests.wasm"


### PR DESCRIPTION
Draft for frame-check alongside #219, which is the design this is built from. Not for merge until the entry shape has your nod.

One durable primitive: Notification entry, private SeenMarker, three link types. Interest markers are the first consumer. Create checks accepted status via administration, dedupes per subject, and enforces a two-tier rate cap from the local chain in one inbox walk. Read resolves each inbox entry to its latest revision by timestamp. Retraction is a state update. is_connected tests for a reciprocal open marker.

Deferred, deliberately: sealed payload (plaintext here, as #213 was); rate limits as DNA properties (constants here, since moving them touches the shared DnaProperties struct and belongs after the shape is agreed); admin resolution states (in the enum, unwritten); the live signal (calls messaging cross-zome, absent until #213 lands).

Nine-step Sweettest, three conductors, passes. Reverting the connected-budget logic makes step 9 fail.

The entry field set is yours to confirm; everything else here follows from it.