### PR TITLE
fix(#187): normalise client hashes at users_organizations write sites

### DIFF
--- a/dnas/requests_and_offers/utils/src/errors.rs
+++ b/dnas/requests_and_offers/utils/src/errors.rs
@@ -128,7 +128,10 @@ pub enum StatusError {
 }
 
 #[derive(Debug, Error)]
-pub enum ServiceTypeError {}
+pub enum ServiceTypeError {
+  #[error("Service type is already approved")]
+  AlreadyApproved,
+}
 
 impl From<CommonError> for WasmError {
   fn from(err: CommonError) -> Self {
@@ -157,6 +160,12 @@ impl From<CommonError> for WasmError {
 
 impl From<UsersError> for WasmError {
   fn from(err: UsersError) -> Self {
+    wasm_error!(WasmErrorInner::Guest(err.to_string()))
+  }
+}
+
+impl From<ServiceTypeError> for WasmError {
+  fn from(err: ServiceTypeError) -> Self {
     wasm_error!(WasmErrorInner::Guest(err.to_string()))
   }
 }

--- a/dnas/requests_and_offers/zomes/coordinator/service_types/src/service_type.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/service_types/src/service_type.rs
@@ -1,7 +1,7 @@
 use hdk::prelude::*;
 use service_types_integrity::{EntryTypes, LinkTypes, ServiceType};
 use utils::{
-  errors::{AdministrationError, CommonError},
+  errors::{AdministrationError, CommonError, ServiceTypeError},
   resolve_chain_root, GetServiceTypeForEntityInput, OriginalActionHash, PreviousActionHash,
   ServiceTypeLinkInput, UpdateServiceTypeLinksInput,
 };
@@ -305,6 +305,12 @@ pub fn approve_service_type(service_type_hash: ActionHash) -> ExternResult<()> {
   // Status paths are keyed by the chain root; a client holding a revision hash
   // would otherwise file this service type under a second, invisible identity.
   let service_type_hash = resolve_chain_root(service_type_hash);
+
+  // A steward may approve a rejected suggestion, reversing an earlier refusal,
+  // but approving twice is a mistake rather than a decision.
+  if get_service_type_status(service_type_hash.clone())? == "approved" {
+    return Err(ServiceTypeError::AlreadyApproved.into());
+  }
 
   // Get the approved path hash
   let approved_path_hash = get_status_path_hash(APPROVED_SERVICE_TYPES_PATH)?;

--- a/dnas/requests_and_offers/zomes/coordinator/users_organizations/src/organization.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/users_organizations/src/organization.rs
@@ -2,8 +2,8 @@ use hdk::prelude::*;
 use users_organizations_integrity::*;
 use utils::{
   errors::{AdministrationError, CommonError, OrganizationsError, UsersError},
-  EntityActionHash, OriginalActionHash, OrganizationContactInput, OrganizationUserInput,
-  PreviousActionHash,
+  find_original_action_hash, EntityActionHash, OriginalActionHash, OrganizationContactInput,
+  OrganizationUserInput, PreviousActionHash,
 };
 
 use crate::{
@@ -104,8 +104,24 @@ pub fn get_latest_organization(original_action_hash: ActionHash) -> ExternResult
   Ok(latest_organization)
 }
 
+/// Resolves both hashes of a client-supplied pair to their chain roots.
+/// Coordinator, member and contact links are anchored at the Create, so a
+/// client holding a revision would miss every guard below and anchor its
+/// link where nothing reads. Propagates rather than falling back: these are
+/// writes behind guards, and a guard looking in the wrong place is worse
+/// than a refused call.
+fn resolve_org_user_input(input: OrganizationUserInput) -> ExternResult<OrganizationUserInput> {
+  Ok(OrganizationUserInput {
+    organization_original_action_hash: find_original_action_hash(
+      input.organization_original_action_hash.0,
+    )?,
+    user_original_action_hash: find_original_action_hash(input.user_original_action_hash.0)?,
+  })
+}
+
 #[hdk_extern]
 pub fn add_member_to_organization(input: OrganizationUserInput) -> ExternResult<bool> {
+  let input = resolve_org_user_input(input)?;
   if !check_if_agent_is_organization_coordinator(input.organization_original_action_hash.0.clone())? {
     return Err(OrganizationsError::NotCoordinator.into());
   }
@@ -233,6 +249,7 @@ pub fn get_user_organizations(
 
 #[hdk_extern]
 pub fn add_coordinator_to_organization(input: OrganizationUserInput) -> ExternResult<bool> {
+  let input = resolve_org_user_input(input)?;
   if !check_if_agent_is_organization_coordinator(input.organization_original_action_hash.0.clone())? {
     return Err(OrganizationsError::NotCoordinator.into());
   }
@@ -372,6 +389,13 @@ pub fn get_organization_contact(
 
 #[hdk_extern]
 pub fn set_organization_contact(input: OrganizationContactInput) -> ExternResult<bool> {
+  let input = OrganizationContactInput {
+    organization_original_action_hash: find_original_action_hash(
+      input.organization_original_action_hash.0,
+    )?,
+    user_original_action_hash: find_original_action_hash(input.user_original_action_hash.0)?,
+    role: input.role,
+  };
   if !check_if_agent_is_organization_coordinator(input.organization_original_action_hash.0.clone())? {
     return Err(OrganizationsError::NotCoordinator.into());
   }
@@ -643,7 +667,10 @@ pub struct UpdateOrganizationInput {
 
 #[hdk_extern]
 pub fn update_organization(input: UpdateOrganizationInput) -> ExternResult<Record> {
-  if !check_if_agent_is_organization_coordinator(input.original_action_hash.0.clone())? {
+  // The client's original may be a revision; the guard and the update link
+  // both need the Create, and a write must not proceed on a guess.
+  let original = find_original_action_hash(input.original_action_hash.0.clone())?;
+  if !check_if_agent_is_organization_coordinator(original.0.clone())? {
     return Err(OrganizationsError::NotCoordinator.into());
   }
 
@@ -653,7 +680,7 @@ pub fn update_organization(input: UpdateOrganizationInput) -> ExternResult<Recor
   )?;
 
   create_link(
-    input.original_action_hash.0,
+    original.0,
     updated_organization_hash.clone(),
     LinkTypes::OrganizationUpdates,
     (),

--- a/dnas/requests_and_offers/zomes/coordinator/users_organizations/src/user.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/users_organizations/src/user.rs
@@ -1,7 +1,10 @@
 use hdk::prelude::*;
 use users_organizations_integrity::*;
 use utils::errors::{CommonError, UsersError};
-use utils::{check_if_progenitor, external_local_call, DnaProperties, EntityActionHashAgents, OriginalActionHash, PreviousActionHash};
+use utils::{
+  check_if_progenitor, external_local_call, find_original_action_hash, DnaProperties,
+  EntityActionHashAgents, OriginalActionHash, PreviousActionHash,
+};
 
 use crate::external_calls::create_status;
 
@@ -158,7 +161,10 @@ pub struct UpdateUserInput {
 
 #[hdk_extern]
 pub fn update_user(input: UpdateUserInput) -> ExternResult<Record> {
-  let original_record = must_get_valid_record(input.original_action_hash.clone().into())?;
+  // The client's original may be a revision; the update link must anchor at
+  // the Create or the next read from it will not find this edit.
+  let original = find_original_action_hash(input.original_action_hash.0.clone())?;
+  let original_record = must_get_valid_record(original.0.clone())?;
 
   let author = original_record.action().author().clone();
   if author != agent_info()?.agent_initial_pubkey {
@@ -168,7 +174,7 @@ pub fn update_user(input: UpdateUserInput) -> ExternResult<Record> {
   let updated_user_hash = update_entry(input.previous_action_hash.into(), &input.updated_user)?;
 
   create_link(
-    input.original_action_hash,
+    original,
     updated_user_hash.clone(),
     LinkTypes::UserUpdates,
     (),

--- a/tests/sweettest/src/common/conductors.rs
+++ b/tests/sweettest/src/common/conductors.rs
@@ -44,6 +44,18 @@ holochain_serialized_bytes::holochain_serial!(DnaPropertiesNoProgenitor);
 ///
 /// Uses `from_bundle_with_overrides` so each call also applies a fresh
 /// network seed — tests run in isolation.
+/// A network seed no other test in the same process will share. Every DNA
+/// built with the same properties has the same hash and therefore the same
+/// network, so parallel tests would otherwise gossip with and dial each
+/// other's conductors; the seed keeps each test's pair on its own network.
+fn unique_network_seed() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock before epoch")
+        .as_nanos();
+    format!("sweettest-{}-{:?}", nanos, std::thread::current().id())
+}
+
 async fn build_dna(progenitor_pubkey: impl Into<String>) -> DnaFile {
     let props = DnaProperties {
         progenitor_pubkey: progenitor_pubkey.into(),
@@ -53,7 +65,9 @@ async fn build_dna(progenitor_pubkey: impl Into<String>) -> DnaFile {
 
     SweetDnaFile::from_bundle_with_overrides(
         std::path::Path::new(DNA_PATH),
-        DnaModifiersOpt::default().with_properties(props_bytes),
+        DnaModifiersOpt::default()
+            .with_properties(props_bytes)
+            .with_network_seed(unique_network_seed()),
     )
     .await
     .unwrap_or_else(|e| {
@@ -101,7 +115,9 @@ async fn build_dna_no_progenitor() -> DnaFile {
 
     SweetDnaFile::from_bundle_with_overrides(
         std::path::Path::new(DNA_PATH),
-        DnaModifiersOpt::default().with_properties(props_bytes),
+        DnaModifiersOpt::default()
+            .with_properties(props_bytes)
+            .with_network_seed(unique_network_seed()),
     )
     .await
     .unwrap_or_else(|e| {

--- a/tests/sweettest/tests/organizations.rs
+++ b/tests/sweettest/tests/organizations.rs
@@ -190,3 +190,140 @@ async fn organization_membership_management() {
     // Alice (creator) remains; only Bob left.
     assert_eq!(members_after.len(), 1, "Organization should have one member (Alice) after Bob leaves");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn organization_tolerates_a_revision_handed_back_as_original() {
+    let (conductors, alice, bob) = setup_two_agents_with_alice_as_progenitor().await;
+
+    conductors[0]
+        .call::<_, Record>(&alice.zome("users_organizations"), "create_user", sample_user("Alice"))
+        .await;
+    conductors[1]
+        .call::<_, Record>(&bob.zome("users_organizations"), "create_user", sample_user("Bob"))
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    let alice_links: Vec<Link> = conductors[0]
+        .call(&alice.zome("users_organizations"), "get_agent_user", alice.agent_pubkey().clone())
+        .await;
+    let alice_user_hash = alice_links[0].target.clone().into_action_hash().unwrap();
+    let bob_links: Vec<Link> = conductors[1]
+        .call(&bob.zome("users_organizations"), "get_agent_user", bob.agent_pubkey().clone())
+        .await;
+    let bob_user_hash = bob_links[0].target.clone().into_action_hash().unwrap();
+
+    accept_entity(&conductors[0], &alice, ENTITY_USERS, alice_user_hash.clone()).await;
+    accept_entity(&conductors[0], &alice, ENTITY_USERS, bob_user_hash.clone()).await;
+
+    let org_record: Record = conductors[0]
+        .call(
+            &alice.zome("users_organizations"),
+            "create_organization",
+            sample_organization("Chain Org"),
+        )
+        .await;
+    let org_hash = org_record.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    accept_entity(&conductors[0], &alice, ENTITY_ORGANIZATIONS, org_hash.clone()).await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    // Two well-formed edits: original stays the Create, previous advances.
+    let first: Record = conductors[0]
+        .call(
+            &alice.zome("users_organizations"),
+            "update_organization",
+            serde_json::json!({
+                "original_action_hash": org_hash,
+                "previous_action_hash": org_record.signed_action.hashed.hash,
+                "updated_organization": OrganizationInput {
+                    name: "Chain Org 1".to_string(),
+                    ..sample_organization("Chain Org 1")
+                }
+            }),
+        )
+        .await;
+    let first_hash = first.signed_action.hashed.hash.clone();
+    let second: Record = conductors[0]
+        .call(
+            &alice.zome("users_organizations"),
+            "update_organization",
+            serde_json::json!({
+                "original_action_hash": org_hash,
+                "previous_action_hash": first_hash,
+                "updated_organization": OrganizationInput {
+                    name: "Chain Org 2".to_string(),
+                    ..sample_organization("Chain Org 2")
+                }
+            }),
+        )
+        .await;
+    let second_hash = second.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    // The third edit mimics a client that derived "original" from the latest
+    // record's original_action_address. In this DNA that field is the previous
+    // revision, so after two edits the client hands over the first revision.
+    let third = conductors[0]
+        .call_fallible::<_, Record>(
+            &alice.zome("users_organizations"),
+            "update_organization",
+            serde_json::json!({
+                "original_action_hash": first_hash,
+                "previous_action_hash": second_hash,
+                "updated_organization": OrganizationInput {
+                    name: "Chain Org 3".to_string(),
+                    ..sample_organization("Chain Org 3")
+                }
+            }),
+        )
+        .await;
+    assert!(
+        third.is_ok(),
+        "third edit with a revision as original must be accepted: {:?}",
+        third.err()
+    );
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    let latest: Option<Record> = conductors[1]
+        .call(
+            &bob.zome("users_organizations"),
+            "get_latest_organization_record",
+            org_hash.clone(),
+        )
+        .await;
+    let latest_org: Organization = latest.unwrap().entry().to_app_option().unwrap().expect("org");
+    assert_eq!(latest_org.name, "Chain Org 3", "third edit must be readable from the Create");
+
+    // A member add with the same poisoned hash must be accepted and must land
+    // where members are read from.
+    let added = conductors[0]
+        .call_fallible::<_, bool>(
+            &alice.zome("users_organizations"),
+            "add_member_to_organization",
+            serde_json::json!({
+                "organization_original_action_hash": first_hash,
+                "user_original_action_hash": bob_user_hash
+            }),
+        )
+        .await;
+    assert!(
+        added.is_ok(),
+        "member add with a revision as original must be accepted: {:?}",
+        added.err()
+    );
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    let members: Vec<Link> = conductors[1]
+        .call(
+            &bob.zome("users_organizations"),
+            "get_organization_members_links",
+            org_hash.clone(),
+        )
+        .await;
+    assert!(
+        members
+            .iter()
+            .any(|l| l.target.clone().into_action_hash() == Some(bob_user_hash.clone())),
+        "member link must anchor at the Create so Bob is readable from it"
+    );
+}

--- a/tests/sweettest/tests/service_types_status.rs
+++ b/tests/sweettest/tests/service_types_status.rs
@@ -93,7 +93,7 @@ async fn only_accepted_users_can_suggest() {
 /// Translated from `user-suggestion.test.ts / Administrators without accepted status can suggest`.
 #[tokio::test(flavor = "multi_thread")]
 async fn admin_can_suggest_without_accepted_status() {
-    let (conductors, alice, bob, alice_user_hash, bob_user_hash) = setup().await;
+    let (conductors, alice, bob, _alice_user_hash, bob_user_hash) = setup().await;
 
     // Register Bob as admin (still pending user).
     conductors[0]
@@ -102,7 +102,7 @@ async fn admin_can_suggest_without_accepted_status() {
             "add_administrator",
             EntityActionHashAgents {
                 entity: ENTITY_NETWORK.to_string(),
-                entity_original_action_hash: alice_user_hash,
+                entity_original_action_hash: bob_user_hash,
                 agent_pubkeys: vec![bob.agent_pubkey().clone()],
             },
         )

--- a/tests/sweettest/tests/users.rs
+++ b/tests/sweettest/tests/users.rs
@@ -183,3 +183,84 @@ async fn create_and_update_user() {
         .await;
     assert!(hijack_result.is_err(), "Bob should not update Alice's user");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn user_tolerates_a_revision_handed_back_as_original() {
+    let (conductors, alice, bob) = setup_two_agents().await;
+
+    let record: Record = conductors[0]
+        .call(&alice.zome("users_organizations"), "create_user", sample_user("Alice"))
+        .await;
+    let original_hash = record.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    // Two well-formed edits: original stays the Create, previous advances.
+    let first: Record = conductors[0]
+        .call(
+            &alice.zome("users_organizations"),
+            "update_user",
+            UpdateUserInput {
+                original_action_hash: original_hash.clone(),
+                previous_action_hash: original_hash.clone(),
+                updated_user: UserInput {
+                    name: "Alice 1".to_string(),
+                    ..sample_user("Alice 1")
+                },
+            },
+        )
+        .await;
+    let first_hash = first.signed_action.hashed.hash.clone();
+    let second: Record = conductors[0]
+        .call(
+            &alice.zome("users_organizations"),
+            "update_user",
+            UpdateUserInput {
+                original_action_hash: original_hash.clone(),
+                previous_action_hash: first_hash.clone(),
+                updated_user: UserInput {
+                    name: "Alice 2".to_string(),
+                    ..sample_user("Alice 2")
+                },
+            },
+        )
+        .await;
+    let second_hash = second.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    // The third edit mimics a client that derived "original" from the latest
+    // record's original_action_address, which is the previous revision here.
+    // update_user only checks authorship, which any revision satisfies, so
+    // this succeeds either way; what differs is where the update link lands.
+    let _: Record = conductors[0]
+        .call(
+            &alice.zome("users_organizations"),
+            "update_user",
+            UpdateUserInput {
+                original_action_hash: first_hash.clone(),
+                previous_action_hash: second_hash.clone(),
+                updated_user: UserInput {
+                    name: "Alice 3".to_string(),
+                    ..sample_user("Alice 3")
+                },
+            },
+        )
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    // Read through the author's conductor, as create_and_update_user does; a cold
+    // dial from the second conductor times out under sweettest on this transport.
+    let latest: Option<Record> = conductors[0]
+        .call(
+            &alice.zome("users_organizations"),
+            "get_latest_user_record",
+            original_hash.clone(),
+        )
+        .await;
+    let latest_user: User = latest
+        .expect("latest record")
+        .entry()
+        .to_app_option()
+        .unwrap()
+        .expect("user entry");
+    assert_eq!(latest_user.name, "Alice 3", "third edit must be readable from the Create");
+}


### PR DESCRIPTION
Closes #187. Closes #231.

Third in the chain after #184 and #212; base is fix/56-status-history.

## Chain root at the users_organizations write sites

The sweep found six sites. The update links in update_user and update_organization, and the member, coordinator and contact links in add_member_to_organization, add_coordinator_to_organization and set_organization_contact, all take the organisation or user hash as the client sends it, for their guards as well as their anchors. A coordinator guard reading a revision finds no coordinator; a link anchored at a revision is invisible from the Create.

A resolve_org_user_input helper resolves both hashes of the pair at the top of the three guard-fronted functions, before their guards. update_organization resolves once and uses the result for guard and anchor; update_user resolves for its anchor.

One decision. The resolve is find_original_action_hash(...)?, propagating, rather than the resolve_chain_root suggested on #187. Every site here is a write behind a guard; a failed resolution that falls back writes a link at a mid-chain anchor permanently, where a failed read can be retried. Same reasoning as on the #184 review and the shape #212 landed for status. The integrity side of the same question is #234: a link rule rejecting a non-Create base would make a fallback safe.

## Reproduction

Two correct edits, then a third that passes the first revision as original. That is what the organisation store derives after two edits: getLatestOrganization reads original_action_address from the latest record, which in this DNA is the previous revision rather than the Create (organizations.store.svelte.ts:357). The user store passes the original through untouched (users.store.svelte.ts:242), so the user site is guarded client-side today and fixed all the same.

On the unfixed zome the organisation case is refused with NotCoordinator and the user case writes its link where no read from the Create finds it. With the fix both third edits are readable from the Create by the other agent, and a member added with the same revision hash is readable from the Create. The store derivation is not changed here.

## Test harness

Both DNA builders in tests/sweettest/src/common/conductors.rs set properties and no network seed, so every test built from the same properties shared a DNA hash and a network. Each test runs its own two conductors and waits for consistency between those two; with three tests in parallel, six conductors were on one DHT. The organisation tests were isolated by a fresh progenitor key per test changing the hash; the users binary was not, and failed every parallel run with iroh timeouts inside get_links while each test passed alone. A unique seed per build isolates each test.

## #231

Included because it is the difference between a green suite and a caveat, and both halves are one line with their tests already written.

admin_can_suggest_without_accepted_status registered Bob with Alice as the entity; register_administrator returns early for an entity already registered, so Bob never received his link. The test now registers Bob as his own entity.

approving_already_approved_fails asserts a second approve is refused; admin_can_approve_rejected_service_type asserts a steward may approve a rejected suggestion. Read together: a refusal can be reversed, an approval cannot be repeated. approve_service_type now refuses when the current status is approved, under the chain-root resolve so it reads the same hash the sweep and the link use. ServiceTypeError gains its first variant and a From impl.

## Verification

Full sweettest suite, one run, on this commit: thirteen binaries, fifty-three tests, none failing. service_types_status has carried its two failures since #110. Run with --test-threads=4, which is what the largest binary needs on a laptop and belongs with #232.

## Related

#229, #233, #234 from the #184 review.
