### PR TITLE
feat(exchanges): record an exchange as six append-only entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,6 +1877,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "exchanges"
+version = "0.1.0"
+dependencies = [
+ "exchanges_integrity",
+ "hdk",
+ "serde",
+ "utils",
+]
+
+[[package]]
+name = "exchanges_integrity"
+version = "0.0.1"
+dependencies = [
+ "hdi",
+ "holochain_serialized_bytes",
+ "serde",
+ "utils",
+]
+
+[[package]]
 name = "exr"
 version = "1.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/dnas/requests_and_offers/workdir/dna.yaml
+++ b/dnas/requests_and_offers/workdir/dna.yaml
@@ -29,6 +29,10 @@ integrity:
       hash: ~
       path: "../../../target/wasm32-unknown-unknown/release/mediums_of_exchange_integrity.wasm"
       dependencies: ~
+    - name: exchanges_integrity
+      hash: ~
+      path: "../../../target/wasm32-unknown-unknown/release/exchanges_integrity.wasm"
+      dependencies: ~
 coordinator:
   zomes:
     - name: users_organizations
@@ -65,3 +69,8 @@ coordinator:
       path: "../../../target/wasm32-unknown-unknown/release/mediums_of_exchange.wasm"
       dependencies:
         - name: mediums_of_exchange_integrity
+    - name: exchanges
+      hash: ~
+      path: "../../../target/wasm32-unknown-unknown/release/exchanges.wasm"
+      dependencies:
+        - name: exchanges_integrity

--- a/dnas/requests_and_offers/zomes/coordinator/exchanges/Cargo.toml
+++ b/dnas/requests_and_offers/zomes/coordinator/exchanges/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "exchanges"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "exchanges"
+
+[dependencies]
+utils = { workspace = true }
+hdk = { workspace = true }
+serde = { workspace = true }
+exchanges_integrity = { workspace = true }

--- a/dnas/requests_and_offers/zomes/coordinator/exchanges/src/exchange.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/exchanges/src/exchange.rs
@@ -70,8 +70,10 @@ pub enum ExchangeStatus {
 pub struct Exchange {
   pub agreement: Record,
   pub response: Option<Record>,
-  pub completions: Vec<Record>,
-  pub reviews: Vec<Record>,
+  pub provider_completion: Option<Record>,
+  pub receiver_completion: Option<Record>,
+  pub provider_review: Option<Record>,
+  pub receiver_review: Option<Record>,
   pub cancellation: Option<Record>,
   pub status: ExchangeStatus,
 }
@@ -162,8 +164,8 @@ fn my_party(agreement: &Agreement) -> ExternResult<ActionHash> {
   }
 }
 
-fn has_entry_by(records: &[Record], author: &AgentPubKey) -> bool {
-  records.iter().any(|r| r.action().author() == author)
+fn by_author(records: &[Record], author: &AgentPubKey) -> Option<Record> {
+  records.iter().find(|r| r.action().author() == author).cloned()
 }
 
 /// Completion and review presuppose an accepted agreement that has not been
@@ -187,10 +189,10 @@ fn require_accepted(agreement_hash: &ActionHash) -> ExternResult<()> {
 
 fn derive_status(
   response: Option<&Record>,
-  completions: &[Record],
-  reviews: &[Record],
   cancellation: Option<&Record>,
-  agreement: &Agreement,
+  provider_done: bool,
+  receiver_done: bool,
+  both_reviewed: bool,
 ) -> ExternResult<ExchangeStatus> {
   if cancellation.is_some() {
     return Ok(ExchangeStatus::Cancelled);
@@ -202,20 +204,7 @@ fn derive_status(
   if !response.accepted {
     return Ok(ExchangeStatus::Declined);
   }
-  // Completions and reviews are authored by agents; the parties are user
-  // hashes. Compare through the agents behind the party records.
-  let provider_agent = record_at(agreement.provider.clone(), "provider")?
-    .action()
-    .author()
-    .clone();
-  let receiver_agent = record_at(agreement.receiver.clone(), "receiver")?
-    .action()
-    .author()
-    .clone();
-  let provider_done = has_entry_by(completions, &provider_agent);
-  let receiver_done = has_entry_by(completions, &receiver_agent);
   if provider_done && receiver_done {
-    let both_reviewed = has_entry_by(reviews, &provider_agent) && has_entry_by(reviews, &receiver_agent);
     return Ok(if both_reviewed { ExchangeStatus::Reviewed } else { ExchangeStatus::Complete });
   }
   if provider_done {
@@ -233,18 +222,35 @@ fn assemble(agreement_record: Record) -> ExternResult<Exchange> {
   let cancellations = records_from(hash, LinkTypes::AgreementCancellations)?;
   let response = responses.into_iter().next();
   let cancellation = cancellations.into_iter().next();
+  // Completions and reviews are authored by agents; the parties are user
+  // hashes. Split them by the agents behind the party records so readers
+  // see roles, not keys.
+  let provider_agent = record_at(agreement.provider.clone(), "provider")?
+    .action()
+    .author()
+    .clone();
+  let receiver_agent = record_at(agreement.receiver.clone(), "receiver")?
+    .action()
+    .author()
+    .clone();
+  let provider_completion = by_author(&completions, &provider_agent);
+  let receiver_completion = by_author(&completions, &receiver_agent);
+  let provider_review = by_author(&reviews, &provider_agent);
+  let receiver_review = by_author(&reviews, &receiver_agent);
   let status = derive_status(
     response.as_ref(),
-    &completions,
-    &reviews,
     cancellation.as_ref(),
-    &agreement,
+    provider_completion.is_some(),
+    receiver_completion.is_some(),
+    provider_review.is_some() && receiver_review.is_some(),
   )?;
   Ok(Exchange {
     agreement: agreement_record,
     response,
-    completions,
-    reviews,
+    provider_completion,
+    receiver_completion,
+    provider_review,
+    receiver_review,
     cancellation,
     status,
   })
@@ -265,6 +271,7 @@ pub fn create_interest(input: CreateInterestInput) -> ExternResult<Record> {
   let hash = create_entry(&EntryTypes::Interest(Interest {
     listing: listing.clone(),
     listing_type: input.listing_type,
+    user: me.clone(),
   }))?;
   create_link(listing, hash.clone(), LinkTypes::ListingInterests, ())?;
   create_link(me, hash.clone(), LinkTypes::UserInterests, ())?;
@@ -376,7 +383,7 @@ pub fn complete_agreement(agreement: ActionHash) -> ExternResult<Record> {
   my_party(&agreement)?;
   require_accepted(&agreement_hash)?;
   let existing = records_from(agreement_hash.clone(), LinkTypes::AgreementCompletions)?;
-  if has_entry_by(&existing, &my_pubkey()?) {
+  if by_author(&existing, &my_pubkey()?).is_some() {
     return Err(CommonError::InvalidData("you have already marked this exchange done".to_string()).into());
   }
   let hash = create_entry(&EntryTypes::Completion(Completion {
@@ -393,7 +400,7 @@ pub fn review_agreement(input: ReviewInput) -> ExternResult<Record> {
   my_party(&agreement)?;
   require_accepted(&agreement_hash)?;
   let existing = records_from(agreement_hash.clone(), LinkTypes::AgreementReviews)?;
-  if has_entry_by(&existing, &my_pubkey()?) {
+  if by_author(&existing, &my_pubkey()?).is_some() {
     return Err(CommonError::InvalidData("you have already reviewed this exchange".to_string()).into());
   }
   let hash = create_entry(&EntryTypes::Review(Review {

--- a/dnas/requests_and_offers/zomes/coordinator/exchanges/src/exchange.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/exchanges/src/exchange.rs
@@ -1,0 +1,449 @@
+use exchanges_integrity::*;
+use hdk::prelude::*;
+use utils::{
+  errors::{AdministrationError, CommonError},
+  find_original_action_hash,
+};
+
+use crate::external_calls::{check_if_entity_is_accepted, get_agent_user};
+
+// ---------------------------------------------------------------------------
+// Inputs
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CreateInterestInput {
+  pub listing: ActionHash,
+  pub listing_type: ListingType,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CreateAgreementInput {
+  pub listing: ActionHash,
+  pub listing_type: ListingType,
+  pub interest: ActionHash,
+  pub primary: ExchangeTerm,
+  pub reciprocal: ExchangeTerm,
+  pub medium: String,
+  pub terms: String,
+  pub delivery_timeframe: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RespondInput {
+  pub agreement: ActionHash,
+  pub accepted: bool,
+  pub note: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ReviewInput {
+  pub agreement: ActionHash,
+  pub rating: u8,
+  pub on_time: bool,
+  pub as_agreed: bool,
+  pub comment: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CancelInput {
+  pub agreement: ActionHash,
+  pub note: String,
+}
+
+// ---------------------------------------------------------------------------
+// Read model. Status is never stored; it is read from which entries exist.
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum ExchangeStatus {
+  Proposed,
+  Agreed,
+  ProviderDelivered,
+  Complete,
+  Reviewed,
+  Declined,
+  Cancelled,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Exchange {
+  pub agreement: Record,
+  pub response: Option<Record>,
+  pub completions: Vec<Record>,
+  pub reviews: Vec<Record>,
+  pub cancellation: Option<Record>,
+  pub status: ExchangeStatus,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn my_pubkey() -> ExternResult<AgentPubKey> {
+  Ok(agent_info()?.agent_initial_pubkey)
+}
+
+/// The calling agent's user hash, which must exist and be accepted.
+fn my_accepted_user() -> ExternResult<ActionHash> {
+  let me = my_pubkey()?;
+  let links = get_agent_user(me)?;
+  let user = links
+    .first()
+    .and_then(|l| l.target.clone().into_action_hash())
+    .ok_or(CommonError::ActionHashNotFound("user".to_string()))?;
+  if !check_if_entity_is_accepted("users".to_string(), user.clone())? {
+    return Err(AdministrationError::EntityNotAccepted("user".to_string()).into());
+  }
+  Ok(user)
+}
+
+/// The user hash behind an agent, for the party who is not the caller.
+fn user_for_agent(agent: AgentPubKey) -> ExternResult<ActionHash> {
+  get_agent_user(agent)?
+    .first()
+    .and_then(|l| l.target.clone().into_action_hash())
+    .ok_or(CommonError::ActionHashNotFound("user".to_string()).into())
+}
+
+/// Resolves a client-supplied hash to its Create. Propagating: every caller
+/// here is about to write, and a link anchored on a fallback is permanent.
+fn root(hash: ActionHash) -> ExternResult<ActionHash> {
+  Ok(find_original_action_hash(hash)?.0)
+}
+
+fn links_from(base: ActionHash, link_type: LinkTypes) -> ExternResult<Vec<Link>> {
+  let filter = link_type
+    .try_into_filter()
+    .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+  get_links(LinkQuery::new(base, filter), GetStrategy::Network)
+}
+
+fn records_from(base: ActionHash, link_type: LinkTypes) -> ExternResult<Vec<Record>> {
+  let mut records = Vec::new();
+  for link in links_from(base, link_type)? {
+    if let Some(hash) = link.target.into_action_hash() {
+      if let Some(record) = get(hash, GetOptions::default())? {
+        records.push(record);
+      }
+    }
+  }
+  Ok(records)
+}
+
+fn entry_of<T: TryFrom<SerializedBytes, Error = SerializedBytesError>>(
+  record: &Record,
+  what: &str,
+) -> ExternResult<T> {
+  record
+    .entry()
+    .to_app_option::<T>()
+    .map_err(CommonError::Serialize)?
+    .ok_or(CommonError::EntryNotFound(what.to_string()).into())
+}
+
+fn record_at(hash: ActionHash, what: &str) -> ExternResult<Record> {
+  get(hash, GetOptions::default())?.ok_or(CommonError::RecordNotFound(what.to_string()).into())
+}
+
+fn agreement_at(hash: &ActionHash) -> ExternResult<(Record, Agreement)> {
+  let record = record_at(hash.clone(), "agreement")?;
+  let agreement = entry_of::<Agreement>(&record, "agreement")?;
+  Ok((record, agreement))
+}
+
+/// Which party the caller is, or an error if neither.
+fn my_party(agreement: &Agreement) -> ExternResult<ActionHash> {
+  let me = my_accepted_user()?;
+  if me == agreement.provider || me == agreement.receiver {
+    Ok(me)
+  } else {
+    Err(AdministrationError::Unauthorized.into())
+  }
+}
+
+fn has_entry_by(records: &[Record], author: &AgentPubKey) -> bool {
+  records.iter().any(|r| r.action().author() == author)
+}
+
+/// Completion and review presuppose an accepted agreement that has not been
+/// cancelled; earlier or later they are refused rather than stored and ignored.
+fn require_accepted(agreement_hash: &ActionHash) -> ExternResult<()> {
+  if !records_from(agreement_hash.clone(), LinkTypes::AgreementCancellations)?.is_empty() {
+    return Err(CommonError::InvalidData("this agreement was cancelled".to_string()).into());
+  }
+  let responses = records_from(agreement_hash.clone(), LinkTypes::AgreementResponses)?;
+  let accepted = responses
+    .first()
+    .map(|r| entry_of::<Response>(r, "response"))
+    .transpose()?
+    .map(|r| r.accepted)
+    .unwrap_or(false);
+  if !accepted {
+    return Err(CommonError::InvalidData("this agreement has not been accepted".to_string()).into());
+  }
+  Ok(())
+}
+
+fn derive_status(
+  response: Option<&Record>,
+  completions: &[Record],
+  reviews: &[Record],
+  cancellation: Option<&Record>,
+  agreement: &Agreement,
+) -> ExternResult<ExchangeStatus> {
+  if cancellation.is_some() {
+    return Ok(ExchangeStatus::Cancelled);
+  }
+  let response = match response {
+    None => return Ok(ExchangeStatus::Proposed),
+    Some(r) => entry_of::<Response>(r, "response")?,
+  };
+  if !response.accepted {
+    return Ok(ExchangeStatus::Declined);
+  }
+  // Completions and reviews are authored by agents; the parties are user
+  // hashes. Compare through the agents behind the party records.
+  let provider_agent = record_at(agreement.provider.clone(), "provider")?
+    .action()
+    .author()
+    .clone();
+  let receiver_agent = record_at(agreement.receiver.clone(), "receiver")?
+    .action()
+    .author()
+    .clone();
+  let provider_done = has_entry_by(completions, &provider_agent);
+  let receiver_done = has_entry_by(completions, &receiver_agent);
+  if provider_done && receiver_done {
+    let both_reviewed = has_entry_by(reviews, &provider_agent) && has_entry_by(reviews, &receiver_agent);
+    return Ok(if both_reviewed { ExchangeStatus::Reviewed } else { ExchangeStatus::Complete });
+  }
+  if provider_done {
+    return Ok(ExchangeStatus::ProviderDelivered);
+  }
+  Ok(ExchangeStatus::Agreed)
+}
+
+fn assemble(agreement_record: Record) -> ExternResult<Exchange> {
+  let hash = agreement_record.signed_action.hashed.hash.clone();
+  let agreement = entry_of::<Agreement>(&agreement_record, "agreement")?;
+  let responses = records_from(hash.clone(), LinkTypes::AgreementResponses)?;
+  let completions = records_from(hash.clone(), LinkTypes::AgreementCompletions)?;
+  let reviews = records_from(hash.clone(), LinkTypes::AgreementReviews)?;
+  let cancellations = records_from(hash, LinkTypes::AgreementCancellations)?;
+  let response = responses.into_iter().next();
+  let cancellation = cancellations.into_iter().next();
+  let status = derive_status(
+    response.as_ref(),
+    &completions,
+    &reviews,
+    cancellation.as_ref(),
+    &agreement,
+  )?;
+  Ok(Exchange {
+    agreement: agreement_record,
+    response,
+    completions,
+    reviews,
+    cancellation,
+    status,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Interest
+// ---------------------------------------------------------------------------
+
+#[hdk_extern]
+pub fn create_interest(input: CreateInterestInput) -> ExternResult<Record> {
+  let me = my_accepted_user()?;
+  let listing = root(input.listing)?;
+  let listing_record = must_get_valid_record(listing.clone())?;
+  if listing_record.action().author() == &my_pubkey()? {
+    return Err(CommonError::InvalidData("a member cannot register interest in their own listing".to_string()).into());
+  }
+  let hash = create_entry(&EntryTypes::Interest(Interest {
+    listing: listing.clone(),
+    listing_type: input.listing_type,
+  }))?;
+  create_link(listing, hash.clone(), LinkTypes::ListingInterests, ())?;
+  create_link(me, hash.clone(), LinkTypes::UserInterests, ())?;
+  record_at(hash, "interest")
+}
+
+#[hdk_extern]
+pub fn withdraw_interest(interest: ActionHash) -> ExternResult<ActionHash> {
+  let interest = root(interest)?;
+  delete_entry(interest)
+}
+
+#[hdk_extern]
+pub fn get_interests_for_listing(listing: ActionHash) -> ExternResult<Vec<Record>> {
+  records_from(root(listing)?, LinkTypes::ListingInterests)
+}
+
+#[hdk_extern]
+pub fn get_my_interests(_: ()) -> ExternResult<Vec<Record>> {
+  let me = my_accepted_user()?;
+  records_from(me, LinkTypes::UserInterests)
+}
+
+// ---------------------------------------------------------------------------
+// Agreement
+// ---------------------------------------------------------------------------
+
+/// Either party writes the agreement up. The caller supplies the listing, the
+/// interest and the terms; provider, receiver and counterparty are derived
+/// here from the listing's author and the listing type, and derived again in
+/// validation, so a client cannot misname the parties.
+#[hdk_extern]
+pub fn create_agreement(input: CreateAgreementInput) -> ExternResult<Record> {
+  let me = my_pubkey()?;
+  let my_user = my_accepted_user()?;
+  let listing = root(input.listing)?;
+  let interest = root(input.interest)?;
+
+  let listing_author = must_get_valid_record(listing.clone())?.action().author().clone();
+  let interest_record = must_get_valid_record(interest.clone())?;
+  let interest_entry = entry_of::<Interest>(&interest_record, "interest")?;
+  if interest_entry.listing != listing {
+    return Err(CommonError::InvalidData("interest is for a different listing".to_string()).into());
+  }
+  let interest_author = interest_record.action().author().clone();
+
+  let other_agent = if me == listing_author {
+    interest_author.clone()
+  } else if me == interest_author {
+    listing_author.clone()
+  } else {
+    return Err(AdministrationError::Unauthorized.into());
+  };
+  let other_user = user_for_agent(other_agent)?;
+
+  let (listing_author_user, interested_user) = if me == listing_author {
+    (my_user.clone(), other_user.clone())
+  } else {
+    (other_user.clone(), my_user.clone())
+  };
+  let (provider, receiver) = match input.listing_type {
+    ListingType::Offer => (listing_author_user, interested_user),
+    ListingType::Request => (interested_user, listing_author_user),
+  };
+
+  let hash = create_entry(&EntryTypes::Agreement(Agreement {
+    listing: listing.clone(),
+    listing_type: input.listing_type,
+    interest,
+    counterparty: other_user.clone(),
+    provider,
+    receiver,
+    primary: input.primary,
+    reciprocal: input.reciprocal,
+    medium: input.medium,
+    terms: input.terms,
+    delivery_timeframe: input.delivery_timeframe,
+  }))?;
+  create_link(listing, hash.clone(), LinkTypes::ListingAgreements, ())?;
+  create_link(my_user, hash.clone(), LinkTypes::UserAgreements, ())?;
+  create_link(other_user, hash.clone(), LinkTypes::UserAgreements, ())?;
+  record_at(hash, "agreement")
+}
+
+#[hdk_extern]
+pub fn respond_to_agreement(input: RespondInput) -> ExternResult<Record> {
+  let agreement_hash = root(input.agreement)?;
+  let (_, agreement) = agreement_at(&agreement_hash)?;
+  let me = my_accepted_user()?;
+  if me != agreement.counterparty {
+    return Err(AdministrationError::Unauthorized.into());
+  }
+  if !links_from(agreement_hash.clone(), LinkTypes::AgreementResponses)?.is_empty() {
+    return Err(CommonError::InvalidData("this agreement already has a response".to_string()).into());
+  }
+  let hash = create_entry(&EntryTypes::Response(Response {
+    agreement: agreement_hash.clone(),
+    accepted: input.accepted,
+    note: input.note,
+  }))?;
+  create_link(agreement_hash, hash.clone(), LinkTypes::AgreementResponses, ())?;
+  record_at(hash, "response")
+}
+
+#[hdk_extern]
+pub fn complete_agreement(agreement: ActionHash) -> ExternResult<Record> {
+  let agreement_hash = root(agreement)?;
+  let (_, agreement) = agreement_at(&agreement_hash)?;
+  my_party(&agreement)?;
+  require_accepted(&agreement_hash)?;
+  let existing = records_from(agreement_hash.clone(), LinkTypes::AgreementCompletions)?;
+  if has_entry_by(&existing, &my_pubkey()?) {
+    return Err(CommonError::InvalidData("you have already marked this exchange done".to_string()).into());
+  }
+  let hash = create_entry(&EntryTypes::Completion(Completion {
+    agreement: agreement_hash.clone(),
+  }))?;
+  create_link(agreement_hash, hash.clone(), LinkTypes::AgreementCompletions, ())?;
+  record_at(hash, "completion")
+}
+
+#[hdk_extern]
+pub fn review_agreement(input: ReviewInput) -> ExternResult<Record> {
+  let agreement_hash = root(input.agreement)?;
+  let (_, agreement) = agreement_at(&agreement_hash)?;
+  my_party(&agreement)?;
+  require_accepted(&agreement_hash)?;
+  let existing = records_from(agreement_hash.clone(), LinkTypes::AgreementReviews)?;
+  if has_entry_by(&existing, &my_pubkey()?) {
+    return Err(CommonError::InvalidData("you have already reviewed this exchange".to_string()).into());
+  }
+  let hash = create_entry(&EntryTypes::Review(Review {
+    agreement: agreement_hash.clone(),
+    rating: input.rating,
+    on_time: input.on_time,
+    as_agreed: input.as_agreed,
+    comment: input.comment,
+  }))?;
+  create_link(agreement_hash, hash.clone(), LinkTypes::AgreementReviews, ())?;
+  record_at(hash, "review")
+}
+
+#[hdk_extern]
+pub fn cancel_agreement(input: CancelInput) -> ExternResult<Record> {
+  let agreement_hash = root(input.agreement)?;
+  let (_, agreement) = agreement_at(&agreement_hash)?;
+  my_party(&agreement)?;
+  let hash = create_entry(&EntryTypes::Cancellation(Cancellation {
+    agreement: agreement_hash.clone(),
+    note: input.note,
+  }))?;
+  create_link(agreement_hash, hash.clone(), LinkTypes::AgreementCancellations, ())?;
+  record_at(hash, "cancellation")
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+#[hdk_extern]
+pub fn get_exchange(agreement: ActionHash) -> ExternResult<Exchange> {
+  let hash = root(agreement)?;
+  let record = record_at(hash, "agreement")?;
+  assemble(record)
+}
+
+#[hdk_extern]
+pub fn get_my_exchanges(_: ()) -> ExternResult<Vec<Exchange>> {
+  let me = my_accepted_user()?;
+  records_from(me, LinkTypes::UserAgreements)?
+    .into_iter()
+    .map(assemble)
+    .collect()
+}
+
+#[hdk_extern]
+pub fn get_exchanges_for_listing(listing: ActionHash) -> ExternResult<Vec<Exchange>> {
+  records_from(root(listing)?, LinkTypes::ListingAgreements)?
+    .into_iter()
+    .map(assemble)
+    .collect()
+}

--- a/dnas/requests_and_offers/zomes/coordinator/exchanges/src/external_calls.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/exchanges/src/external_calls.rs
@@ -1,0 +1,18 @@
+use hdk::prelude::*;
+use utils::{external_local_call, EntityActionHash, OriginalActionHash};
+
+/// The user record links for an agent. Used for the caller's own user and
+/// for the other party's; both go through the extern, which reads the
+/// network (see #237 for the self-lookup case).
+pub fn get_agent_user(agent_pubkey: AgentPubKey) -> ExternResult<Vec<Link>> {
+  external_local_call("get_agent_user", "users_organizations", agent_pubkey)
+}
+
+/// Whether an entity has accepted status.
+pub fn check_if_entity_is_accepted(entity_type: String, entity_hash: ActionHash) -> ExternResult<bool> {
+  let input = EntityActionHash {
+    entity: entity_type,
+    entity_original_action_hash: OriginalActionHash(entity_hash),
+  };
+  external_local_call("check_if_entity_is_accepted", "administration", input)
+}

--- a/dnas/requests_and_offers/zomes/coordinator/exchanges/src/lib.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/exchanges/src/lib.rs
@@ -1,0 +1,10 @@
+//! Exchange record: the coordination layer of an exchange between two members.
+//!
+//! Interest, agreement, response, completion, review and cancellation, all
+//! append-only; state is read from which of them exist. See
+//! documentation/architecture/EXCHANGE_RECORD.md.
+
+pub mod exchange;
+pub mod external_calls;
+
+pub use exchange::*;

--- a/dnas/requests_and_offers/zomes/integrity/exchanges/Cargo.toml
+++ b/dnas/requests_and_offers/zomes/integrity/exchanges/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "exchanges_integrity"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "exchanges_integrity"
+
+[dependencies]
+utils = { workspace = true }
+hdi = { workspace = true }
+holochain_serialized_bytes = { workspace = true }
+serde = { workspace = true }

--- a/dnas/requests_and_offers/zomes/integrity/exchanges/src/lib.rs
+++ b/dnas/requests_and_offers/zomes/integrity/exchanges/src/lib.rs
@@ -1,0 +1,467 @@
+use hdi::prelude::*;
+use utils::errors::CommonError;
+
+/// Which kind of listing an exchange settles. Carried on entries so the
+/// coordinator looks the listing up in the right zome and a cross-zome error
+/// propagates rather than reading as absence.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum ListingType {
+  Request,
+  Offer,
+}
+
+/// Whose hands a resource moves out of, relative to the party the term
+/// belongs to.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum Direction {
+  Provide,
+  Receive,
+}
+
+/// What the reciprocal side is, as framed by the medium of exchange. The
+/// primary side is always a service.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum ResourceKind {
+  Service,
+  Currency,
+  Gift,
+  Tbd,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct Quantity {
+  pub value: f64,
+  pub unit: String,
+}
+
+/// One side of the pair. Mirrors an hREA intent: a transfer, in a direction,
+/// of a resource conforming to a specification, optionally quantified.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ExchangeTerm {
+  pub direction: Direction,
+  pub resource_conforms_to: String,
+  pub resource_kind: ResourceKind,
+  pub quantity: Option<Quantity>,
+}
+
+/// A member marking a listing as one they want to talk about. The first
+/// entry of every exchange; an agreement must point at one.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct Interest {
+  pub listing: ActionHash,
+  pub listing_type: ListingType,
+}
+
+/// What two parties agreed off-app, written up by either of them. The
+/// listing, the interest it settles, the two parties as user hashes, and the
+/// terms. The medium is the frame the reciprocal term is read through and is
+/// never itself a term.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct Agreement {
+  pub listing: ActionHash,
+  pub listing_type: ListingType,
+  pub interest: ActionHash,
+  pub counterparty: ActionHash,
+  pub provider: ActionHash,
+  pub receiver: ActionHash,
+  pub primary: ExchangeTerm,
+  pub reciprocal: ExchangeTerm,
+  pub medium: String,
+  pub terms: String,
+  pub delivery_timeframe: String,
+}
+
+/// The other party accepting or declining an agreement.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct Response {
+  pub agreement: ActionHash,
+  pub accepted: bool,
+  pub note: String,
+}
+
+/// One party recording that their part is done.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct Completion {
+  pub agreement: ActionHash,
+}
+
+/// One party's review of an exchange.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct Review {
+  pub agreement: ActionHash,
+  pub rating: u8,
+  pub on_time: bool,
+  pub as_agreed: bool,
+  pub comment: String,
+}
+
+/// Either party withdrawing from an agreement.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct Cancellation {
+  pub agreement: ActionHash,
+  pub note: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+  Interest(Interest),
+  Agreement(Agreement),
+  Response(Response),
+  Completion(Completion),
+  Review(Review),
+  Cancellation(Cancellation),
+}
+
+#[derive(Serialize, Deserialize)]
+#[hdk_link_types]
+pub enum LinkTypes {
+  /// Listing Create -> Interest.
+  ListingInterests,
+  /// User Create -> Interest, for the member's own dashboard.
+  UserInterests,
+  /// Listing Create -> Agreement.
+  ListingAgreements,
+  /// User Create -> Agreement, written for both parties.
+  UserAgreements,
+  /// Agreement Create -> Response.
+  AgreementResponses,
+  /// Agreement Create -> Completion.
+  AgreementCompletions,
+  /// Agreement Create -> Review.
+  AgreementReviews,
+  /// Agreement Create -> Cancellation.
+  AgreementCancellations,
+}
+
+#[hdk_extern]
+pub fn genesis_self_check(_data: GenesisSelfCheckData) -> ExternResult<ValidateCallbackResult> {
+  Ok(ValidateCallbackResult::Valid)
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic reads. Validation may use must_get_* and nothing else, so
+// every rule below reads exactly the records the entry names and no links.
+// ---------------------------------------------------------------------------
+
+fn invalid(reason: &str) -> ExternResult<ValidateCallbackResult> {
+  Ok(ValidateCallbackResult::Invalid(reason.to_string()))
+}
+
+/// The record at a hash, which must be a Create: the chain-root rule at the
+/// validation layer. A revision handed in as an identity is refused here on
+/// every peer, which is what makes any coordinator fallback safe.
+fn create_record(hash: &ActionHash, what: &str) -> ExternResult<Result<Record, String>> {
+  let record = must_get_valid_record(hash.clone())?;
+  match record.action() {
+    Action::Create(_) => Ok(Ok(record)),
+    _ => Ok(Err(format!("{what} must be referenced by its Create"))),
+  }
+}
+
+fn author_of(record: &Record) -> AgentPubKey {
+  record.action().author().clone()
+}
+
+fn entry_of<T: TryFrom<SerializedBytes, Error = SerializedBytesError>>(
+  record: &Record,
+  what: &str,
+) -> ExternResult<Result<T, String>> {
+  match record.entry().to_app_option::<T>() {
+    Ok(Some(entry)) => Ok(Ok(entry)),
+    Ok(None) => Ok(Err(format!("{what} has no entry"))),
+    Err(e) => Err(CommonError::Serialize(e).into()),
+  }
+}
+
+/// Reads an agreement by hash, checking it is a Create. Returns the record
+/// and the deserialized entry, or the reason it is unusable.
+fn agreement_at(hash: &ActionHash) -> ExternResult<Result<(Record, Agreement), String>> {
+  let record = match create_record(hash, "agreement")? {
+    Ok(r) => r,
+    Err(reason) => return Ok(Err(reason)),
+  };
+  let agreement = match entry_of::<Agreement>(&record, "agreement")? {
+    Ok(a) => a,
+    Err(reason) => return Ok(Err(reason)),
+  };
+  Ok(Ok((record, agreement)))
+}
+
+/// The agent behind a user hash: the author of the user's Create.
+fn agent_for_user(user: &ActionHash) -> ExternResult<Result<AgentPubKey, String>> {
+  Ok(create_record(user, "user")?.map(|r| author_of(&r)))
+}
+
+fn validate_term(term: &ExchangeTerm, side: &str) -> Option<String> {
+  match term.resource_kind {
+    ResourceKind::Gift | ResourceKind::Tbd => {
+      if term.quantity.is_some() {
+        return Some(format!("{side} term of kind gift or tbd carries no quantity"));
+      }
+      if !term.resource_conforms_to.is_empty() {
+        return Some(format!("{side} term of kind gift or tbd conforms to nothing"));
+      }
+    }
+    ResourceKind::Service | ResourceKind::Currency => {
+      if term.resource_conforms_to.is_empty() {
+        return Some(format!("{side} term names no resource specification"));
+      }
+    }
+  }
+  if let Some(q) = &term.quantity {
+    if !(q.value.is_finite() && q.value > 0.0) || q.unit.is_empty() {
+      return Some(format!("{side} term quantity must be positive with a unit"));
+    }
+  }
+  None
+}
+
+// ---------------------------------------------------------------------------
+// Entry rules
+// ---------------------------------------------------------------------------
+
+fn validate_interest(interest: &Interest) -> ExternResult<ValidateCallbackResult> {
+  if let Err(reason) = create_record(&interest.listing, "listing")? {
+    return invalid(&reason);
+  }
+  Ok(ValidateCallbackResult::Valid)
+}
+
+/// An agreement points at an interest on the same listing. Its author is the
+/// listing's author or the interest's author, and the counterparty is the
+/// other. Provider and receiver are those two, assigned by listing type.
+fn validate_agreement(author: &AgentPubKey, agreement: &Agreement) -> ExternResult<ValidateCallbackResult> {
+  let listing = match create_record(&agreement.listing, "listing")? {
+    Ok(r) => r,
+    Err(reason) => return invalid(&reason),
+  };
+  let interest_record = match create_record(&agreement.interest, "interest")? {
+    Ok(r) => r,
+    Err(reason) => return invalid(&reason),
+  };
+  let interest = match entry_of::<Interest>(&interest_record, "interest")? {
+    Ok(i) => i,
+    Err(reason) => return invalid(&reason),
+  };
+  if interest.listing != agreement.listing {
+    return invalid("agreement and its interest name different listings");
+  }
+  if interest.listing_type != agreement.listing_type {
+    return invalid("agreement and its interest disagree on listing type");
+  }
+
+  let listing_author = author_of(&listing);
+  let interest_author = author_of(&interest_record);
+  if listing_author == interest_author {
+    return invalid("a member cannot exchange with themselves");
+  }
+  let other = if *author == listing_author {
+    interest_author.clone()
+  } else if *author == interest_author {
+    listing_author.clone()
+  } else {
+    return invalid("agreement author is neither the listing author nor the interested member");
+  };
+
+  match agent_for_user(&agreement.counterparty)? {
+    Ok(agent) if agent == other => {}
+    Ok(_) => return invalid("counterparty is not the other party"),
+    Err(reason) => return invalid(&reason),
+  }
+
+  let provider_agent = match agent_for_user(&agreement.provider)? {
+    Ok(a) => a,
+    Err(reason) => return invalid(&reason),
+  };
+  let receiver_agent = match agent_for_user(&agreement.receiver)? {
+    Ok(a) => a,
+    Err(reason) => return invalid(&reason),
+  };
+  let (expected_provider, expected_receiver) = match agreement.listing_type {
+    ListingType::Offer => (listing_author.clone(), interest_author.clone()),
+    ListingType::Request => (interest_author.clone(), listing_author.clone()),
+  };
+  if provider_agent != expected_provider || receiver_agent != expected_receiver {
+    return invalid("provider and receiver do not match the listing type and its parties");
+  }
+
+  if agreement.primary.direction != Direction::Provide
+    || agreement.primary.resource_kind != ResourceKind::Service
+  {
+    return invalid("primary term is the service provided");
+  }
+  if agreement.reciprocal.direction != Direction::Receive {
+    return invalid("reciprocal term is what the provider receives");
+  }
+  if let Some(reason) = validate_term(&agreement.primary, "primary") {
+    return invalid(&reason);
+  }
+  if let Some(reason) = validate_term(&agreement.reciprocal, "reciprocal") {
+    return invalid(&reason);
+  }
+  if agreement.medium.trim().is_empty() {
+    return invalid("agreement names no medium of exchange");
+  }
+  Ok(ValidateCallbackResult::Valid)
+}
+
+/// A response is written by the agreement's counterparty.
+fn validate_response(author: &AgentPubKey, response: &Response) -> ExternResult<ValidateCallbackResult> {
+  let (_, agreement) = match agreement_at(&response.agreement)? {
+    Ok(pair) => pair,
+    Err(reason) => return invalid(&reason),
+  };
+  match agent_for_user(&agreement.counterparty)? {
+    Ok(agent) if agent == *author => Ok(ValidateCallbackResult::Valid),
+    Ok(_) => invalid("only the counterparty responds to an agreement"),
+    Err(reason) => invalid(&reason),
+  }
+}
+
+/// Completions, reviews and cancellations are written by a party.
+fn validate_party_entry(
+  author: &AgentPubKey,
+  agreement_hash: &ActionHash,
+  what: &str,
+) -> ExternResult<ValidateCallbackResult> {
+  let (_, agreement) = match agreement_at(agreement_hash)? {
+    Ok(pair) => pair,
+    Err(reason) => return invalid(&reason),
+  };
+  let provider = match agent_for_user(&agreement.provider)? {
+    Ok(a) => a,
+    Err(reason) => return invalid(&reason),
+  };
+  let receiver = match agent_for_user(&agreement.receiver)? {
+    Ok(a) => a,
+    Err(reason) => return invalid(&reason),
+  };
+  if *author == provider || *author == receiver {
+    Ok(ValidateCallbackResult::Valid)
+  } else {
+    invalid(&format!("only a party to the agreement writes a {what}"))
+  }
+}
+
+fn validate_review(author: &AgentPubKey, review: &Review) -> ExternResult<ValidateCallbackResult> {
+  if review.rating > 5 {
+    return invalid("rating is 0 to 5");
+  }
+  validate_party_entry(author, &review.agreement, "review")
+}
+
+// ---------------------------------------------------------------------------
+// Link rules. Every base is a Create of the right kind; every target is an
+// entry of the right type. Deletes are refused: the record is append-only.
+// ---------------------------------------------------------------------------
+
+fn base_is_create(base: &AnyLinkableHash, what: &str) -> ExternResult<Result<(), String>> {
+  let hash = match base.clone().into_action_hash() {
+    Some(h) => h,
+    None => return Ok(Err(format!("{what} link base is not an action hash"))),
+  };
+  Ok(create_record(&hash, what)?.map(|_| ()))
+}
+
+fn target_is<T: TryFrom<SerializedBytes, Error = SerializedBytesError>>(
+  target: &AnyLinkableHash,
+  what: &str,
+) -> ExternResult<Result<(), String>> {
+  let hash = match target.clone().into_action_hash() {
+    Some(h) => h,
+    None => return Ok(Err(format!("{what} link target is not an action hash"))),
+  };
+  let record = match create_record(&hash, what)? {
+    Ok(r) => r,
+    Err(reason) => return Ok(Err(reason)),
+  };
+  Ok(entry_of::<T>(&record, what)?.map(|_| ()))
+}
+
+fn validate_link(
+  link_type: LinkTypes,
+  base: &AnyLinkableHash,
+  target: &AnyLinkableHash,
+) -> ExternResult<ValidateCallbackResult> {
+  let base_check = match link_type {
+    LinkTypes::ListingInterests | LinkTypes::ListingAgreements => base_is_create(base, "listing")?,
+    LinkTypes::UserInterests | LinkTypes::UserAgreements => base_is_create(base, "user")?,
+    _ => base_is_create(base, "agreement")?,
+  };
+  if let Err(reason) = base_check {
+    return invalid(&reason);
+  }
+  let target_check = match link_type {
+    LinkTypes::ListingInterests | LinkTypes::UserInterests => target_is::<Interest>(target, "interest")?,
+    LinkTypes::ListingAgreements | LinkTypes::UserAgreements => target_is::<Agreement>(target, "agreement")?,
+    LinkTypes::AgreementResponses => target_is::<Response>(target, "response")?,
+    LinkTypes::AgreementCompletions => target_is::<Completion>(target, "completion")?,
+    LinkTypes::AgreementReviews => target_is::<Review>(target, "review")?,
+    LinkTypes::AgreementCancellations => target_is::<Cancellation>(target, "cancellation")?,
+  };
+  if let Err(reason) = target_check {
+    return invalid(&reason);
+  }
+  Ok(ValidateCallbackResult::Valid)
+}
+
+// ---------------------------------------------------------------------------
+// Routing. Every op reaches a rule; nothing falls through as valid by default
+// except ops this zome has no opinion on.
+// ---------------------------------------------------------------------------
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+  match op.flattened::<EntryTypes, LinkTypes>()? {
+    FlatOp::StoreEntry(store_entry) => match store_entry {
+      OpEntry::CreateEntry { app_entry, action } => {
+        let author = &action.author;
+        match app_entry {
+          EntryTypes::Interest(i) => validate_interest(&i),
+          EntryTypes::Agreement(a) => validate_agreement(author, &a),
+          EntryTypes::Response(r) => validate_response(author, &r),
+          EntryTypes::Completion(c) => validate_party_entry(author, &c.agreement, "completion"),
+          EntryTypes::Review(r) => validate_review(author, &r),
+          EntryTypes::Cancellation(c) => validate_party_entry(author, &c.agreement, "cancellation"),
+        }
+      }
+      OpEntry::UpdateEntry { .. } => invalid("exchange records are append-only; nothing is updated"),
+      _ => Ok(ValidateCallbackResult::Valid),
+    },
+    FlatOp::StoreRecord(store_record) => match store_record {
+      // An interest may be withdrawn by its author; nothing else is deleted.
+      OpRecord::DeleteEntry { original_action_hash, action, .. } => {
+        let original = must_get_valid_record(original_action_hash)?;
+        match original.entry().to_app_option::<Interest>() {
+          Ok(Some(_)) => {
+            if author_of(&original) == action.author {
+              Ok(ValidateCallbackResult::Valid)
+            } else {
+              invalid("only the interested member withdraws their interest")
+            }
+          }
+          _ => invalid("exchange records are append-only; only an interest is withdrawn"),
+        }
+      }
+      OpRecord::UpdateEntry { .. } => invalid("exchange records are append-only; nothing is updated"),
+      _ => Ok(ValidateCallbackResult::Valid),
+    },
+    FlatOp::RegisterCreateLink {
+      link_type,
+      base_address,
+      target_address,
+      ..
+    } => validate_link(link_type, &base_address, &target_address),
+    FlatOp::RegisterDeleteLink { .. } => invalid("exchange links are never deleted"),
+    _ => Ok(ValidateCallbackResult::Valid),
+  }
+}

--- a/dnas/requests_and_offers/zomes/integrity/exchanges/src/lib.rs
+++ b/dnas/requests_and_offers/zomes/integrity/exchanges/src/lib.rs
@@ -51,6 +51,8 @@ pub struct ExchangeTerm {
 pub struct Interest {
   pub listing: ActionHash,
   pub listing_type: ListingType,
+  /// The interested member's user hash, so a listing's author sees who.
+  pub user: ActionHash,
 }
 
 /// What two parties agreed off-app, written up by either of them. The
@@ -229,11 +231,15 @@ fn validate_term(term: &ExchangeTerm, side: &str) -> Option<String> {
 // Entry rules
 // ---------------------------------------------------------------------------
 
-fn validate_interest(interest: &Interest) -> ExternResult<ValidateCallbackResult> {
+fn validate_interest(author: &AgentPubKey, interest: &Interest) -> ExternResult<ValidateCallbackResult> {
   if let Err(reason) = create_record(&interest.listing, "listing")? {
     return invalid(&reason);
   }
-  Ok(ValidateCallbackResult::Valid)
+  match agent_for_user(&interest.user)? {
+    Ok(agent) if agent == *author => Ok(ValidateCallbackResult::Valid),
+    Ok(_) => invalid("an interest names its own author's user"),
+    Err(reason) => invalid(&reason),
+  }
 }
 
 /// An agreement points at an interest on the same listing. Its author is the
@@ -426,7 +432,7 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
       OpEntry::CreateEntry { app_entry, action } => {
         let author = &action.author;
         match app_entry {
-          EntryTypes::Interest(i) => validate_interest(&i),
+          EntryTypes::Interest(i) => validate_interest(author, &i),
           EntryTypes::Agreement(a) => validate_agreement(author, &a),
           EntryTypes::Response(r) => validate_response(author, &r),
           EntryTypes::Completion(c) => validate_party_entry(author, &c.agreement, "completion"),

--- a/documentation/DOCUMENTATION_INDEX.md
+++ b/documentation/DOCUMENTATION_INDEX.md
@@ -47,6 +47,7 @@
 
 - **[Architecture README](architecture/README.md)** - Architecture overview: component layout, 7-layer pattern, network bootstrap
 - **[Architecture Overview](architecture.md)** - System architecture and design patterns
+- **[Exchange Record](architecture/EXCHANGE_RECORD.md)** - The six-entry append-only exchange record: entry model, derived states, integrity rules
 - **[hREA Integration](architecture/hrea-integration.md)** - Holochain REA framework integration
 - **[Frontend Refactoring Programme](architecture/frontend-refactoring/README.md)** - Proposed evolution of the frontend: execution, coordination, representation
 
@@ -171,6 +172,7 @@
 - [Architecture Overview](architecture.md) - System design
 - [System Architecture](ai/rules/system-architecture.md) - Architectural guidelines
 - [7-Layer Effect-TS Architecture](../CLAUDE.md#architectural-patterns) - Framework patterns
+- [Exchange Record](architecture/EXCHANGE_RECORD.md) - How an exchange is recorded and its state derived
 - [hREA Integration](architecture/hrea-integration.md) - Resource-Event-Agent framework
 - [Frontend Refactoring Programme](architecture/frontend-refactoring/README.md) - Proposed frontend evolution and its implementation plan
 

--- a/documentation/architecture/EXCHANGE_RECORD.md
+++ b/documentation/architecture/EXCHANGE_RECORD.md
@@ -77,6 +77,27 @@ The design system's `ExchangeStatus` has nine values. Seven derive from which en
 
 **disputed** is out of scope: it is the stewarding case in `post-mvp-dispute-resolution.md` and belongs in alpha.3 with the rest of stewarding. The GitBook rule stands in the interim: concerns go to the administrator.
 
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> Proposed : Interest, then Agreement
+    Proposed --> Agreed : Response, accepted
+    Proposed --> Declined : Response, declined
+    Proposed --> Withdrawn : Cancellation
+    Agreed --> ProviderDelivered : Completion by provider
+    Agreed --> Agreed : Completion by receiver first
+    Agreed --> Cancelled : Cancellation
+    ProviderDelivered --> Complete : Completion by receiver
+    ProviderDelivered --> Cancelled : Cancellation
+    Complete --> Reviewed : Review by both
+    Declined --> [*]
+    Withdrawn --> [*]
+    Cancelled --> [*]
+    Reviewed --> [*]
+```
+
+Every arrow is one append-only entry; no state is stored. Withdrawn and Cancelled are the same `Cancellation` entry, told apart by whether a `Response` exists. Counter is a `Response` declined followed by a new `Agreement` on the same `Interest`. Whose turn it is falls out of the same reading: the counterparty at Proposed, whoever has not completed at Agreed, the receiver at ProviderDelivered, whoever has not reviewed at Complete.
+
 ## 7. Integrity rules
 
 Routed in the integrity zome's `validate`, every op, from the first commit, per #234.

--- a/documentation/architecture/EXCHANGE_RECORD.md
+++ b/documentation/architecture/EXCHANGE_RECORD.md
@@ -154,4 +154,10 @@ Pull. B's dashboard reads `UserAgreements`; A's listing reads `ListingInterests`
 
 ## 14. Milestone
 
-Proposed for alpha.1, and the decision is the reviewer's by merging or not. The case: the product owner requires the release to record exchanges; the change is a new zome pair and its UI and touches nothing existing; it is excluded by not merging, with nothing to unwind. #192 is alpha.1; if it lands first, this rebases onto it.
+Proposed for alpha.1 (#248), and the decision is the reviewer's by merging or not. The case: the product owner requires the release to record exchanges, and the change is excluded by not merging, with nothing to unwind.
+
+It is mostly new, but it does not touch nothing. Besides the new zome pair and its UI it modifies twelve existing files: `NavBar.svelte`, `NavDropdown.svelte`, `MenuDrawer.svelte`, `ContactModal.svelte`, the offer and request detail pages, `types/ui.ts`, `types/holochain.ts`, `errors/error-contexts.ts`, `errors/index.ts`, `utils/mocks.ts`, and both DNA manifests. The manifest change moves the DNA hash; breaking the DNA is accepted through v0.6.0 and migration is a v0.7.0 feature under #144, and alpha.1 has already moved the hash independently of this change.
+
+The listing pages are where the interim first contact lands: `ListingInterest.svelte` replaces `ContactButton`, because alpha.1 has no messaging and registering interest is how first contact happens. Both surfaces stay when the conversations module arrives in alpha.2; the interest button does not retract to being only an interest button.
+
+A Service Exchange names a real offer on both sides. The return service is chosen from the reciprocal giver's active offers, with no free-text alternative, because an intent with no ResourceSpecification behind it cannot be mirrored to hREA.

--- a/documentation/architecture/EXCHANGE_RECORD.md
+++ b/documentation/architecture/EXCHANGE_RECORD.md
@@ -1,0 +1,136 @@
+# Exchange Record: The Interim Half
+
+**Status:** frame-check draft (v0.2), for endorse-or-redirect, not a build spec
+**Companion:** `documentation/requirements/post-mvp/exchange-process.md` (the hREA-first design this precedes)
+**Related:** #90 (hREA exchange process, alpha.3), #190 (mutual consent on commitments), #51 and #219 (notifications, alpha.2), #184 (chain-root rule), #234 (link validation routing)
+
+---
+
+## 1. Why now
+
+The bulletin board pivot (`ab462063`) left R&O able to show a listing and the member's contact details, and nothing else. Two members can find each other and talk; the app has no record that they agreed anything or did anything. Alpha testers are being asked to make exchanges, and the product owner needs the release to record them. Messaging is alpha.2 and the hREA process is alpha.3, so this is the smallest thing that records an exchange before either exists.
+
+## 2. What it is, and is not
+
+It is the coordination layer: who responded to which listing, what the two of them agreed, whether each did their part, what each thought of it. Negotiation happens off-app, by whatever means the two people choose, using the contact details the profile already exposes (#220). The record starts when they have agreed.
+
+It is not an hREA agreement, a message thread, a dispute process, or a settlement. Each of those is a later layer that describes or extends this record; section 9 shows how.
+
+## 3. The flow
+
+1. B reads A's listing and marks interest. A sees B on the listing and on My Listings.
+2. A and B agree terms off-app.
+3. Either of them writes the agreement, naming the other and the terms. The other sees it on their dashboard.
+4. The other accepts or declines.
+5. Each party, when their part is done, marks it done.
+6. Each party, optionally, reviews.
+
+Either party may cancel after step 3. Nothing in the flow requires both to be online at once.
+
+## 4. Entry types
+
+All six are append-only. Nothing is edited; state is read from what exists (section 6).
+
+| Entry | Author | Fields |
+|---|---|---|
+| Interest | B | listing (original action hash) |
+| Agreement | A or B | listing, listing type, interest (the Interest this settles), counterparty, provider, receiver, primary term, reciprocal term, medium, terms (text), delivery timeframe (text) |
+| Response | the other party | agreement, accepted (bool), note (text) |
+| Completion | provider or receiver | agreement |
+| Review | provider or receiver | agreement, rating (0 to 5), on time (bool), as agreed (bool), comment (text) |
+| Cancellation | provider or receiver | agreement, note (text) |
+
+`provider` and `receiver` are the two parties as user hashes, assigned from the listing type: an offer's author provides, a request's author receives. `interest` is the Interest the agreement settles; every agreement follows an interest, whichever party writes it up. Terms follow the design system's `ExchangeTerm` exactly: action (transfer), direction, resource conforms to, resource kind (service, currency, gift, tbd), optional quantity. The medium is the frame the reciprocal term is read through and is never itself a term.
+
+Party names, locations and avatars are read from profiles at display time. The entries hold hashes only.
+
+## 5. Links
+
+| Link | Base | Target |
+|---|---|---|
+| ListingInterests | listing | Interest |
+| UserInterests | B | Interest |
+| ListingAgreements | listing | Agreement |
+| UserAgreements | A, and separately B | Agreement |
+| AgreementResponses | Agreement | Response |
+| AgreementCompletions | Agreement | Completion |
+| AgreementReviews | Agreement | Review |
+| AgreementCancellations | Agreement | Cancellation |
+
+A dashboard is `UserAgreements` from the viewer's own hash. A listing's interested members are `ListingInterests` from the listing. Everything about one exchange is the agreement and its four child link types.
+
+## 6. Derived states
+
+The design system's `ExchangeStatus` has nine values. Seven derive from which entries exist; two are decisions.
+
+| State | Read as |
+|---|---|
+| proposed | Agreement, no Response |
+| agreed | Response with accepted true, no Completion |
+| provider-delivered | Completion by provider only |
+| complete | Completion by both |
+| reviewed | Review by both |
+| declined | Response with accepted false |
+| cancelled | Cancellation by either |
+
+**in-progress** collapses into agreed: nothing happens between agreeing and delivering that either party records, so no entry can produce it. The detail screen labels agreed as underway.
+
+**disputed** is out of scope: it is the stewarding case in `post-mvp-dispute-resolution.md` and belongs in alpha.3 with the rest of stewarding. The GitBook rule stands in the interim: concerns go to the administrator.
+
+## 7. Integrity rules
+
+Routed in the integrity zome's `validate`, every op, from the first commit, per #234.
+
+- An Agreement points at an Interest whose listing is the Agreement's listing. The Agreement's author is either the listing's author or the Interest's author, and the counterparty is the other. Validation reads both records with `must_get_valid_record`, which is deterministic where a link read is not.
+- A Response's author is the Agreement's counterparty.
+- A Completion, Review or Cancellation's author is the Agreement's provider or receiver.
+- One Response per Agreement. One Completion and one Review per party per Agreement.
+- Every listing, interest and agreement hash an entry refers to is a Create, and every link base is a Create.
+
+A wrong write fails validation on every peer and never lands. The coordinator guards below are the same rules applied earlier, for a better error; the integrity rules are what make them true.
+
+## 8. Chain-root rule
+
+Every client-supplied hash, listing or agreement, is resolved to its Create before a guard reads it or a link anchors on it, per #184. These are writes, so the resolve is the propagating `find_original_action_hash(...)?`, per #212 and #236: a failed resolution refuses the call rather than anchoring a link where nothing reads.
+
+## 9. hREA mapping
+
+The companion design's table, with this record's entries beside it. Each row is a description of an entry that already exists, not a migration of it.
+
+| This record | hREA entity (companion design) |
+|---|---|
+| Agreement | Agreement, plus a Commitment per term |
+| Response, accepted | the Commitments become binding |
+| Completion, per party | EconomicEvent, one per party |
+| both Completions | Fulfillment links, Event to Commitment |
+| Review | custom review zome, as the companion design has it |
+| primary and reciprocal terms | Intent pair on the Proposal |
+
+When #90 lands, the mapping runs over existing agreements and new ones are written both ways. Nothing here is replaced.
+
+## 10. Screens
+
+The design system has the six: exchanges, detail, proposal, confirm, complete, review. Two changes for the interim. The proposal opens from the listing, or from an interest on it, rather than from a message thread. A listing gains an "interested" action for readers and, for its author, the list of who is interested with a "propose" beside each name.
+
+## 11. Notifications
+
+Pull. B's dashboard reads `UserAgreements`; A's listing reads `ListingInterests`. When #51 lands, each write sends a remote signal carrying the hash as a nudge. Signals are best-effort and unstored, so nothing that matters ever travels in one; the link is the record and the signal is a doorbell.
+
+## 12. Considered and not taken
+
+**Countersigning, now.** Holochain can commit one entry to both chains at once with both signatures, the literal form of "both sign". It needs both agents to accept a preflight inside a window of seconds to minutes and then commit; if one has stepped away the session fails and the app has to say so and fall back. Presence inferred from pings is a guess the session then tests the hard way. Agreement plus Response derives to the same state with each signature on its author's own chain and nobody waiting. When presence is real, alpha.2's signals, a countersigned Agreement becomes a fast path for the case where both are there, and derives to the same state with the same hREA mapping; nothing here has to move to admit it. #190 is where that decision sits.
+
+**The removed zome (`ab462063~1`), read rather than remembered.** It was in-app negotiation without messaging: B's response carried the terms, A approved or rejected it through a separate status entry with a reason, and an agreement was minted from the approved response. The agreement held a mutable status and two mutable completion flags, on status-path links that rotated as it moved; twenty-five externs, four update-chain link types. Its integrity `validate` handled `StoreEntry` and `StoreRecord` only, the same gap as #234. Reused from it: the Cargo and DNA wiring; `external_calls.rs`, with its listing lookup taking the listing type so a cross-zome error propagates instead of reading as absence; the review shape. Not reused: the response that carries terms, the status entry, the mutable agreement, the status paths, and the update chains for state.
+
+**A status field.** Every bug this month came from a mutable field or a mutable link standing in for state that should have been read. State here is derived and nothing is edited.
+
+## 13. Acceptance
+
+- Sweettest: the full lifecycle as one story; decline; cancel; each integrity rule refused at its site; a revision hash tolerated at each write.
+- Full sweettest suite green in one run on the commit.
+- Store and page unit tests; one e2e lifecycle spec for the side the harness can drive.
+- No file outside the two new zomes, `dna.yaml`, and the new UI is changed.
+
+## 14. Milestone
+
+Proposed for alpha.1, and the decision is the reviewer's by merging or not. The case: the product owner requires the release to record exchanges; the change is a new zome pair and its UI and touches nothing existing; it is excluded by not merging, with nothing to unwind. #192 is alpha.1; if it lands first, this rebases onto it.

--- a/documentation/requirements/post-mvp/exchange-process.md
+++ b/documentation/requirements/post-mvp/exchange-process.md
@@ -2,6 +2,8 @@
 
 > **Status**: Re-scoped to MVP. Targeted for **MVP: Exchange Process & Reputation** milestone. See [#90](https://github.com/happenings-community/requests-and-offers/issues/90).
 
+> **This document describes the second of two passes, and the first has shipped.** Alpha.1 records exchanges in a custom append-only zome pair rather than in hREA, because hREA is not yet building on the Holochain 0.7 line and the release needs exchanges recorded. That interim record is specified in [Exchange Record](../../architecture/EXCHANGE_RECORD.md), and each of its six entries has an hREA counterpart by design, so the record migrates rather than being replaced. The hREA-first architecture below is the alpha.2 target, and the migration between the two is [#250](https://github.com/happenings-community/requests-and-offers/issues/250). Read the section below as where this is going, not as what is running.
+
 ## Overview
 
 The **Exchange Process** is the core value exchange mechanism of the Requests and Offers application. This feature transforms static requests and offers into dynamic, managed transactions between community members, providing the economic coordination layer that enables actual value exchange within the peer-to-peer marketplace.

--- a/tests/sweettest/Cargo.toml
+++ b/tests/sweettest/Cargo.toml
@@ -72,5 +72,9 @@ name = "offers"
 path = "tests/offers.rs"
 
 [[test]]
+name = "exchanges"
+path = "tests/exchanges.rs"
+
+[[test]]
 name = "mediums_of_exchange"
 path = "tests/mediums_of_exchange.rs"

--- a/tests/sweettest/tests/exchanges.rs
+++ b/tests/sweettest/tests/exchanges.rs
@@ -1,0 +1,340 @@
+//! Exchange record: interest, agreement, response, completion, review,
+//! cancellation, with status derived from what exists.
+
+use holochain::prelude::*;
+use holochain::sweettest::*;
+use requests_and_offers_sweettest::common::*;
+use serde_json::{json, Value};
+
+/// The coordinator's read model, mirrored here so Records deserialize as
+/// Records; serde_json::Value cannot receive msgpack byte arrays.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct Exchange {
+    agreement: Record,
+    response: Option<Record>,
+    completions: Vec<Record>,
+    reviews: Vec<Record>,
+    cancellation: Option<Record>,
+    status: String,
+}
+
+fn service_term(direction: &str, what: &str) -> Value {
+    json!({
+        "direction": direction,
+        "resource_conforms_to": what,
+        "resource_kind": "Service",
+        "quantity": { "value": 2.0, "unit": "h" }
+    })
+}
+
+fn gift_term() -> Value {
+    json!({
+        "direction": "Receive",
+        "resource_conforms_to": "",
+        "resource_kind": "Gift",
+        "quantity": null
+    })
+}
+
+fn agreement_input(listing: &ActionHash, interest: &ActionHash) -> Value {
+    json!({
+        "listing": listing,
+        "listing_type": "Offer",
+        "interest": interest,
+        "primary": service_term("Provide", "Web design"),
+        "reciprocal": gift_term(),
+        "medium": "Pay it forward",
+        "terms": "Two hours of design review over a call, agreed by phone.",
+        "delivery_timeframe": "Within two weeks"
+    })
+}
+
+fn status_of(exchange: &Exchange) -> &str {
+    exchange.status.as_str()
+}
+
+/// Alice (progenitor, admin) creates an offer; both users accepted.
+/// Returns (conductors, alice, bob, offer_hash).
+async fn setup_with_offer() -> (SweetConductorBatch, SweetCell, SweetCell, ActionHash) {
+    let (conductors, alice, bob) = setup_two_agents_with_alice_as_progenitor().await;
+
+    conductors[0]
+        .call::<_, Record>(&alice.zome("users_organizations"), "create_user", sample_user("Alice"))
+        .await;
+    conductors[1]
+        .call::<_, Record>(&bob.zome("users_organizations"), "create_user", sample_user("Bob"))
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    let alice_links: Vec<Link> = conductors[0]
+        .call(&alice.zome("users_organizations"), "get_agent_user", alice.agent_pubkey().clone())
+        .await;
+    let alice_user_hash = alice_links[0].target.clone().into_action_hash().unwrap();
+    let bob_links: Vec<Link> = conductors[1]
+        .call(&bob.zome("users_organizations"), "get_agent_user", bob.agent_pubkey().clone())
+        .await;
+    let bob_user_hash = bob_links[0].target.clone().into_action_hash().unwrap();
+    accept_entity(&conductors[0], &alice, ENTITY_USERS, alice_user_hash).await;
+    accept_entity(&conductors[0], &alice, ENTITY_USERS, bob_user_hash).await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    let offer: Record = conductors[0]
+        .call(&alice.zome("offers"), "create_offer", sample_offer("Web design review"))
+        .await;
+    let offer_hash = offer.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    (conductors, alice, bob, offer_hash)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn exchange_lifecycle_from_interest_to_reviewed() {
+    let (conductors, alice, bob, offer_hash) = setup_with_offer().await;
+
+    // Bob marks interest; Alice sees it on her listing.
+    let interest: Record = conductors[1]
+        .call(
+            &bob.zome("exchanges"),
+            "create_interest",
+            json!({ "listing": offer_hash, "listing_type": "Offer" }),
+        )
+        .await;
+    let interest_hash = interest.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    let interests: Vec<Record> = conductors[0]
+        .call(&alice.zome("exchanges"), "get_interests_for_listing", offer_hash.clone())
+        .await;
+    assert_eq!(interests.len(), 1, "Alice sees Bob's interest on her listing");
+
+    // They talk off-app. Bob writes it up: either party may.
+    let agreement: Record = conductors[1]
+        .call(&bob.zome("exchanges"), "create_agreement", agreement_input(&offer_hash, &interest_hash))
+        .await;
+    let agreement_hash = agreement.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    let ex: Exchange = conductors[0]
+        .call(&alice.zome("exchanges"), "get_exchange", agreement_hash.clone())
+        .await;
+    assert_eq!(status_of(&ex), "Proposed");
+
+    // Alice, the counterparty, accepts.
+    let _: Record = conductors[0]
+        .call(
+            &alice.zome("exchanges"),
+            "respond_to_agreement",
+            json!({ "agreement": agreement_hash, "accepted": true, "note": "Looking forward to it." }),
+        )
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    let ex: Exchange = conductors[1]
+        .call(&bob.zome("exchanges"), "get_exchange", agreement_hash.clone())
+        .await;
+    assert_eq!(status_of(&ex), "Agreed");
+
+    // Alice provides (it is her offer) and marks done first.
+    let _: Record = conductors[0]
+        .call(&alice.zome("exchanges"), "complete_agreement", agreement_hash.clone())
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    let ex: Exchange = conductors[1]
+        .call(&bob.zome("exchanges"), "get_exchange", agreement_hash.clone())
+        .await;
+    assert_eq!(status_of(&ex), "ProviderDelivered");
+
+    // Bob marks done; both signed the same agreement as complete.
+    let _: Record = conductors[1]
+        .call(&bob.zome("exchanges"), "complete_agreement", agreement_hash.clone())
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    let ex: Exchange = conductors[0]
+        .call(&alice.zome("exchanges"), "get_exchange", agreement_hash.clone())
+        .await;
+    assert_eq!(status_of(&ex), "Complete");
+    assert_eq!(ex.completions.len(), 2);
+
+    // Both review.
+    for (i, cell) in [(0usize, &alice), (1usize, &bob)] {
+        let _: Record = conductors[i]
+            .call(
+                &cell.zome("exchanges"),
+                "review_agreement",
+                json!({ "agreement": agreement_hash, "rating": 5, "on_time": true, "as_agreed": true, "comment": "Great." }),
+            )
+            .await;
+    }
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    let ex: Exchange = conductors[1]
+        .call(&bob.zome("exchanges"), "get_exchange", agreement_hash.clone())
+        .await;
+    assert_eq!(status_of(&ex), "Reviewed");
+
+    // Each party's dashboard holds the one exchange.
+    let mine: Vec<Exchange> = conductors[0].call(&alice.zome("exchanges"), "get_my_exchanges", ()).await;
+    let theirs: Vec<Exchange> = conductors[1].call(&bob.zome("exchanges"), "get_my_exchanges", ()).await;
+    assert_eq!(mine.len(), 1);
+    assert_eq!(theirs.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agreement_declined_by_the_counterparty() {
+    let (conductors, alice, bob, offer_hash) = setup_with_offer().await;
+
+    let interest: Record = conductors[1]
+        .call(&bob.zome("exchanges"), "create_interest", json!({ "listing": offer_hash, "listing_type": "Offer" }))
+        .await;
+    let interest_hash = interest.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    // Alice writes it up this time; Bob is the counterparty and declines.
+    let agreement: Record = conductors[0]
+        .call(&alice.zome("exchanges"), "create_agreement", agreement_input(&offer_hash, &interest_hash))
+        .await;
+    let agreement_hash = agreement.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    let _: Record = conductors[1]
+        .call(
+            &bob.zome("exchanges"),
+            "respond_to_agreement",
+            json!({ "agreement": agreement_hash, "accepted": false, "note": "Timing does not work." }),
+        )
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    let ex: Exchange = conductors[0]
+        .call(&alice.zome("exchanges"), "get_exchange", agreement_hash.clone())
+        .await;
+    assert_eq!(status_of(&ex), "Declined");
+
+    // A declined agreement cannot be completed.
+    let done = conductors[0]
+        .call_fallible::<_, Record>(&alice.zome("exchanges"), "complete_agreement", agreement_hash)
+        .await;
+    assert!(done.is_err(), "completion of a declined agreement must be refused");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agreement_cancelled_after_acceptance() {
+    let (conductors, alice, bob, offer_hash) = setup_with_offer().await;
+
+    let interest: Record = conductors[1]
+        .call(&bob.zome("exchanges"), "create_interest", json!({ "listing": offer_hash, "listing_type": "Offer" }))
+        .await;
+    let interest_hash = interest.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    let agreement: Record = conductors[0]
+        .call(&alice.zome("exchanges"), "create_agreement", agreement_input(&offer_hash, &interest_hash))
+        .await;
+    let agreement_hash = agreement.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    let _: Record = conductors[1]
+        .call(
+            &bob.zome("exchanges"),
+            "respond_to_agreement",
+            json!({ "agreement": agreement_hash, "accepted": true, "note": "" }),
+        )
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    // Bob cancels; either party may.
+    let _: Record = conductors[1]
+        .call(
+            &bob.zome("exchanges"),
+            "cancel_agreement",
+            json!({ "agreement": agreement_hash, "note": "Something came up." }),
+        )
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    let ex: Exchange = conductors[0]
+        .call(&alice.zome("exchanges"), "get_exchange", agreement_hash.clone())
+        .await;
+    assert_eq!(status_of(&ex), "Cancelled");
+
+    let done = conductors[0]
+        .call_fallible::<_, Record>(&alice.zome("exchanges"), "complete_agreement", agreement_hash)
+        .await;
+    assert!(done.is_err(), "completion of a cancelled agreement must be refused");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn exchange_refusals() {
+    let (conductors, alice, bob, offer_hash) = setup_with_offer().await;
+
+    // A member cannot register interest in their own listing.
+    let own = conductors[0]
+        .call_fallible::<_, Record>(
+            &alice.zome("exchanges"),
+            "create_interest",
+            json!({ "listing": offer_hash, "listing_type": "Offer" }),
+        )
+        .await;
+    assert!(own.is_err(), "interest in your own listing must be refused");
+
+    let interest: Record = conductors[1]
+        .call(&bob.zome("exchanges"), "create_interest", json!({ "listing": offer_hash, "listing_type": "Offer" }))
+        .await;
+    let interest_hash = interest.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    // Bob writes the agreement, so Bob is not its counterparty and cannot respond to it.
+    let agreement: Record = conductors[1]
+        .call(&bob.zome("exchanges"), "create_agreement", agreement_input(&offer_hash, &interest_hash))
+        .await;
+    let agreement_hash = agreement.signed_action.hashed.hash.clone();
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    let self_response = conductors[1]
+        .call_fallible::<_, Record>(
+            &bob.zome("exchanges"),
+            "respond_to_agreement",
+            json!({ "agreement": agreement_hash, "accepted": true, "note": "" }),
+        )
+        .await;
+    assert!(self_response.is_err(), "the author of an agreement cannot respond to it");
+
+    // Completion before acceptance is refused.
+    let early = conductors[0]
+        .call_fallible::<_, Record>(&alice.zome("exchanges"), "complete_agreement", agreement_hash.clone())
+        .await;
+    assert!(early.is_err(), "completion before acceptance must be refused");
+
+    // Alice accepts once; a second response is refused.
+    let _: Record = conductors[0]
+        .call(
+            &alice.zome("exchanges"),
+            "respond_to_agreement",
+            json!({ "agreement": agreement_hash, "accepted": true, "note": "" }),
+        )
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    let second = conductors[0]
+        .call_fallible::<_, Record>(
+            &alice.zome("exchanges"),
+            "respond_to_agreement",
+            json!({ "agreement": agreement_hash, "accepted": true, "note": "" }),
+        )
+        .await;
+    assert!(second.is_err(), "a second response must be refused");
+
+    // A party completes once; a second completion by the same party is refused.
+    let _: Record = conductors[0]
+        .call(&alice.zome("exchanges"), "complete_agreement", agreement_hash.clone())
+        .await;
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+    let again = conductors[0]
+        .call_fallible::<_, Record>(&alice.zome("exchanges"), "complete_agreement", agreement_hash.clone())
+        .await;
+    assert!(again.is_err(), "a second completion by the same party must be refused");
+
+    // A rating above five is refused by validation.
+    let bad_review = conductors[0]
+        .call_fallible::<_, Record>(
+            &alice.zome("exchanges"),
+            "review_agreement",
+            json!({ "agreement": agreement_hash, "rating": 6, "on_time": true, "as_agreed": true, "comment": "" }),
+        )
+        .await;
+    assert!(bad_review.is_err(), "a rating above five must be refused");
+}

--- a/tests/sweettest/tests/exchanges.rs
+++ b/tests/sweettest/tests/exchanges.rs
@@ -13,8 +13,10 @@ use serde_json::{json, Value};
 struct Exchange {
     agreement: Record,
     response: Option<Record>,
-    completions: Vec<Record>,
-    reviews: Vec<Record>,
+    provider_completion: Option<Record>,
+    receiver_completion: Option<Record>,
+    provider_review: Option<Record>,
+    receiver_review: Option<Record>,
     cancellation: Option<Record>,
     status: String,
 }
@@ -153,7 +155,7 @@ async fn exchange_lifecycle_from_interest_to_reviewed() {
         .call(&alice.zome("exchanges"), "get_exchange", agreement_hash.clone())
         .await;
     assert_eq!(status_of(&ex), "Complete");
-    assert_eq!(ex.completions.len(), 2);
+    assert!(ex.provider_completion.is_some() && ex.receiver_completion.is_some());
 
     // Both review.
     for (i, cell) in [(0usize, &alice), (1usize, &bob)] {

--- a/ui/src/lib/components/exchanges/ListingInterest.svelte
+++ b/ui/src/lib/components/exchanges/ListingInterest.svelte
@@ -1,20 +1,26 @@
 <script lang="ts">
   import { encodeHashToBase64, type ActionHash } from '@holochain/client';
-  import { getToastStore } from '@skeletonlabs/skeleton';
+  import { getModalStore, getToastStore, type ModalComponent } from '@skeletonlabs/skeleton';
+  import ContactModal from '$lib/components/shared/listings/ContactModal.svelte';
   import exchangesStore from '$lib/stores/exchanges.store.svelte';
   import usersStore from '$lib/stores/users.store.svelte';
   import { runEffect } from '$lib/utils/effect';
   import type { ListingType } from '$lib/types/holochain';
-  import type { UIInterest, UIUser } from '$lib/types/ui';
+  import type { UIInterest, UIOrganization, UIUser } from '$lib/types/ui';
+  import { formatWhen } from '$lib/utils/exchange-ui';
 
   type Props = {
     listingHash: ActionHash;
     listingType: ListingType;
+    listingTitle: string;
+    creator: UIUser | null;
+    organization: UIOrganization | null;
     isCreator: boolean;
   };
-  let { listingHash, listingType, isCreator }: Props = $props();
+  let { listingHash, listingType, listingTitle, creator, organization, isCreator }: Props = $props();
 
   const toastStore = getToastStore();
+  const modalStore = getModalStore();
 
   let interests = $state<UIInterest[]>([]);
   let people = $state<Record<string, UIUser | null>>({});
@@ -25,6 +31,9 @@
   const isMine = (i: UIInterest) => !!me && i.user.toString() === me.toString();
   const mine = $derived(interests.find(isMine) ?? null);
   const others = $derived(interests.filter((i) => !isMine(i)));
+  const firstName = $derived(creator?.name?.split(' ')[0] ?? 'the listing owner');
+  const noun = $derived(listingType === 'Offer' ? 'offer' : 'request');
+  const hasContactInfo = $derived(!!(creator?.email || creator?.phone || organization?.email));
 
   const proposeHref = (interest: UIInterest) =>
     `/exchanges/propose?interest=${encodeHashToBase64(interest.interest_hash)}` +
@@ -35,6 +44,14 @@
       message: e instanceof Error ? e.message : String(e),
       background: 'variant-filled-error'
     });
+  }
+
+  function openContact() {
+    const component: ModalComponent = {
+      ref: ContactModal,
+      props: { user: creator, organization, listingType: noun, listingTitle }
+    };
+    modalStore.trigger({ type: 'component', component, meta: { title: '', body: '' } });
   }
 
   async function load() {
@@ -56,8 +73,8 @@
     busy = true;
     try {
       await runEffect(exchangesStore.createInterest(listingHash, listingType));
-      toastStore.trigger({ message: 'Interest registered', background: 'variant-filled-success' });
       await load();
+      if (hasContactInfo) openContact();
     } catch (e) {
       fail(e);
     } finally {
@@ -100,7 +117,7 @@
                 {person?.name ?? 'A member'}
               </a>
               <a class="variant-filled-primary btn btn-sm" href={proposeHref(interest)}>
-                Write up the agreement
+                Send a proposal
               </a>
             </li>
           {/each}
@@ -108,23 +125,32 @@
       {/if}
     </div>
   {:else if me}
-    <div class="card space-y-3 p-4">
+    <div class="space-y-2 text-center">
       {#if mine}
-        <p>You have registered interest. Either of you can write up the agreement.</p>
-        <div class="flex flex-wrap gap-2">
-          <a class="variant-filled-primary btn" href={proposeHref(mine)}>Write up the agreement</a>
-          <button class="variant-ghost-surface btn" onclick={withdraw} disabled={busy}>
+        <div class="alert variant-soft-primary py-2 text-sm">
+          You registered interest on {formatWhen(mine.created_at)}. {firstName} can see it; either of you can send a proposal.
+        </div>
+        <div class="flex flex-col gap-2 sm:flex-row">
+          <a class="variant-filled-primary btn flex-1" href={proposeHref(mine)}>Send a proposal</a>
+          <button class="variant-ghost-surface btn flex-1" onclick={withdraw} disabled={busy}>
             Withdraw interest
           </button>
         </div>
+        {#if hasContactInfo}
+          <button class="variant-soft-primary btn w-full" onclick={openContact}>
+            View contact information
+          </button>
+        {:else}
+          <p class="text-xs text-surface-500">Contact information not available</p>
+        {/if}
       {:else}
-        <p class="text-surface-500">
-          Registering interest lets the listing owner know, and lets either of you write up an
-          agreement.
-        </p>
-        <button class="variant-filled-primary btn" onclick={express} disabled={busy}>
-          I am interested
+        <button class="variant-filled-primary btn w-full" onclick={express} disabled={busy}>
+          Interested in this {noun}?
         </button>
+        <p class="text-xs text-surface-500">
+          Registering interest lets {firstName} know, opens their contact details, and lets either of
+          you send a proposal.
+        </p>
       {/if}
     </div>
   {/if}

--- a/ui/src/lib/components/exchanges/ListingInterest.svelte
+++ b/ui/src/lib/components/exchanges/ListingInterest.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+  import { encodeHashToBase64, type ActionHash } from '@holochain/client';
+  import { getToastStore } from '@skeletonlabs/skeleton';
+  import exchangesStore from '$lib/stores/exchanges.store.svelte';
+  import usersStore from '$lib/stores/users.store.svelte';
+  import { runEffect } from '$lib/utils/effect';
+  import type { ListingType } from '$lib/types/holochain';
+  import type { UIInterest, UIUser } from '$lib/types/ui';
+
+  type Props = {
+    listingHash: ActionHash;
+    listingType: ListingType;
+    isCreator: boolean;
+  };
+  let { listingHash, listingType, isCreator }: Props = $props();
+
+  const toastStore = getToastStore();
+
+  let interests = $state<UIInterest[]>([]);
+  let people = $state<Record<string, UIUser | null>>({});
+  let loaded = $state(false);
+  let busy = $state(false);
+
+  const me = $derived(usersStore.currentUser?.original_action_hash);
+  const isMine = (i: UIInterest) => !!me && i.user.toString() === me.toString();
+  const mine = $derived(interests.find(isMine) ?? null);
+  const others = $derived(interests.filter((i) => !isMine(i)));
+
+  const proposeHref = (interest: UIInterest) =>
+    `/exchanges/propose?interest=${encodeHashToBase64(interest.interest_hash)}` +
+    `&listing=${encodeHashToBase64(listingHash)}&type=${listingType}`;
+
+  function fail(e: unknown) {
+    toastStore.trigger({
+      message: e instanceof Error ? e.message : String(e),
+      background: 'variant-filled-error'
+    });
+  }
+
+  async function load() {
+    try {
+      interests = await runEffect(exchangesStore.getInterestsForListing(listingHash));
+      loaded = true;
+      for (const i of interests) {
+        const key = encodeHashToBase64(i.user);
+        if (!(key in people)) {
+          people[key] = await runEffect(usersStore.getUserByActionHash(i.user));
+        }
+      }
+    } catch (e) {
+      fail(e);
+    }
+  }
+
+  async function express() {
+    busy = true;
+    try {
+      await runEffect(exchangesStore.createInterest(listingHash, listingType));
+      toastStore.trigger({ message: 'Interest registered', background: 'variant-filled-success' });
+      await load();
+    } catch (e) {
+      fail(e);
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function withdraw() {
+    if (!mine) return;
+    busy = true;
+    try {
+      await runEffect(exchangesStore.withdrawInterest(mine.interest_hash));
+      toastStore.trigger({ message: 'Interest withdrawn', background: 'variant-filled-surface' });
+      await load();
+    } catch (e) {
+      fail(e);
+    } finally {
+      busy = false;
+    }
+  }
+
+  $effect(() => {
+    listingHash;
+    load();
+  });
+</script>
+
+{#if loaded}
+  {#if isCreator}
+    <div class="card space-y-3 p-4">
+      <h3 class="h3">Interested members</h3>
+      {#if others.length === 0}
+        <p class="text-surface-500">No one has registered interest yet.</p>
+      {:else}
+        <ul class="space-y-2">
+          {#each others as interest (encodeHashToBase64(interest.interest_hash))}
+            {@const person = people[encodeHashToBase64(interest.user)]}
+            <li class="flex items-center justify-between gap-3">
+              <a class="anchor" href={`/users/${encodeHashToBase64(interest.user)}`}>
+                {person?.name ?? 'A member'}
+              </a>
+              <a class="variant-filled-primary btn btn-sm" href={proposeHref(interest)}>
+                Write up the agreement
+              </a>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+  {:else if me}
+    <div class="card space-y-3 p-4">
+      {#if mine}
+        <p>You have registered interest. Either of you can write up the agreement.</p>
+        <div class="flex flex-wrap gap-2">
+          <a class="variant-filled-primary btn" href={proposeHref(mine)}>Write up the agreement</a>
+          <button class="variant-ghost-surface btn" onclick={withdraw} disabled={busy}>
+            Withdraw interest
+          </button>
+        </div>
+      {:else}
+        <p class="text-surface-500">
+          Registering interest lets the listing owner know, and lets either of you write up an
+          agreement.
+        </p>
+        <button class="variant-filled-primary btn" onclick={express} disabled={busy}>
+          I am interested
+        </button>
+      {/if}
+    </div>
+  {/if}
+{/if}

--- a/ui/src/lib/components/exchanges/ListingInterest.svelte
+++ b/ui/src/lib/components/exchanges/ListingInterest.svelte
@@ -148,7 +148,7 @@
           Interested in this {noun}?
         </button>
         <p class="text-xs text-surface-500">
-          Registering interest lets {firstName} know, opens their contact details, and lets either of
+          Registering interest notifies {firstName}, opens their contact details, and lets either of
           you send a proposal.
         </p>
       {/if}

--- a/ui/src/lib/components/mediums-of-exchange/MoEInitializer.svelte
+++ b/ui/src/lib/components/mediums-of-exchange/MoEInitializer.svelte
@@ -31,8 +31,7 @@
   const predefinedMediums: MediumOfExchangeInDHT[] = [
     // Base exchange categories (foundational types)
     { code: 'PAY_IT_FORWARD', name: 'Free/Pay it Forward', exchange_type: 'base' },
-    { code: 'EXCHANGE_SERVICES', name: 'Service Exchange', exchange_type: 'base' },
-    { code: 'OPEN_DISCUSSION', name: "Let's Discuss", exchange_type: 'base' }
+    { code: 'EXCHANGE_SERVICES', name: 'Service Exchange', exchange_type: 'base' }
   ];
 
   // Check if there are existing mediums of exchange
@@ -212,7 +211,6 @@
           <ul class="ml-2 list-inside list-disc space-y-1 text-xs">
             <li>Service Exchange</li>
             <li>Free/Pay it Forward</li>
-            <li>Let's Discuss</li>
           </ul>
           <p class="text-xs italic text-surface-500">
             Foundational exchange frameworks for non-monetary trades

--- a/ui/src/lib/components/offers/OfferDetailsModal.svelte
+++ b/ui/src/lib/components/offers/OfferDetailsModal.svelte
@@ -358,9 +358,9 @@
               {/if}
             </div>
             <div>
-              <p class="font-semibold">{creator.name}</p>
+              <p class="font-semibold">Name: {creator.name}</p>
               {#if creator.nickname}
-                <p class="text-surface-600-300-token text-sm">@{creator.nickname}</p>
+                <p class="text-surface-600-300-token text-sm">Nickname/Handle: {creator.nickname}</p>
               {/if}
             </div>
           </div>

--- a/ui/src/lib/components/requests/RequestDetailsModal.svelte
+++ b/ui/src/lib/components/requests/RequestDetailsModal.svelte
@@ -450,9 +450,9 @@
                   {/if}
                 </div>
                 <div>
-                  <p class="font-semibold">{creator.name}</p>
+                  <p class="font-semibold">Name: {creator.name}</p>
                   {#if creator.nickname}
-                    <p class="text-surface-600-300-token text-sm">@{creator.nickname}</p>
+                    <p class="text-surface-600-300-token text-sm">Nickname/Handle: {creator.nickname}</p>
                   {/if}
                 </div>
               </div>

--- a/ui/src/lib/components/requests/RequestForm.svelte
+++ b/ui/src/lib/components/requests/RequestForm.svelte
@@ -22,6 +22,7 @@
   import MediumOfExchangeSelector from '@/lib/components/mediums-of-exchange/MediumOfExchangeSelector.svelte';
   import MediumOfExchangeSuggestionForm from '@/lib/components/mediums-of-exchange/MediumOfExchangeSuggestionForm.svelte';
   import mediumsOfExchangeStore from '$lib/stores/mediums_of_exchange.store.svelte';
+  import offersStore from '$lib/stores/offers.store.svelte';
   import MarkdownToolbar from '$lib/components/shared/MarkdownToolbar.svelte';
 
   type Props = {
@@ -101,6 +102,33 @@
     timeZone = value;
   }
 
+  // A Service Exchange request needs the author to hold at least one
+  // active offer: a Service Exchange names a real offer on both sides.
+  // UI gate only; the zome stays permissive (the condition is temporal).
+  let myOffersCount = $state<number | null>(null);
+
+  const serviceExchangeSelected = $derived(
+    mediumsOfExchangeStore.approvedMediumsOfExchange.some(
+      (moe) =>
+        moe.name === 'Service Exchange' &&
+        selectedMediumOfExchange.some(
+          (h) => h.toString() === moe.original_action_hash?.toString()
+        )
+    )
+  );
+  const serviceExchangeGated = $derived(serviceExchangeSelected && myOffersCount === 0);
+
+  async function loadMyOffers() {
+    try {
+      const me = usersStore.currentUser?.original_action_hash;
+      if (!me) return;
+      const offers = await E.runPromise(offersStore.getUserOffers(me));
+      myOffersCount = offers.length;
+    } catch (error) {
+      console.error('Error loading own offers for the Service Exchange gate:', error);
+    }
+  }
+
   // Handle medium of exchange selection change
   function handleMediumOfExchangeChange(selectedHashes: ActionHash[]) {
     selectedMediumOfExchange = selectedHashes;
@@ -111,6 +139,7 @@
     loadCoordinatedOrganizations();
     loadPublishedOrganization();
     loadMediumsOfExchange();
+    loadMyOffers();
   });
 
   // Update service types and mediums of exchange when request is loaded (for edit mode)
@@ -668,9 +697,20 @@
     </label>
   </div>
 
+  {#if serviceExchangeGated}
+    <p class="alert variant-soft-warning text-sm">
+      Create an offer to enable service exchanges: a Service Exchange names a real offer on both
+      sides, so publish what you would give in return first.
+    </p>
+  {/if}
+
   <!-- Submit Button -->
   <div class="flex gap-4">
-    <button type="submit" class="variant-filled-primary btn" disabled={!isValid || submitting}>
+    <button
+      type="submit"
+      class="variant-filled-primary btn"
+      disabled={!isValid || submitting || serviceExchangeGated}
+    >
       {#if submitting}
         <span class="loading loading-spinner loading-sm"></span>
       {/if}

--- a/ui/src/lib/components/shared/NavBar.svelte
+++ b/ui/src/lib/components/shared/NavBar.svelte
@@ -10,6 +10,10 @@
   import NetworkStatusPopup from '$lib/components/network/NetworkStatusPopup.svelte';
   import usersStore from '$lib/stores/users.store.svelte';
   import administrationStore from '$lib/stores/administration.store.svelte';
+  import exchangesStore from '$lib/stores/exchanges.store.svelte';
+  import { turnOf } from '$lib/utils/exchange-ui';
+  import { runEffect } from '$lib/utils/effect';
+  import { onMount } from 'svelte';
   import {
     getConnectionStatusContext,
     type ConnectionStatus
@@ -87,11 +91,31 @@
       {
         href: '/exchanges',
         label: 'My Exchanges',
+        badge: pendingCount,
         icon: '🤝',
         description: 'Agreements you are part of'
       }
     ];
   }
+
+  // Exchanges waiting on this member: derived from the store's read model
+  // and turnOf, no notification system involved. Cleared by acting, not by
+  // dismissing. Refreshed on a poll so another agent's move shows without a
+  // reload; #51 replaces the poll with a signal later.
+  const pendingCount = $derived(
+    exchangesStore.exchanges.filter(
+      (e) => turnOf(e, usersStore.currentUser?.original_action_hash) === 'you'
+    ).length
+  );
+
+  onMount(() => {
+    const refresh = () => {
+      if (usersStore.currentUser) runEffect(exchangesStore.refreshMyExchanges()).catch(() => {});
+    };
+    refresh();
+    const interval = setInterval(refresh, 15000);
+    return () => clearInterval(interval);
+  });
 
   const communityItems = [
     {

--- a/ui/src/lib/components/shared/NavBar.svelte
+++ b/ui/src/lib/components/shared/NavBar.svelte
@@ -83,6 +83,12 @@
         label: 'My Listings',
         icon: '📋',
         description: 'Manage your requests and offers'
+      },
+      {
+        href: '/exchanges',
+        label: 'My Exchanges',
+        icon: '🤝',
+        description: 'Agreements you are part of'
       }
     ];
   }

--- a/ui/src/lib/components/shared/NavDropdown.svelte
+++ b/ui/src/lib/components/shared/NavDropdown.svelte
@@ -8,12 +8,16 @@
       label: string;
       icon: string;
       description?: string;
+      badge?: number;
     }>;
     isOpen?: boolean;
     alignRight?: boolean;
   };
 
   let { title, items, isOpen = false, alignRight = false }: Props = $props();
+
+  const total = $derived(items.reduce((n, item) => n + (item.badge ?? 0), 0));
+  const shown = (n: number) => (n > 9 ? '9+' : String(n));
 
   const dispatch = createEventDispatcher();
   let dropdownRef: HTMLDivElement;
@@ -77,9 +81,12 @@
     class="rounded px-3 py-2 transition-colors hover:text-secondary-300 focus:outline-none focus:ring-2 focus:ring-secondary-300 focus:ring-opacity-50"
     aria-expanded={isHovered}
     aria-haspopup="true"
-    aria-label={`${title} menu`}
+    aria-label={total > 0 ? `${title} menu, ${total} waiting on you` : `${title} menu`}
   >
     {title}
+    {#if total > 0}
+      <span class="badge ml-1 bg-white px-1.5 py-0 text-xs font-semibold text-primary-700" aria-hidden="true">{shown(total)}</span>
+    {/if}
     <svg
       class="ml-1 inline-block h-4 w-4 transition-transform duration-200 {isHovered
         ? 'rotate-180'
@@ -118,7 +125,15 @@
           <div class="flex items-center gap-3">
             <span class="flex-shrink-0 text-lg">{item.icon}</span>
             <div class="min-w-0 flex-1">
-              <div class="font-medium text-gray-900">{item.label}</div>
+              <div class="flex items-center gap-2 font-medium text-gray-900">
+                {item.label}
+                {#if item.badge}
+                  <span
+                    class="badge variant-filled-primary px-1.5 py-0 text-xs"
+                    aria-label="{item.badge} waiting on you"
+                  >{shown(item.badge)}</span>
+                {/if}
+              </div>
               {#if item.description}
                 <div class="truncate text-sm text-gray-500">{item.description}</div>
               {/if}

--- a/ui/src/lib/components/shared/drawers/MenuDrawer.svelte
+++ b/ui/src/lib/components/shared/drawers/MenuDrawer.svelte
@@ -105,6 +105,14 @@
           <span class="text-lg">📋</span>
           <span>My Listings</span>
         </a>
+        <a
+          href="/exchanges"
+          onclick={closeDrawer}
+          class="flex items-center gap-3 rounded-lg p-3 transition-colors hover:bg-primary-400"
+        >
+          <span class="text-xl">🤝</span>
+          <span>My Exchanges</span>
+        </a>
       </div>
     </div>
 

--- a/ui/src/lib/components/shared/listings/ContactDisplay.svelte
+++ b/ui/src/lib/components/shared/listings/ContactDisplay.svelte
@@ -131,9 +131,9 @@
           {/if}
         </div>
         <div>
-          <p class="font-semibold"><UserName user={user} /></p>
+          <p class="font-semibold">Name: <UserName user={user} /></p>
           {#if user.nickname}
-            <p class="text-sm text-surface-600 dark:text-surface-400">@{user.nickname}</p>
+            <p class="text-sm text-surface-600 dark:text-surface-400">Nickname/Handle: {user.nickname}</p>
           {/if}
         </div>
       </div>

--- a/ui/src/lib/components/shared/listings/ContactModal.svelte
+++ b/ui/src/lib/components/shared/listings/ContactModal.svelte
@@ -147,7 +147,7 @@
           <div class="flex-1">
             <h5 class="h5 font-medium text-white"><UserName user={user} /></h5>
             {#if user.nickname}
-              <p class="text-sm text-surface-300">@{user.nickname}</p>
+              <p class="text-sm text-surface-300">Nickname/Handle: {user.nickname}</p>
             {/if}
           </div>
         </div>

--- a/ui/src/lib/components/shared/listings/ContactModal.svelte
+++ b/ui/src/lib/components/shared/listings/ContactModal.svelte
@@ -20,6 +20,16 @@
     listingTitle = ''
   }: Props = $props();
 
+  // mailto and tel links. The subject names the listing so the recipient
+  // knows what the message is about before opening it.
+  const subject = $derived(listingTitle ? `Your ${listingType}: ${listingTitle}` : 'Requests & Offers');
+  const body = $derived(
+    `Hi,\n\nI saw your ${listingTitle ? listingType : 'listing'} on Requests & Offers and I am interested.\n\n`
+  );
+  const mailto = (email: string) =>
+    `mailto:${email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+  const tel = (phone: string) => `tel:${phone.replace(/[^+\d]/g, '')}`;
+
   const toastStore = getToastStore();
 
   // Computed values
@@ -88,7 +98,7 @@
             <span class="text-xl">📧</span>
             <div class="min-w-0 flex-1">
               <p class="text-sm font-medium text-surface-300">Email</p>
-              <p class="break-all font-mono text-sm text-white">{organization.email}</p>
+              <a href={mailto(organization.email)} class="break-all font-mono text-sm text-white underline decoration-dotted underline-offset-2 hover:text-primary-300">{organization.email}</a>
             </div>
           </div>
           <button
@@ -151,7 +161,7 @@
               <span class="text-xl">📧</span>
               <div class="min-w-0 flex-1">
                 <p class="text-sm font-medium text-surface-300">Email</p>
-                <p class="break-all font-mono text-sm text-white">{user.email}</p>
+                <a href={mailto(user.email)} class="break-all font-mono text-sm text-white underline decoration-dotted underline-offset-2 hover:text-primary-300">{user.email}</a>
               </div>
             </div>
             <button
@@ -172,7 +182,7 @@
               <span class="text-xl">📞</span>
               <div class="min-w-0 flex-1">
                 <p class="text-sm font-medium text-surface-300">Phone</p>
-                <p class="font-mono text-sm text-white">{user.phone}</p>
+                <a href={tel(user.phone)} class="break-all font-mono text-sm text-white underline decoration-dotted underline-offset-2 hover:text-primary-300">{user.phone}</a>
               </div>
             </div>
             <button

--- a/ui/src/lib/components/users/UserDetailsModal.svelte
+++ b/ui/src/lib/components/users/UserDetailsModal.svelte
@@ -86,7 +86,7 @@
       </div>
       <div class="flex min-w-0 flex-col items-center">
         <h2 class="h2 mb-1 truncate font-bold"><UserName user={user} /></h2>
-        <p class="text-surface-300">@{user.nickname}</p>
+        <p class="text-surface-300">Nickname/Handle: {user.nickname}</p>
         {#if user.bio}
           <MarkdownRenderer content={user.bio || ''} class="mt-3 text-center leading-relaxed" />
         {/if}

--- a/ui/src/lib/errors/error-contexts.ts
+++ b/ui/src/lib/errors/error-contexts.ts
@@ -237,48 +237,19 @@ export const HREA_CONTEXTS = {
   SYNC_WITH_HREA: 'Failed to sync with hREA'
 } as const;
 
-// Exchange Error Contexts
+// Exchange contexts
 export const EXCHANGE_CONTEXTS = {
-  // Proposal contexts
-  RESPONSE_CREATION: 'Creating exchange response',
-  RESPONSE_UPDATE: 'Updating response status',
-  RESPONSE_FETCH: 'Fetching exchange response',
-  RESPONSE_VALIDATION: 'Validating response data',
-  RESPONSE_APPROVAL: 'Approving exchange response',
-  RESPONSE_REJECTION: 'Rejecting exchange response',
-  RESPONSE_DELETION: 'Deleting exchange response',
-
-  // Agreement contexts
-  AGREEMENT_CREATION: 'Creating exchange agreement',
-  AGREEMENT_UPDATE: 'Updating agreement status',
-  AGREEMENT_FETCH: 'Fetching exchange agreement',
-  AGREEMENT_COMPLETION: 'Marking agreement complete',
-  AGREEMENT_PROVIDER_COMPLETION: 'Provider marking completion',
-  AGREEMENT_RECEIVER_COMPLETION: 'Receiver marking completion',
-
-  // Review contexts
-  REVIEW_CREATION: 'Creating exchange review',
-  REVIEW_FETCH: 'Fetching exchange review',
-  REVIEW_VALIDATION: 'Validating review data',
-  REVIEW_STATISTICS: 'Calculating review statistics',
-
-  // Collection contexts
-  RESPONSES_FETCH: 'Fetching exchange responses',
-  AGREEMENTS_FETCH: 'Fetching exchange agreements',
-  REVIEWS_FETCH: 'Fetching exchange reviews',
-  EXCHANGE_DASHBOARD: 'Loading exchange dashboard',
-
-  // Business logic contexts
-  EXCHANGE_WORKFLOW: 'Processing exchange workflow',
-  PERMISSIONS_CHECK: 'Checking exchange permissions',
-  STATUS_TRANSITION: 'Processing status transition',
-  ENTITY_LINKING: 'Creating entity relationships',
-
-  // Cache contexts
-  RESPONSE_CACHE: 'Managing response cache',
-  AGREEMENT_CACHE: 'Managing agreement cache',
-  REVIEW_CACHE: 'Managing review cache',
-  CACHE_INVALIDATION: 'Invalidating exchange cache'
+  CREATE_INTEREST: 'Failed to register interest',
+  WITHDRAW_INTEREST: 'Failed to withdraw interest',
+  GET_INTERESTS: 'Failed to get interests',
+  CREATE_AGREEMENT: 'Failed to write up the agreement',
+  RESPOND: 'Failed to respond to the agreement',
+  COMPLETE: 'Failed to mark the exchange done',
+  REVIEW: 'Failed to review the exchange',
+  CANCEL: 'Failed to cancel the agreement',
+  GET_EXCHANGE: 'Failed to get the exchange',
+  GET_MY_EXCHANGES: 'Failed to get your exchanges',
+  GET_LISTING_EXCHANGES: 'Failed to get exchanges for the listing'
 } as const;
 
 // Weave/Moss domain contexts

--- a/ui/src/lib/errors/exchanges.errors.ts
+++ b/ui/src/lib/errors/exchanges.errors.ts
@@ -1,0 +1,40 @@
+import { Data } from 'effect';
+
+/**
+ * Error type for the Exchanges domain, one per domain as the other zomes have.
+ */
+export class ExchangeError extends Data.TaggedError('ExchangeError')<{
+  readonly message: string;
+  readonly cause?: unknown;
+  readonly context?: string;
+  readonly agreementId?: string;
+  readonly operation?: string;
+}> {
+  static fromError(
+    error: unknown,
+    context: string,
+    agreementId?: string,
+    operation?: string
+  ): ExchangeError {
+    if (error instanceof ExchangeError) {
+      return error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return new ExchangeError({
+      message: `${context}: ${message}`,
+      cause: error,
+      context,
+      agreementId,
+      operation
+    });
+  }
+
+  static create(
+    message: string,
+    context?: string,
+    agreementId?: string,
+    operation?: string
+  ): ExchangeError {
+    return new ExchangeError({ message, context, agreementId, operation });
+  }
+}

--- a/ui/src/lib/errors/index.ts
+++ b/ui/src/lib/errors/index.ts
@@ -6,6 +6,7 @@ export * from './holochain-client.errors';
 export * from './hrea.errors';
 export * from './mediums-of-exchange.errors';
 export * from './offers.errors';
+export * from './exchanges.errors';
 export * from './organizations.errors';
 export * from './requests.errors';
 export * from './runtime.errors';

--- a/ui/src/lib/schemas/users.schemas.ts
+++ b/ui/src/lib/schemas/users.schemas.ts
@@ -319,7 +319,7 @@ export const createUIUser = (data: Partial<UIUser>): UIUser => {
  * it should never appear in the UI. This function strips it (and a
  * defensive leading variant) for display.
  *
- * Embedded dots (initials like "J. R. R. Tolkien", titles like "Dr. Smith")
+ * Embedded dots (initials like "Arthur C. Clarke", titles like "Dr. Smith")
  * are preserved because they don't match the boundary patterns.
  */
 export const formatUserName = (name: string | null | undefined): string => {

--- a/ui/src/lib/services/zomes/exchanges.service.ts
+++ b/ui/src/lib/services/zomes/exchanges.service.ts
@@ -1,0 +1,136 @@
+import type { ActionHash, Record } from '@holochain/client';
+import { HolochainClientServiceTag } from '$lib/services/HolochainClientService.svelte';
+import { Effect as E, Layer, Context } from 'effect';
+import { ExchangeError } from '$lib/errors/exchanges.errors';
+import { EXCHANGE_CONTEXTS } from '$lib/errors/error-contexts';
+import type {
+  CreateAgreementInput,
+  ExchangeReadModel,
+  ListingType,
+  ReviewInput
+} from '$lib/types/holochain';
+import { wrapZomeCallWithErrorFactory } from '$lib/utils/zome-helpers';
+
+export { ExchangeError };
+
+// --- Service Interface ---
+
+export interface ExchangesService {
+  readonly createInterest: (
+    listing: ActionHash,
+    listingType: ListingType
+  ) => E.Effect<Record, ExchangeError>;
+  readonly withdrawInterest: (interest: ActionHash) => E.Effect<ActionHash, ExchangeError>;
+  readonly getInterestsForListing: (listing: ActionHash) => E.Effect<Record[], ExchangeError>;
+  readonly getMyInterests: () => E.Effect<Record[], ExchangeError>;
+  readonly createAgreement: (input: CreateAgreementInput) => E.Effect<Record, ExchangeError>;
+  readonly respondToAgreement: (
+    agreement: ActionHash,
+    accepted: boolean,
+    note: string
+  ) => E.Effect<Record, ExchangeError>;
+  readonly completeAgreement: (agreement: ActionHash) => E.Effect<Record, ExchangeError>;
+  readonly reviewAgreement: (
+    agreement: ActionHash,
+    review: ReviewInput
+  ) => E.Effect<Record, ExchangeError>;
+  readonly cancelAgreement: (agreement: ActionHash, note: string) => E.Effect<Record, ExchangeError>;
+  readonly getExchange: (agreement: ActionHash) => E.Effect<ExchangeReadModel, ExchangeError>;
+  readonly getMyExchanges: () => E.Effect<ExchangeReadModel[], ExchangeError>;
+  readonly getExchangesForListing: (
+    listing: ActionHash
+  ) => E.Effect<ExchangeReadModel[], ExchangeError>;
+}
+
+export class ExchangesServiceTag extends Context.Tag('ExchangesService')<
+  ExchangesServiceTag,
+  ExchangesService
+>() {}
+
+export const ExchangesServiceLive: Layer.Layer<
+  ExchangesServiceTag,
+  never,
+  HolochainClientServiceTag
+> = Layer.effect(
+  ExchangesServiceTag,
+  E.gen(function* () {
+    const holochainClient = yield* HolochainClientServiceTag;
+
+    const wrapZomeCall = <T>(
+      fnName: string,
+      payload: unknown,
+      context: string
+    ): E.Effect<T, ExchangeError> =>
+      wrapZomeCallWithErrorFactory(
+        holochainClient,
+        'exchanges',
+        fnName,
+        payload,
+        context,
+        ExchangeError.fromError
+      );
+
+    const createInterest = (listing: ActionHash, listingType: ListingType) =>
+      wrapZomeCall<Record>(
+        'create_interest',
+        { listing, listing_type: listingType },
+        EXCHANGE_CONTEXTS.CREATE_INTEREST
+      );
+
+    const withdrawInterest = (interest: ActionHash) =>
+      wrapZomeCall<ActionHash>('withdraw_interest', interest, EXCHANGE_CONTEXTS.WITHDRAW_INTEREST);
+
+    const getInterestsForListing = (listing: ActionHash) =>
+      wrapZomeCall<Record[]>('get_interests_for_listing', listing, EXCHANGE_CONTEXTS.GET_INTERESTS);
+
+    const getMyInterests = () =>
+      wrapZomeCall<Record[]>('get_my_interests', null, EXCHANGE_CONTEXTS.GET_INTERESTS);
+
+    const createAgreement = (input: CreateAgreementInput) =>
+      wrapZomeCall<Record>('create_agreement', input, EXCHANGE_CONTEXTS.CREATE_AGREEMENT);
+
+    const respondToAgreement = (agreement: ActionHash, accepted: boolean, note: string) =>
+      wrapZomeCall<Record>(
+        'respond_to_agreement',
+        { agreement, accepted, note },
+        EXCHANGE_CONTEXTS.RESPOND
+      );
+
+    const completeAgreement = (agreement: ActionHash) =>
+      wrapZomeCall<Record>('complete_agreement', agreement, EXCHANGE_CONTEXTS.COMPLETE);
+
+    const reviewAgreement = (agreement: ActionHash, review: ReviewInput) =>
+      wrapZomeCall<Record>('review_agreement', { agreement, ...review }, EXCHANGE_CONTEXTS.REVIEW);
+
+    const cancelAgreement = (agreement: ActionHash, note: string) =>
+      wrapZomeCall<Record>('cancel_agreement', { agreement, note }, EXCHANGE_CONTEXTS.CANCEL);
+
+    const getExchange = (agreement: ActionHash) =>
+      wrapZomeCall<ExchangeReadModel>('get_exchange', agreement, EXCHANGE_CONTEXTS.GET_EXCHANGE);
+
+    const getMyExchanges = () =>
+      wrapZomeCall<ExchangeReadModel[]>('get_my_exchanges', null, EXCHANGE_CONTEXTS.GET_MY_EXCHANGES);
+
+    const getExchangesForListing = (listing: ActionHash) =>
+      wrapZomeCall<ExchangeReadModel[]>(
+        'get_exchanges_for_listing',
+        listing,
+        EXCHANGE_CONTEXTS.GET_LISTING_EXCHANGES
+      );
+
+    return ExchangesServiceTag.of({
+      createInterest,
+      withdrawInterest,
+      getInterestsForListing,
+      getMyInterests,
+      createAgreement,
+      respondToAgreement,
+      completeAgreement,
+      reviewAgreement,
+      cancelAgreement,
+      getExchange,
+      getMyExchanges,
+      getExchangesForListing
+    });
+  })
+);

--- a/ui/src/lib/stores/exchanges.store.svelte.ts
+++ b/ui/src/lib/stores/exchanges.store.svelte.ts
@@ -31,6 +31,7 @@ export type ExchangesStore = {
   readonly error: string | null;
 
   loadMyExchanges: () => E.Effect<UIExchange[], ExchangeError>;
+  refreshMyExchanges: () => E.Effect<UIExchange[], ExchangeError>;
   getExchange: (agreement: ActionHash) => E.Effect<UIExchange, ExchangeError>;
   getExchangesForListing: (listing: ActionHash) => E.Effect<UIExchange[], ExchangeError>;
   getInterestsForListing: (listing: ActionHash) => E.Effect<UIInterest[], ExchangeError>;
@@ -112,17 +113,20 @@ export const createExchangesStore = (): E.Effect<ExchangesStore, never, Exchange
     const refetch = (agreement: ActionHash) =>
       pipe(service.getExchange(agreement), E.map(toUIExchange), E.map(upsert));
 
-    const loadMyExchanges = () =>
-      tracked(
-        pipe(
-          service.getMyExchanges(),
-          E.map((models) => models.map(toUIExchange)),
-          E.map((list) => {
-            exchanges = list;
-            return list;
-          })
-        )
+    const fetchMyExchanges = () =>
+      pipe(
+        service.getMyExchanges(),
+        E.map((models) => models.map(toUIExchange)),
+        E.map((list) => {
+          exchanges = list;
+          return list;
+        })
       );
+
+    const loadMyExchanges = () => tracked(fetchMyExchanges());
+
+    // Same fetch without the loading flag, for background polling.
+    const refreshMyExchanges = () => fetchMyExchanges();
 
     const getExchange = (agreement: ActionHash) => tracked(refetch(agreement));
 
@@ -175,6 +179,7 @@ export const createExchangesStore = (): E.Effect<ExchangesStore, never, Exchange
         return error;
       },
       loadMyExchanges,
+      refreshMyExchanges,
       getExchange,
       getExchangesForListing,
       getInterestsForListing,

--- a/ui/src/lib/stores/exchanges.store.svelte.ts
+++ b/ui/src/lib/stores/exchanges.store.svelte.ts
@@ -1,0 +1,203 @@
+import type { ActionHash, Record } from '@holochain/client';
+import { Effect as E, pipe } from 'effect';
+import {
+  ExchangesServiceTag,
+  ExchangesServiceLive,
+  type ExchangesService
+} from '$lib/services/zomes/exchanges.service';
+import { HolochainClientServiceLive } from '$lib/services/HolochainClientService.svelte';
+import { ExchangeError } from '$lib/errors/exchanges.errors';
+import { decodeRecord } from '$lib/utils';
+import type {
+  AgreementInDHT,
+  CancellationInDHT,
+  CreateAgreementInput,
+  ExchangeReadModel,
+  InterestInDHT,
+  ListingType,
+  ResponseInDHT,
+  ReviewInDHT,
+  ReviewInput
+} from '$lib/types/holochain';
+import type { UIExchange, UIInterest } from '$lib/types/ui';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export type ExchangesStore = {
+  readonly exchanges: UIExchange[];
+  readonly loading: boolean;
+  readonly error: string | null;
+
+  loadMyExchanges: () => E.Effect<UIExchange[], ExchangeError>;
+  getExchange: (agreement: ActionHash) => E.Effect<UIExchange, ExchangeError>;
+  getExchangesForListing: (listing: ActionHash) => E.Effect<UIExchange[], ExchangeError>;
+  getInterestsForListing: (listing: ActionHash) => E.Effect<UIInterest[], ExchangeError>;
+  getMyInterests: () => E.Effect<UIInterest[], ExchangeError>;
+  createInterest: (listing: ActionHash, listingType: ListingType) => E.Effect<UIInterest, ExchangeError>;
+  withdrawInterest: (interest: ActionHash) => E.Effect<void, ExchangeError>;
+  createAgreement: (input: CreateAgreementInput) => E.Effect<UIExchange, ExchangeError>;
+  respond: (agreement: ActionHash, accepted: boolean, note: string) => E.Effect<UIExchange, ExchangeError>;
+  complete: (agreement: ActionHash) => E.Effect<UIExchange, ExchangeError>;
+  review: (agreement: ActionHash, review: ReviewInput) => E.Effect<UIExchange, ExchangeError>;
+  cancel: (agreement: ActionHash, note: string) => E.Effect<UIExchange, ExchangeError>;
+};
+
+// ============================================================================
+// DECODING
+// ============================================================================
+
+const timed = (record: Record) => ({
+  created_at: Math.floor(Number(record.signed_action.hashed.content.timestamp) / 1000)
+});
+
+const hashOf = (record: Record): ActionHash => record.signed_action.hashed.hash;
+
+const entryWithTime = <T>(record: Record | null): (T & { created_at: number }) | undefined =>
+  record ? { ...decodeRecord<T>(record), ...timed(record) } : undefined;
+
+const toUIInterest = (record: Record): UIInterest => ({
+  ...decodeRecord<InterestInDHT>(record),
+  ...timed(record),
+  interest_hash: hashOf(record)
+});
+
+const toUIExchange = (model: ExchangeReadModel): UIExchange => ({
+  ...timed(model.agreement),
+  agreement_hash: hashOf(model.agreement),
+  agreement: decodeRecord<AgreementInDHT>(model.agreement),
+  status: model.status,
+  response: entryWithTime<ResponseInDHT>(model.response),
+  provider_done: model.provider_completion ? timed(model.provider_completion) : undefined,
+  receiver_done: model.receiver_completion ? timed(model.receiver_completion) : undefined,
+  provider_review: entryWithTime<ReviewInDHT>(model.provider_review),
+  receiver_review: entryWithTime<ReviewInDHT>(model.receiver_review),
+  cancellation: entryWithTime<CancellationInDHT>(model.cancellation)
+});
+
+// ============================================================================
+// STORE
+// ============================================================================
+
+export const createExchangesStore = (): E.Effect<ExchangesStore, never, ExchangesServiceTag> =>
+  E.gen(function* () {
+    const service: ExchangesService = yield* ExchangesServiceTag;
+
+    let exchanges = $state<UIExchange[]>([]);
+    let loading = $state(false);
+    let error = $state<string | null>(null);
+
+    /** Runs an effect with the store's loading and error flags around it. */
+    const tracked = <A>(effect: E.Effect<A, ExchangeError>): E.Effect<A, ExchangeError> =>
+      pipe(
+        E.sync(() => {
+          loading = true;
+          error = null;
+        }),
+        E.flatMap(() => effect),
+        E.tapError((e) => E.sync(() => (error = e.message))),
+        E.ensuring(E.sync(() => (loading = false)))
+      );
+
+    /** Replaces an exchange in the list by agreement hash, or appends it. */
+    const upsert = (exchange: UIExchange) => {
+      const key = exchange.agreement_hash.toString();
+      const i = exchanges.findIndex((x) => x.agreement_hash.toString() === key);
+      if (i >= 0) exchanges[i] = exchange;
+      else exchanges.push(exchange);
+      return exchange;
+    };
+
+    const refetch = (agreement: ActionHash) =>
+      pipe(service.getExchange(agreement), E.map(toUIExchange), E.map(upsert));
+
+    const loadMyExchanges = () =>
+      tracked(
+        pipe(
+          service.getMyExchanges(),
+          E.map((models) => models.map(toUIExchange)),
+          E.map((list) => {
+            exchanges = list;
+            return list;
+          })
+        )
+      );
+
+    const getExchange = (agreement: ActionHash) => tracked(refetch(agreement));
+
+    const getExchangesForListing = (listing: ActionHash) =>
+      tracked(pipe(service.getExchangesForListing(listing), E.map((m) => m.map(toUIExchange))));
+
+    const getInterestsForListing = (listing: ActionHash) =>
+      tracked(pipe(service.getInterestsForListing(listing), E.map((r) => r.map(toUIInterest))));
+
+    const getMyInterests = () =>
+      tracked(pipe(service.getMyInterests(), E.map((r) => r.map(toUIInterest))));
+
+    const createInterest = (listing: ActionHash, listingType: ListingType) =>
+      tracked(pipe(service.createInterest(listing, listingType), E.map(toUIInterest)));
+
+    const withdrawInterest = (interest: ActionHash) =>
+      tracked(pipe(service.withdrawInterest(interest), E.asVoid));
+
+    const createAgreement = (input: CreateAgreementInput) =>
+      tracked(
+        pipe(
+          service.createAgreement(input),
+          E.flatMap((record) => refetch(hashOf(record)))
+        )
+      );
+
+    const afterWrite = (agreement: ActionHash, write: E.Effect<Record, ExchangeError>) =>
+      tracked(pipe(write, E.flatMap(() => refetch(agreement))));
+
+    const respond = (agreement: ActionHash, accepted: boolean, note: string) =>
+      afterWrite(agreement, service.respondToAgreement(agreement, accepted, note));
+
+    const complete = (agreement: ActionHash) =>
+      afterWrite(agreement, service.completeAgreement(agreement));
+
+    const review = (agreement: ActionHash, input: ReviewInput) =>
+      afterWrite(agreement, service.reviewAgreement(agreement, input));
+
+    const cancel = (agreement: ActionHash, note: string) =>
+      afterWrite(agreement, service.cancelAgreement(agreement, note));
+
+    return {
+      get exchanges() {
+        return exchanges;
+      },
+      get loading() {
+        return loading;
+      },
+      get error() {
+        return error;
+      },
+      loadMyExchanges,
+      getExchange,
+      getExchangesForListing,
+      getInterestsForListing,
+      getMyInterests,
+      createInterest,
+      withdrawInterest,
+      createAgreement,
+      respond,
+      complete,
+      review,
+      cancel
+    };
+  });
+
+// ============================================================================
+// STORE INSTANCE
+// ============================================================================
+
+const exchangesStore: ExchangesStore = pipe(
+  createExchangesStore(),
+  E.provide(ExchangesServiceLive),
+  E.provide(HolochainClientServiceLive),
+  E.runSync
+);
+
+export default exchangesStore;

--- a/ui/src/lib/stores/offers.store.svelte.ts
+++ b/ui/src/lib/stores/offers.store.svelte.ts
@@ -129,8 +129,9 @@ const createUIOffer = createUIEntityFromRecord<OfferInDHT, UIOffer>(
       previous_action_hash: actionHash,
       creator,
       organization,
-      created_at: timestamp,
-      updated_at: timestamp,
+      // Holochain action timestamps are microseconds; UI dates are milliseconds.
+      created_at: Math.floor(timestamp / 1000),
+      updated_at: Math.floor(timestamp / 1000),
       service_type_hashes: serviceTypeHashes,
       medium_of_exchange_hashes: mediumOfExchangeHashes,
       // Temporary field for permission checking fallback

--- a/ui/src/lib/stores/organizations.store.svelte.ts
+++ b/ui/src/lib/stores/organizations.store.svelte.ts
@@ -157,8 +157,8 @@ const createUIOrganization = createUIEntityFromRecord<OrganizationInDHT, UIOrgan
       coordinators,
       contact,
       status,
-      created_at: timestamp,
-      updated_at: timestamp
+      created_at: Math.floor(timestamp / 1000),
+      updated_at: Math.floor(timestamp / 1000)
     };
   }
 );

--- a/ui/src/lib/stores/requests.store.svelte.ts
+++ b/ui/src/lib/stores/requests.store.svelte.ts
@@ -137,8 +137,9 @@ const createUIRequest = createUIEntityFromRecord<RequestInDHT, UIRequest>(
       previous_action_hash: actionHash,
       creator,
       organization,
-      created_at: timestamp,
-      updated_at: timestamp,
+      // Holochain action timestamps are microseconds; UI dates are milliseconds.
+      created_at: Math.floor(timestamp / 1000),
+      updated_at: Math.floor(timestamp / 1000),
       service_type_hashes: serviceTypeHashes,
       medium_of_exchange_hashes: mediumOfExchangeHashes,
       // Field for permission checking fallback

--- a/ui/src/lib/stores/serviceTypes.store.svelte.ts
+++ b/ui/src/lib/stores/serviceTypes.store.svelte.ts
@@ -93,8 +93,8 @@ const createUIServiceType = createUIEntityFromRecord<ServiceTypeInDHT, UIService
     original_action_hash: actionHash,
     previous_action_hash: actionHash,
     creator: additionalData?.authorPubKey as ActionHash | undefined,
-    created_at: timestamp,
-    updated_at: timestamp,
+    created_at: Math.floor(timestamp / 1000),
+    updated_at: Math.floor(timestamp / 1000),
     status: (additionalData?.status as 'pending' | 'approved' | 'rejected') || 'approved'
   })
 );

--- a/ui/src/lib/stores/users.store.svelte.ts
+++ b/ui/src/lib/stores/users.store.svelte.ts
@@ -106,8 +106,8 @@ const createUIUser = createUIEntityFromRecord<UserInDHT, UIUser>(
       original_action_hash: actionHash,
       previous_action_hash: actionHash,
       status,
-      created_at: timestamp,
-      updated_at: timestamp
+      created_at: Math.floor(timestamp / 1000),
+      updated_at: Math.floor(timestamp / 1000)
     };
   }
 );

--- a/ui/src/lib/types/holochain.ts
+++ b/ui/src/lib/types/holochain.ts
@@ -137,3 +137,107 @@ export type OfferInput = OfferInDHT & {
   medium_of_exchange_hashes: ActionHash[];
   organization?: ActionHash;
 };
+
+// ============================================================================
+// EXCHANGES
+// See documentation/architecture/EXCHANGE_RECORD.md. Six append-only entries;
+// status is derived by the zome and never stored.
+// ============================================================================
+
+export type ListingType = 'Request' | 'Offer';
+export type ExchangeDirection = 'Provide' | 'Receive';
+export type ResourceKind = 'Service' | 'Currency' | 'Gift' | 'Tbd';
+
+export type ExchangeQuantity = {
+  value: number;
+  unit: string;
+};
+
+export type ExchangeTerm = {
+  direction: ExchangeDirection;
+  resource_conforms_to: string;
+  resource_kind: ResourceKind;
+  quantity: ExchangeQuantity | null;
+};
+
+export type InterestInDHT = {
+  listing: ActionHash;
+  listing_type: ListingType;
+  user: ActionHash;
+};
+
+export type AgreementInDHT = {
+  listing: ActionHash;
+  listing_type: ListingType;
+  interest: ActionHash;
+  counterparty: ActionHash;
+  provider: ActionHash;
+  receiver: ActionHash;
+  primary: ExchangeTerm;
+  reciprocal: ExchangeTerm;
+  medium: string;
+  terms: string;
+  delivery_timeframe: string;
+};
+
+export type ResponseInDHT = {
+  agreement: ActionHash;
+  accepted: boolean;
+  note: string;
+};
+
+export type CompletionInDHT = {
+  agreement: ActionHash;
+};
+
+export type ReviewInDHT = {
+  agreement: ActionHash;
+  rating: number;
+  on_time: boolean;
+  as_agreed: boolean;
+  comment: string;
+};
+
+export type CancellationInDHT = {
+  agreement: ActionHash;
+  note: string;
+};
+
+export type ExchangeStatus =
+  | 'Proposed'
+  | 'Agreed'
+  | 'ProviderDelivered'
+  | 'Complete'
+  | 'Reviewed'
+  | 'Declined'
+  | 'Cancelled';
+
+/** The zome's read model for one exchange: the agreement and its children. */
+export type ExchangeReadModel = {
+  agreement: import('@holochain/client').Record;
+  response: import('@holochain/client').Record | null;
+  provider_completion: import('@holochain/client').Record | null;
+  receiver_completion: import('@holochain/client').Record | null;
+  provider_review: import('@holochain/client').Record | null;
+  receiver_review: import('@holochain/client').Record | null;
+  cancellation: import('@holochain/client').Record | null;
+  status: ExchangeStatus;
+};
+
+export type CreateAgreementInput = {
+  listing: ActionHash;
+  listing_type: ListingType;
+  interest: ActionHash;
+  primary: ExchangeTerm;
+  reciprocal: ExchangeTerm;
+  medium: string;
+  terms: string;
+  delivery_timeframe: string;
+};
+
+export type ReviewInput = {
+  rating: number;
+  on_time: boolean;
+  as_agreed: boolean;
+  comment: string;
+};

--- a/ui/src/lib/types/ui.ts
+++ b/ui/src/lib/types/ui.ts
@@ -87,54 +87,27 @@ export type UIServiceType = ServiceTypeInDHT & {
 };
 
 // ============================================================================
-// EXCHANGES TYPES
+// EXCHANGES
 // ============================================================================
 
-export type UIExchangeResponse = {
-  actionHash: ActionHash;
-  entry: {
-    request_hash?: ActionHash;
-    offer_hash?: ActionHash;
-    service_details: string;
-    terms: string;
-    exchange_medium: string;
-    exchange_value?: string;
-    delivery_timeframe?: string;
-    notes?: string;
-    status: 'Pending' | 'Approved' | 'Rejected';
-    created_at: number;
-    updated_at: number;
-  };
-};
+type Timed = { created_at: number };
 
-export type UIExchangeAgreement = {
-  actionHash: ActionHash;
-  entry: {
-    proposal_hash: ActionHash;
-    provider_agent: AgentPubKey;
-    receiver_agent: AgentPubKey;
-    service_details: string;
-    exchange_medium: string;
-    exchange_value?: string;
-    delivery_timeframe?: string;
-    status: 'Active' | 'Completed';
-    provider_completed: boolean;
-    receiver_completed: boolean;
-    created_at: number;
-    updated_at: number;
+export type UIInterest = import('$lib/types/holochain').InterestInDHT &
+  Timed & {
+    interest_hash: ActionHash;
   };
-};
 
-export type UIExchangeReview = {
-  actionHash: ActionHash;
-  entry: {
-    agreement_hash: ActionHash;
-    reviewer_agent: AgentPubKey;
-    reviewer_type: 'Provider' | 'Receiver';
-    rating: number;
-    comments?: string;
-    created_at: number;
-  };
+/** An exchange read by role; who did what is answered by the zome. */
+export type UIExchange = Timed & {
+  agreement_hash: ActionHash;
+  agreement: import('$lib/types/holochain').AgreementInDHT;
+  status: import('$lib/types/holochain').ExchangeStatus;
+  response?: import('$lib/types/holochain').ResponseInDHT & Timed;
+  provider_done?: Timed;
+  receiver_done?: Timed;
+  provider_review?: import('$lib/types/holochain').ReviewInDHT & Timed;
+  receiver_review?: import('$lib/types/holochain').ReviewInDHT & Timed;
+  cancellation?: import('$lib/types/holochain').CancellationInDHT & Timed;
 };
 
 // ============================================================================

--- a/ui/src/lib/utils/exchange-ui.ts
+++ b/ui/src/lib/utils/exchange-ui.ts
@@ -1,0 +1,91 @@
+import type { ActionHash } from '@holochain/client';
+import type { ExchangeStatus, ExchangeTerm } from '$lib/types/holochain';
+import type { UIExchange } from '$lib/types/ui';
+
+export const EXCHANGE_STATUS_LABEL: Record<ExchangeStatus, string> = {
+  Proposed: 'Proposed',
+  Agreed: 'Agreed',
+  ProviderDelivered: 'Awaiting confirmation',
+  Complete: 'Awaiting reviews',
+  Reviewed: 'Completed',
+  Declined: 'Declined',
+  Cancelled: 'Cancelled'
+};
+
+export function exchangeStatusVariant(status: ExchangeStatus): string {
+  switch (status) {
+    case 'Proposed':
+      return 'variant-filled-secondary';
+    case 'Agreed':
+      return 'variant-filled-primary';
+    case 'ProviderDelivered':
+      return 'variant-filled-tertiary';
+    case 'Complete':
+      return 'variant-filled-warning';
+    case 'Reviewed':
+      return 'variant-filled-success';
+    case 'Declined':
+    case 'Cancelled':
+      return 'variant-filled-surface';
+  }
+}
+
+export const EXCHANGE_TABS = {
+  proposals: ['Proposed', 'Declined'],
+  active: ['Agreed', 'ProviderDelivered', 'Cancelled'],
+  completed: ['Complete', 'Reviewed']
+} as const satisfies Record<string, readonly ExchangeStatus[]>;
+
+export type ExchangeTab = keyof typeof EXCHANGE_TABS;
+
+export function tabOf(status: ExchangeStatus): ExchangeTab {
+  for (const [tab, states] of Object.entries(EXCHANGE_TABS)) {
+    if ((states as readonly ExchangeStatus[]).includes(status)) return tab as ExchangeTab;
+  }
+  return 'active';
+}
+
+export function termLabel(term: ExchangeTerm): string {
+  if (term.resource_kind === 'Tbd') return 'To be agreed';
+  if (term.resource_kind === 'Gift') return 'Gift, nothing owed';
+  const q = term.quantity ? `${term.quantity.value} ${term.quantity.unit} ` : '';
+  return `${q}${term.resource_conforms_to}`.trim();
+}
+
+export type ExchangeRole = 'provider' | 'receiver';
+
+const same = (a: Uint8Array | undefined, b: Uint8Array | undefined) =>
+  !!a && !!b && a.toString() === b.toString();
+
+export function roleOf(exchange: UIExchange, myUserHash: ActionHash | undefined): ExchangeRole | null {
+  if (same(exchange.agreement.provider, myUserHash)) return 'provider';
+  if (same(exchange.agreement.receiver, myUserHash)) return 'receiver';
+  return null;
+}
+
+export function counterpartyOf(exchange: UIExchange, myUserHash: ActionHash | undefined): ActionHash {
+  return same(exchange.agreement.provider, myUserHash)
+    ? exchange.agreement.receiver
+    : exchange.agreement.provider;
+}
+
+/** The agreement names the counterparty; whoever is not it wrote it up. */
+export function wroteIt(exchange: UIExchange, myUserHash: ActionHash | undefined): boolean {
+  return !same(exchange.agreement.counterparty, myUserHash);
+}
+
+export function doneBy(exchange: UIExchange, role: ExchangeRole | null): boolean {
+  return role === 'provider' ? !!exchange.provider_done : role === 'receiver' ? !!exchange.receiver_done : false;
+}
+
+export function reviewedBy(exchange: UIExchange, role: ExchangeRole | null): boolean {
+  return role === 'provider' ? !!exchange.provider_review : role === 'receiver' ? !!exchange.receiver_review : false;
+}
+
+export function otherRole(role: ExchangeRole | null): ExchangeRole | null {
+  return role === 'provider' ? 'receiver' : role === 'receiver' ? 'provider' : null;
+}
+
+export function formatWhen(ms: number): string {
+  return new Date(ms).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+}

--- a/ui/src/lib/utils/exchange-ui.ts
+++ b/ui/src/lib/utils/exchange-ui.ts
@@ -38,18 +38,22 @@ export const EXCHANGE_TABS = {
 
 export type ExchangeTab = keyof typeof EXCHANGE_TABS;
 
-export function tabOf(status: ExchangeStatus): ExchangeTab {
+/** A proposal withdrawn before anyone answered it belongs with proposals, not active. */
+export function tabOf(exchange: UIExchange): ExchangeTab {
+  if (exchange.status === 'Cancelled' && !exchange.response) return 'proposals';
   for (const [tab, states] of Object.entries(EXCHANGE_TABS)) {
-    if ((states as readonly ExchangeStatus[]).includes(status)) return tab as ExchangeTab;
+    if ((states as readonly ExchangeStatus[]).includes(exchange.status)) return tab as ExchangeTab;
   }
   return 'active';
 }
 
 export function termLabel(term: ExchangeTerm): string {
-  if (term.resource_kind === 'Tbd') return 'To be agreed';
+  if (term.resource_kind === 'Tbd') return 'To be discussed';
   if (term.resource_kind === 'Gift') return 'Gift, nothing owed';
-  const q = term.quantity ? `${term.quantity.value} ${term.quantity.unit} ` : '';
-  return `${q}${term.resource_conforms_to}`.trim();
+  if (!term.quantity) return term.resource_conforms_to;
+  if (term.resource_kind === 'Currency') return `${term.quantity.value} ${term.resource_conforms_to}`;
+  const unit = term.quantity.value === 1 ? term.quantity.unit.replace(/s$/, '') : term.quantity.unit;
+  return `${term.quantity.value} ${unit} of ${term.resource_conforms_to}`;
 }
 
 export type ExchangeRole = 'provider' | 'receiver';
@@ -84,6 +88,54 @@ export function reviewedBy(exchange: UIExchange, role: ExchangeRole | null): boo
 
 export function otherRole(role: ExchangeRole | null): ExchangeRole | null {
   return role === 'provider' ? 'receiver' : role === 'receiver' ? 'provider' : null;
+}
+
+/** A proposal cancelled before anyone answered it was withdrawn, not cancelled. */
+export function statusLabel(exchange: UIExchange): string {
+  if (exchange.status === 'Cancelled' && !exchange.response) return 'Withdrawn';
+  return EXCHANGE_STATUS_LABEL[exchange.status];
+}
+
+export type Turn = 'you' | 'them' | 'none';
+
+/** Whose move it is, from the record alone. */
+export function turnOf(exchange: UIExchange, myUserHash: ActionHash | undefined): Turn {
+  const role = roleOf(exchange, myUserHash);
+  if (!role) return 'none';
+  switch (exchange.status) {
+    case 'Proposed':
+      return wroteIt(exchange, myUserHash) ? 'them' : 'you';
+    case 'Agreed':
+      return doneBy(exchange, role) ? 'them' : 'you';
+    case 'ProviderDelivered':
+      return role === 'receiver' ? 'you' : 'them';
+    case 'Complete':
+      return reviewedBy(exchange, role) ? 'them' : 'you';
+    default:
+      return 'none';
+  }
+}
+
+/** A proposal someone else sent me that I have not answered. */
+export function awaitingMe(exchange: UIExchange, myUserHash: ActionHash | undefined): boolean {
+  return turnOf(exchange, myUserHash) === 'you';
+}
+
+/** What the card's button says, by what the status asks of the reader. */
+export function actionLabel(exchange: UIExchange, role: ExchangeRole | null): string {
+  switch (exchange.status) {
+    case 'Proposed':
+    case 'Declined':
+      return 'Open proposal';
+    case 'ProviderDelivered':
+      return role === 'receiver' ? 'Confirm delivery' : 'Open exchange';
+    case 'Complete':
+      return reviewedBy(exchange, role) ? 'Open exchange' : 'Leave a review';
+    case 'Reviewed':
+      return 'View summary';
+    default:
+      return 'Open exchange';
+  }
 }
 
 export function formatWhen(ms: number): string {

--- a/ui/src/lib/utils/mocks.ts
+++ b/ui/src/lib/utils/mocks.ts
@@ -476,35 +476,3 @@ export function createSuggestedMockedMediumOfExchange(): MediumOfExchangeInDHT {
 
   return faker.helpers.arrayElement(uniqueMediums);
 }
-
-export function createMockedExchangeResponse(targetEntityType: 'request' | 'offer' = 'request') {
-  const exchangeMediums = ['USD', 'CAD', 'EUR', 'Hours', 'Favor', 'Barter', 'Local Currency'];
-  const timeframes = ['1-2 days', 'within a week', 'flexible', 'ASAP', '2-3 weeks', 'negotiable'];
-
-  const baseResponse = {
-    service_details:
-      targetEntityType === 'request'
-        ? faker.lorem.sentences(2, ' ') +
-          ' I can provide this service with high quality and attention to detail.'
-        : faker.lorem.sentences(2, ' ') +
-          ' I would like to use this offered service for my project.',
-    terms:
-      faker.lorem.sentences(3, ' ') +
-      ' All work will be completed according to agreed specifications.',
-    exchange_medium: faker.helpers.arrayElement(exchangeMediums),
-    exchange_value: faker.helpers.maybe(
-      () =>
-        faker.helpers.arrayElement(['$50', '$100', '2 hours', 'negotiable', '€75', 'fair trade']),
-      { probability: 0.8 }
-    ),
-    delivery_timeframe: faker.helpers.maybe(() => faker.helpers.arrayElement(timeframes), {
-      probability: 0.7
-    }),
-    notes: faker.helpers.maybe(
-      () => faker.lorem.sentence() + ' Please feel free to contact me with any questions.',
-      { probability: 0.6 }
-    )
-  };
-
-  return baseResponse;
-}

--- a/ui/src/routes/(public)/exchanges/+page.svelte
+++ b/ui/src/routes/(public)/exchanges/+page.svelte
@@ -7,21 +7,25 @@
   import { runEffect } from '$lib/utils/effect';
   import { useConnectionGuard } from '$lib/composables/connection/useConnectionGuard';
   import {
-    EXCHANGE_STATUS_LABEL,
+    actionLabel,
+    awaitingMe,
     counterpartyOf,
     exchangeStatusVariant,
     formatWhen,
     roleOf,
+    statusLabel,
     tabOf,
     termLabel,
+    turnOf,
+    wroteIt,
     type ExchangeTab
   } from '$lib/utils/exchange-ui';
   import type { UIExchange } from '$lib/types/ui';
 
-  const TABS: { key: ExchangeTab; label: string }[] = [
-    { key: 'proposals', label: 'Proposals' },
-    { key: 'active', label: 'Active' },
-    { key: 'completed', label: 'Completed' }
+  const TABS: { key: ExchangeTab; label: string; icon: string; blurb: string; ring: string }[] = [
+    { key: 'proposals', label: 'Proposals', icon: '\u{1F4E8}', blurb: 'Sent to you or by you, waiting on an answer.', ring: 'ring-secondary-500' },
+    { key: 'active', label: 'Active', icon: '\u{1F504}', blurb: 'Agreements under way, until both parts are done.', ring: 'ring-primary-500' },
+    { key: 'completed', label: 'Completed', icon: '\u{1F389}', blurb: 'Both parts done; reviews to leave or already given.', ring: 'ring-success-500' }
   ];
 
   let tab = $state<ExchangeTab>('active');
@@ -31,25 +35,43 @@
   let loadError = $state<string | null>(null);
 
   const me = $derived(usersStore.currentUser?.original_action_hash);
+  const b64 = encodeHashToBase64;
+  const count = (t: ExchangeTab) => exchangesStore.exchanges.filter((e) => tabOf(e) === t).length;
+  const mine = (t: ExchangeTab) =>
+    exchangesStore.exchanges.filter((e) => tabOf(e) === t && awaitingMe(e, me)).length;
+  let side = $state<'all' | 'provider' | 'receiver'>('all');
+  let from = $state<'all' | 'Offer' | 'Request'>('all');
+  let order = $state<'latest' | 'oldest'>('latest');
+  let turn = $state<'all' | 'you' | 'them'>('all');
   const shown = $derived(
     exchangesStore.exchanges
-      .filter((e) => tabOf(e.status) === tab)
-      .sort((a, b) => b.created_at - a.created_at)
+      .filter((e) => tabOf(e) === tab)
+      .filter((e) => side === 'all' || roleOf(e, me) === side)
+      .filter((e) => from === 'all' || e.agreement.listing_type === from)
+      .filter((e) => turn === 'all' || turnOf(e, me) === turn)
+      .sort((a, b) => (order === 'latest' ? 1 : -1) * (lastActivity(b) - lastActivity(a)))
   );
-  const counts = $derived({
-    proposals: exchangesStore.exchanges.filter((e) => tabOf(e.status) === 'proposals').length,
-    active: exchangesStore.exchanges.filter((e) => tabOf(e.status) === 'active').length,
-    completed: exchangesStore.exchanges.filter((e) => tabOf(e.status) === 'completed').length
-  });
+
+  function lastActivity(e: UIExchange): number {
+    return Math.max(
+      e.created_at,
+      e.response?.created_at ?? 0,
+      e.provider_done?.created_at ?? 0,
+      e.receiver_done?.created_at ?? 0,
+      e.provider_review?.created_at ?? 0,
+      e.receiver_review?.created_at ?? 0,
+      e.cancellation?.created_at ?? 0
+    );
+  }
 
   async function resolveLabels(list: UIExchange[]) {
     for (const e of list) {
-      const other = encodeHashToBase64(counterpartyOf(e, me));
+      const other = b64(counterpartyOf(e, me));
       if (!(other in names)) {
         const user = await runEffect(usersStore.getUserByActionHash(counterpartyOf(e, me)));
         names[other] = user?.name ?? 'A member';
       }
-      const listing = encodeHashToBase64(e.agreement.listing);
+      const listing = b64(e.agreement.listing);
       if (!(listing in titles)) {
         const item =
           e.agreement.listing_type === 'Offer'
@@ -65,6 +87,10 @@
       try {
         await runEffect(useConnectionGuard());
         const list = await runEffect(exchangesStore.loadMyExchanges());
+        const first = (['proposals', 'active', 'completed'] as ExchangeTab[]).find((t) =>
+          list.some((e) => tabOf(e) === t && awaitingMe(e, me))
+        );
+        if (first) tab = first;
         ready = true;
         await resolveLabels(list);
       } catch (e) {
@@ -75,63 +101,100 @@
 </script>
 
 <svelte:head>
-  <title>My exchanges</title>
+  <title>My Exchanges</title>
 </svelte:head>
 
 <section class="container mx-auto space-y-6 p-4">
   <header class="space-y-1">
-    <h1 class="h1">My exchanges</h1>
-    <p class="text-surface-500">Agreements you are part of, and where each one has got to.</p>
+    <h1 class="h1">My Exchanges</h1>
+    <p class="text-surface-500">Deals you're proposing, working through, and have completed</p>
   </header>
 
-  <nav class="flex gap-2" aria-label="Exchange groups">
+  <div class="grid gap-4 md:grid-cols-3" role="tablist" aria-label="Exchange groups">
     {#each TABS as t (t.key)}
       <button
-        class="btn btn-sm {tab === t.key ? 'variant-filled-primary' : 'variant-ghost-surface'}"
+        class="card space-y-2 p-4 text-left transition-colors hover:bg-surface-100 dark:hover:bg-surface-700 {tab === t.key ? `ring-2 ${t.ring}` : ''}"
+        role="tab"
+        aria-selected={tab === t.key}
         onclick={() => (tab = t.key)}
-        aria-pressed={tab === t.key}
       >
-        {t.label}
-        <span class="badge variant-soft ml-1">{counts[t.key]}</span>
+        <div class="flex items-start justify-between">
+          <span class="text-2xl">{t.icon}</span>
+          <span class="text-3xl font-bold">{count(t.key)}</span>
+        </div>
+        <h2 class="h4">{t.label}</h2>
+        <p class="text-sm text-surface-500">{t.blurb}</p>
+        {#if mine(t.key) > 0}
+          <span class="badge variant-filled-secondary">{mine(t.key)} your turn</span>
+        {/if}
       </button>
     {/each}
-  </nav>
+  </div>
+
+  <div class="flex flex-wrap items-center gap-4 text-sm">
+    <label class="flex items-center gap-2"><span class="text-surface-500">Side</span>
+      <select class="select select-sm w-auto" bind:value={side}>
+        <option value="all">All</option><option value="provider">I give</option><option value="receiver">I receive</option>
+      </select></label>
+    <label class="flex items-center gap-2"><span class="text-surface-500">From</span>
+      <select class="select select-sm w-auto" bind:value={from}>
+        <option value="all">All</option><option value="Offer">An offer</option><option value="Request">A request</option>
+      </select></label>
+    <label class="flex items-center gap-2"><span class="text-surface-500">Turn</span>
+      <select class="select select-sm w-auto" bind:value={turn}>
+        <option value="all">All</option><option value="you">Mine</option><option value="them">Theirs</option>
+      </select></label>
+    <label class="flex items-center gap-2"><span class="text-surface-500">Order</span>
+      <select class="select select-sm w-auto" bind:value={order}>
+        <option value="latest">Latest first</option><option value="oldest">Oldest first</option>
+      </select></label>
+  </div>
 
   {#if loadError}
     <div class="alert variant-filled-error">{loadError}</div>
   {:else if !ready}
     <p class="text-surface-500">Loading your exchanges...</p>
   {:else if shown.length === 0}
-    <div class="card p-6 text-center text-surface-500">
-      {#if tab === 'proposals'}
-        Nothing proposed at the moment. Register interest in a listing to start one.
-      {:else if tab === 'active'}
-        No exchanges under way.
-      {:else}
-        Nothing completed yet.
-      {/if}
+    <div class="card space-y-3 p-6 text-center">
+      <p class="text-surface-500">{side === 'all' && from === 'all' && turn === 'all' ? `No ${tab} exchanges yet.` : `Nothing ${tab} matches those filters.`}</p>
+      <a class="variant-filled-primary btn" href="/requests">Browse listings to start one</a>
     </div>
   {:else}
     <ul class="space-y-3">
-      {#each shown as e (encodeHashToBase64(e.agreement_hash))}
+      {#each shown as e (b64(e.agreement_hash))}
         {@const role = roleOf(e, me)}
+        {@const other = names[b64(counterpartyOf(e, me))]}
+        {@const give = role === 'provider' ? e.agreement.primary : e.agreement.reciprocal}
+        {@const get = role === 'provider' ? e.agreement.reciprocal : e.agreement.primary}
         <li>
           <a
-            class="card block space-y-2 p-4 transition-colors hover:bg-surface-100 dark:hover:bg-surface-700"
-            href={`/exchanges/${encodeHashToBase64(e.agreement_hash)}`}
+            class="card block space-y-3 p-4 transition-colors hover:bg-surface-100 dark:hover:bg-surface-700"
+            href={`/exchanges/${b64(e.agreement_hash)}`}
           >
-            <div class="flex flex-wrap items-center justify-between gap-2">
-              <h3 class="h4">{titles[encodeHashToBase64(e.agreement.listing)] ?? '...'}</h3>
-              <span class="badge {exchangeStatusVariant(e.status)}">
-                {EXCHANGE_STATUS_LABEL[e.status]}
-              </span>
+            <div class="flex flex-wrap items-center gap-2 text-sm">
+              <span class="badge {exchangeStatusVariant(e.status)}">{statusLabel(e)}</span>
+              {#if turnOf(e, me) === 'you'}<span class="badge variant-filled-secondary">Your turn</span>
+              {:else if turnOf(e, me) === 'them'}<span class="badge variant-soft-surface">Waiting on {other ?? 'them'}</span>{/if}
+              {#if e.agreement.medium}<span class="badge variant-soft-surface">{e.agreement.medium}</span>{/if}
+              <span class="text-surface-500">{role === 'provider' ? 'You provide' : 'You receive'}</span>
+              {#if e.status === 'Proposed' || e.status === 'Declined'}
+                <span class="text-surface-500">Proposed by {wroteIt(e, me) ? 'you' : (other ?? '...')}</span>
+              {/if}
+              <span class="ml-auto text-xs text-surface-500">{formatWhen(lastActivity(e))}</span>
             </div>
-            <p class="text-sm">
-              {role === 'provider' ? 'You provide' : 'You receive'}
-              {termLabel(e.agreement.primary).toLowerCase()}
-              with {names[encodeHashToBase64(counterpartyOf(e, me))] ?? '...'}
-            </p>
-            <p class="text-xs text-surface-500">{formatWhen(e.created_at)}</p>
+            <h3 class="h4">{titles[b64(e.agreement.listing)] ?? '...'}</h3>
+            <div class="flex flex-wrap items-center gap-2 text-sm">
+              <span>You give {termLabel(give)}</span>
+              <span class="text-surface-500">&#8646;</span>
+              <span>{other ?? 'They'} {other ? 'gives' : 'give'} {termLabel(get)}</span>
+            </div>
+            <div class="flex items-center gap-2 text-sm">
+              <span class="flex h-6 w-6 items-center justify-center rounded-full bg-primary-500 text-xs text-white">
+                {(other ?? '?')[0]}
+              </span>
+              <span>{other ?? '...'}</span>
+              <span class="variant-filled-primary btn btn-sm ml-auto">{actionLabel(e, role)} &rarr;</span>
+            </div>
           </a>
         </li>
       {/each}

--- a/ui/src/routes/(public)/exchanges/+page.svelte
+++ b/ui/src/routes/(public)/exchanges/+page.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  import { encodeHashToBase64 } from '@holochain/client';
+  import exchangesStore from '$lib/stores/exchanges.store.svelte';
+  import usersStore from '$lib/stores/users.store.svelte';
+  import offersStore from '$lib/stores/offers.store.svelte';
+  import requestsStore from '$lib/stores/requests.store.svelte';
+  import { runEffect } from '$lib/utils/effect';
+  import { useConnectionGuard } from '$lib/composables/connection/useConnectionGuard';
+  import {
+    EXCHANGE_STATUS_LABEL,
+    counterpartyOf,
+    exchangeStatusVariant,
+    formatWhen,
+    roleOf,
+    tabOf,
+    termLabel,
+    type ExchangeTab
+  } from '$lib/utils/exchange-ui';
+  import type { UIExchange } from '$lib/types/ui';
+
+  const TABS: { key: ExchangeTab; label: string }[] = [
+    { key: 'proposals', label: 'Proposals' },
+    { key: 'active', label: 'Active' },
+    { key: 'completed', label: 'Completed' }
+  ];
+
+  let tab = $state<ExchangeTab>('active');
+  let names = $state<Record<string, string>>({});
+  let titles = $state<Record<string, string>>({});
+  let ready = $state(false);
+  let loadError = $state<string | null>(null);
+
+  const me = $derived(usersStore.currentUser?.original_action_hash);
+  const shown = $derived(
+    exchangesStore.exchanges
+      .filter((e) => tabOf(e.status) === tab)
+      .sort((a, b) => b.created_at - a.created_at)
+  );
+  const counts = $derived({
+    proposals: exchangesStore.exchanges.filter((e) => tabOf(e.status) === 'proposals').length,
+    active: exchangesStore.exchanges.filter((e) => tabOf(e.status) === 'active').length,
+    completed: exchangesStore.exchanges.filter((e) => tabOf(e.status) === 'completed').length
+  });
+
+  async function resolveLabels(list: UIExchange[]) {
+    for (const e of list) {
+      const other = encodeHashToBase64(counterpartyOf(e, me));
+      if (!(other in names)) {
+        const user = await runEffect(usersStore.getUserByActionHash(counterpartyOf(e, me)));
+        names[other] = user?.name ?? 'A member';
+      }
+      const listing = encodeHashToBase64(e.agreement.listing);
+      if (!(listing in titles)) {
+        const item =
+          e.agreement.listing_type === 'Offer'
+            ? await runEffect(offersStore.getOffer(e.agreement.listing))
+            : await runEffect(requestsStore.getRequest(e.agreement.listing));
+        titles[listing] = item?.title ?? 'A listing';
+      }
+    }
+  }
+
+  $effect(() => {
+    (async () => {
+      try {
+        await runEffect(useConnectionGuard());
+        const list = await runEffect(exchangesStore.loadMyExchanges());
+        ready = true;
+        await resolveLabels(list);
+      } catch (e) {
+        loadError = e instanceof Error ? e.message : String(e);
+      }
+    })();
+  });
+</script>
+
+<svelte:head>
+  <title>My exchanges</title>
+</svelte:head>
+
+<section class="container mx-auto space-y-6 p-4">
+  <header class="space-y-1">
+    <h1 class="h1">My exchanges</h1>
+    <p class="text-surface-500">Agreements you are part of, and where each one has got to.</p>
+  </header>
+
+  <nav class="flex gap-2" aria-label="Exchange groups">
+    {#each TABS as t (t.key)}
+      <button
+        class="btn btn-sm {tab === t.key ? 'variant-filled-primary' : 'variant-ghost-surface'}"
+        onclick={() => (tab = t.key)}
+        aria-pressed={tab === t.key}
+      >
+        {t.label}
+        <span class="badge variant-soft ml-1">{counts[t.key]}</span>
+      </button>
+    {/each}
+  </nav>
+
+  {#if loadError}
+    <div class="alert variant-filled-error">{loadError}</div>
+  {:else if !ready}
+    <p class="text-surface-500">Loading your exchanges...</p>
+  {:else if shown.length === 0}
+    <div class="card p-6 text-center text-surface-500">
+      {#if tab === 'proposals'}
+        Nothing proposed at the moment. Register interest in a listing to start one.
+      {:else if tab === 'active'}
+        No exchanges under way.
+      {:else}
+        Nothing completed yet.
+      {/if}
+    </div>
+  {:else}
+    <ul class="space-y-3">
+      {#each shown as e (encodeHashToBase64(e.agreement_hash))}
+        {@const role = roleOf(e, me)}
+        <li>
+          <a
+            class="card block space-y-2 p-4 transition-colors hover:bg-surface-100 dark:hover:bg-surface-700"
+            href={`/exchanges/${encodeHashToBase64(e.agreement_hash)}`}
+          >
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <h3 class="h4">{titles[encodeHashToBase64(e.agreement.listing)] ?? '...'}</h3>
+              <span class="badge {exchangeStatusVariant(e.status)}">
+                {EXCHANGE_STATUS_LABEL[e.status]}
+              </span>
+            </div>
+            <p class="text-sm">
+              {role === 'provider' ? 'You provide' : 'You receive'}
+              {termLabel(e.agreement.primary).toLowerCase()}
+              with {names[encodeHashToBase64(counterpartyOf(e, me))] ?? '...'}
+            </p>
+            <p class="text-xs text-surface-500">{formatWhen(e.created_at)}</p>
+          </a>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>

--- a/ui/src/routes/(public)/exchanges/[id]/+page.svelte
+++ b/ui/src/routes/(public)/exchanges/[id]/+page.svelte
@@ -1,0 +1,284 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import { goto } from '$app/navigation';
+  import { decodeHashFromBase64, encodeHashToBase64 } from '@holochain/client';
+  import { getToastStore } from '@skeletonlabs/skeleton';
+  import exchangesStore from '$lib/stores/exchanges.store.svelte';
+  import usersStore from '$lib/stores/users.store.svelte';
+  import offersStore from '$lib/stores/offers.store.svelte';
+  import requestsStore from '$lib/stores/requests.store.svelte';
+  import { runEffect } from '$lib/utils/effect';
+  import { useConnectionGuard } from '$lib/composables/connection/useConnectionGuard';
+  import {
+    EXCHANGE_STATUS_LABEL,
+    counterpartyOf,
+    doneBy,
+    exchangeStatusVariant,
+    formatWhen,
+    otherRole,
+    reviewedBy,
+    roleOf,
+    termLabel,
+    wroteIt
+  } from '$lib/utils/exchange-ui';
+  import type { UIExchange, UIUser } from '$lib/types/ui';
+  import type { ReviewInDHT } from '$lib/types/holochain';
+
+  const toastStore = getToastStore();
+
+  const agreementHash = $derived.by(() => {
+    try {
+      return page.params.id ? decodeHashFromBase64(page.params.id) : null;
+    } catch {
+      return null;
+    }
+  });
+
+  let exchange = $state<UIExchange | null>(null);
+  let other = $state<UIUser | null>(null);
+  let listingTitle = $state('');
+  let loadError = $state<string | null>(null);
+  let busy = $state(false);
+
+  let note = $state('');
+  let rating = $state(5);
+  let onTime = $state(true);
+  let asAgreed = $state(true);
+  let comment = $state('');
+
+  const me = $derived(usersStore.currentUser?.original_action_hash);
+  const role = $derived(exchange ? roleOf(exchange, me) : null);
+  const iWroteIt = $derived(exchange ? wroteIt(exchange, me) : false);
+  const myDone = $derived(exchange ? doneBy(exchange, role) : false);
+  const theirDone = $derived(exchange ? doneBy(exchange, otherRole(role)) : false);
+  const myReview = $derived(exchange ? reviewedBy(exchange, role) : false);
+  const theirReview = $derived(exchange ? reviewedBy(exchange, otherRole(role)) : false);
+  const listingHref = $derived(
+    exchange
+      ? `/${exchange.agreement.listing_type === 'Offer' ? 'offers' : 'requests'}/${encodeHashToBase64(exchange.agreement.listing)}`
+      : '#'
+  );
+
+  const myReviewText = $derived(
+    role === 'provider' ? exchange?.provider_review : exchange?.receiver_review
+  );
+  const theirReviewText = $derived(
+    role === 'provider' ? exchange?.receiver_review : exchange?.provider_review
+  );
+
+  function fail(e: unknown) {
+    toastStore.trigger({
+      message: e instanceof Error ? e.message : String(e),
+      background: 'variant-filled-error'
+    });
+  }
+
+  function ok(message: string) {
+    toastStore.trigger({ message, background: 'variant-filled-success' });
+  }
+
+  async function act(label: string, run: () => Promise<UIExchange>) {
+    busy = true;
+    try {
+      exchange = await run();
+      ok(label);
+      note = '';
+    } catch (e) {
+      fail(e);
+    } finally {
+      busy = false;
+    }
+  }
+
+  const hash = () => exchange!.agreement_hash;
+  const accept = () => act('Agreement accepted', () => runEffect(exchangesStore.respond(hash(), true, note)));
+  const decline = () => act('Agreement declined', () => runEffect(exchangesStore.respond(hash(), false, note)));
+  const complete = () => act('Marked as done', () => runEffect(exchangesStore.complete(hash())));
+  const cancel = () => act('Agreement cancelled', () => runEffect(exchangesStore.cancel(hash(), note)));
+  const review = () =>
+    act('Review recorded', () =>
+      runEffect(
+        exchangesStore.review(hash(), { rating, on_time: onTime, as_agreed: asAgreed, comment })
+      )
+    );
+
+  $effect(() => {
+    const target = agreementHash;
+    if (!target) {
+      loadError = 'That exchange address is not valid.';
+      return;
+    }
+    (async () => {
+      try {
+        await runEffect(useConnectionGuard());
+        const loaded = await runEffect(exchangesStore.getExchange(target));
+        exchange = loaded;
+        const [user, listing] = await Promise.all([
+          runEffect(usersStore.getUserByActionHash(counterpartyOf(loaded, me))),
+          loaded.agreement.listing_type === 'Offer'
+            ? runEffect(offersStore.getOffer(loaded.agreement.listing))
+            : runEffect(requestsStore.getRequest(loaded.agreement.listing))
+        ]);
+        other = user;
+        listingTitle = listing?.title ?? 'A listing';
+      } catch (e) {
+        loadError = e instanceof Error ? e.message : String(e);
+      }
+    })();
+  });
+</script>
+
+<svelte:head>
+  <title>{listingTitle ? `Exchange: ${listingTitle}` : 'Exchange'}</title>
+</svelte:head>
+
+{#snippet reviewCard(label: string, r: (ReviewInDHT & { created_at: number }) | undefined)}
+  <div class="card space-y-1 p-4">
+    <p class="font-semibold">{label}</p>
+    {#if r}
+      <p>{'*'.repeat(r.rating)}{'.'.repeat(5 - r.rating)} {r.rating} of 5</p>
+      <p class="text-sm text-surface-500">
+        {r.on_time ? 'On time' : 'Not on time'}. {r.as_agreed ? 'As agreed' : 'Not as agreed'}.
+      </p>
+      {#if r.comment}<p class="text-sm">{r.comment}</p>{/if}
+    {:else}
+      <p class="text-sm text-surface-500">Not yet given.</p>
+    {/if}
+  </div>
+{/snippet}
+
+<section class="container mx-auto max-w-3xl space-y-6 p-4">
+  <div class="flex items-center justify-between">
+    <button class="variant-soft btn btn-sm" onclick={() => goto('/exchanges')}>Back to exchanges</button>
+  </div>
+
+  {#if loadError}
+    <div class="alert variant-filled-error">{loadError}</div>
+  {:else if !exchange}
+    <p class="text-surface-500">Loading the exchange...</p>
+  {:else}
+    {@const a = exchange.agreement}
+    <header class="space-y-2">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <h1 class="h2"><a class="anchor" href={listingHref}>{listingTitle || '...'}</a></h1>
+        <span class="badge {exchangeStatusVariant(exchange.status)}">
+          {EXCHANGE_STATUS_LABEL[exchange.status]}
+        </span>
+      </div>
+      <p class="text-surface-500">
+        With
+        <a class="anchor" href={`/users/${encodeHashToBase64(counterpartyOf(exchange, me))}`}>
+          {other?.name ?? 'a member'}
+        </a>.
+        You are the {role ?? 'observer'}. Written up on {formatWhen(exchange.created_at)}
+        {iWroteIt ? 'by you' : `by ${other?.name ?? 'them'}`}.
+      </p>
+    </header>
+
+    <div class="grid gap-4 md:grid-cols-2">
+      <div class="card space-y-1 p-4">
+        <p class="text-xs uppercase tracking-wide text-surface-500">
+          {role === 'provider' ? 'You provide' : 'They provide'}
+        </p>
+        <p class="font-semibold">{termLabel(a.primary)}</p>
+      </div>
+      <div class="card space-y-1 p-4">
+        <p class="text-xs uppercase tracking-wide text-surface-500">
+          {role === 'provider' ? 'You receive' : 'They receive'}
+        </p>
+        <p class="font-semibold">{termLabel(a.reciprocal)}</p>
+        {#if a.medium}<p class="text-sm text-surface-500">via {a.medium}</p>{/if}
+      </div>
+    </div>
+
+    {#if a.terms || a.delivery_timeframe}
+      <div class="card space-y-2 p-4">
+        {#if a.delivery_timeframe}<p><span class="font-semibold">When:</span> {a.delivery_timeframe}</p>{/if}
+        {#if a.terms}<p class="whitespace-pre-line">{a.terms}</p>{/if}
+      </div>
+    {/if}
+
+    {#if exchange.status === 'Declined' && exchange.response}
+      <div class="alert variant-soft-surface">
+        <p>Declined on {formatWhen(exchange.response.created_at)}.</p>
+        {#if exchange.response.note}<p class="text-sm">{exchange.response.note}</p>{/if}
+      </div>
+    {:else if exchange.status === 'Cancelled' && exchange.cancellation}
+      <div class="alert variant-soft-surface">
+        <p>Cancelled on {formatWhen(exchange.cancellation.created_at)}.</p>
+        {#if exchange.cancellation.note}<p class="text-sm">{exchange.cancellation.note}</p>{/if}
+      </div>
+    {/if}
+
+    {#if role}
+      <div class="card space-y-3 p-4">
+        {#if exchange.status === 'Proposed'}
+          {#if iWroteIt}
+            <p>Waiting for {other?.name ?? 'them'} to accept or decline.</p>
+          {:else}
+            <p>{other?.name ?? 'They'} wrote this up. Accept it, or decline with a note.</p>
+            <textarea class="textarea" rows="2" bind:value={note} placeholder="A note, if declining"></textarea>
+            <div class="flex flex-wrap gap-2">
+              <button class="variant-filled-primary btn" onclick={accept} disabled={busy}>Accept</button>
+              <button class="variant-ghost-surface btn" onclick={decline} disabled={busy}>Decline</button>
+            </div>
+          {/if}
+        {:else if exchange.status === 'Agreed' || exchange.status === 'ProviderDelivered'}
+          {#if myDone}
+            <p>You have marked your part done. Waiting for {other?.name ?? 'them'}.</p>
+          {:else}
+            <p>
+              {#if theirDone}{other?.name ?? 'They'} has marked their part done.{/if}
+              Mark yours when it is.
+            </p>
+            <button class="variant-filled-primary btn" onclick={complete} disabled={busy}>
+              Mark my part done
+            </button>
+          {/if}
+          <details class="mt-2">
+            <summary class="cursor-pointer text-sm text-surface-500">Cancel this agreement</summary>
+            <div class="mt-2 space-y-2">
+              <textarea class="textarea" rows="2" bind:value={note} placeholder="Why, briefly"></textarea>
+              <button class="variant-ghost-error btn btn-sm" onclick={cancel} disabled={busy}>
+                Cancel agreement
+              </button>
+            </div>
+          </details>
+        {:else if exchange.status === 'Complete'}
+          {#if myReview}
+            <p>Thanks for your review. Waiting for {other?.name ?? 'them'} to review.</p>
+          {:else}
+            <p>Both parts are done. How did it go?</p>
+            <label class="label">
+              <span>Rating</span>
+              <select class="select" bind:value={rating}>
+                {#each [5, 4, 3, 2, 1, 0] as n (n)}<option value={n}>{n} of 5</option>{/each}
+              </select>
+            </label>
+            <label class="flex items-center gap-2"><input class="checkbox" type="checkbox" bind:checked={onTime} /> On time</label>
+            <label class="flex items-center gap-2"><input class="checkbox" type="checkbox" bind:checked={asAgreed} /> As agreed</label>
+            <textarea class="textarea" rows="3" bind:value={comment} placeholder="Anything worth saying"></textarea>
+            <button class="variant-filled-primary btn" onclick={review} disabled={busy}>Send review</button>
+          {/if}
+        {:else if exchange.status === 'Reviewed'}
+          <p>Completed and reviewed by both of you.</p>
+        {/if}
+      </div>
+    {/if}
+
+    {#if exchange.status === 'Complete' || exchange.status === 'Reviewed'}
+      <div class="grid gap-4 md:grid-cols-2">
+        {@render reviewCard('Your review', myReviewText)}
+        {@render reviewCard(`${other?.name ?? 'Their'} review`, theirReviewText)}
+      </div>
+    {/if}
+
+    <div class="space-y-1 text-sm text-surface-500">
+      <p>Written up {formatWhen(exchange.created_at)}</p>
+      {#if exchange.response}<p>{exchange.response.accepted ? 'Accepted' : 'Declined'} {formatWhen(exchange.response.created_at)}</p>{/if}
+      {#if exchange.provider_done}<p>Provider done {formatWhen(exchange.provider_done.created_at)}</p>{/if}
+      {#if exchange.receiver_done}<p>Receiver done {formatWhen(exchange.receiver_done.created_at)}</p>{/if}
+      {#if exchange.cancellation}<p>Cancelled {formatWhen(exchange.cancellation.created_at)}</p>{/if}
+    </div>
+  {/if}
+</section>

--- a/ui/src/routes/(public)/exchanges/[id]/+page.svelte
+++ b/ui/src/routes/(public)/exchanges/[id]/+page.svelte
@@ -2,7 +2,8 @@
   import { page } from '$app/state';
   import { goto } from '$app/navigation';
   import { decodeHashFromBase64, encodeHashToBase64 } from '@holochain/client';
-  import { getToastStore } from '@skeletonlabs/skeleton';
+  import { getModalStore, getToastStore, type ModalComponent } from '@skeletonlabs/skeleton';
+  import ContactModal from '$lib/components/shared/listings/ContactModal.svelte';
   import exchangesStore from '$lib/stores/exchanges.store.svelte';
   import usersStore from '$lib/stores/users.store.svelte';
   import offersStore from '$lib/stores/offers.store.svelte';
@@ -10,8 +11,8 @@
   import { runEffect } from '$lib/utils/effect';
   import { useConnectionGuard } from '$lib/composables/connection/useConnectionGuard';
   import {
-    EXCHANGE_STATUS_LABEL,
     counterpartyOf,
+    statusLabel,
     doneBy,
     exchangeStatusVariant,
     formatWhen,
@@ -25,6 +26,21 @@
   import type { ReviewInDHT } from '$lib/types/holochain';
 
   const toastStore = getToastStore();
+  const modalStore = getModalStore();
+
+  function discuss() {
+    if (!other || !exchange) return;
+    const component: ModalComponent = {
+      ref: ContactModal,
+      props: {
+        user: other,
+        organization: null,
+        listingType: exchange.agreement.listing_type === 'Offer' ? 'offer' : 'request',
+        listingTitle
+      }
+    };
+    modalStore.trigger({ type: 'component', component, meta: { title: '', body: '' } });
+  }
 
   const agreementHash = $derived.by(() => {
     try {
@@ -41,9 +57,9 @@
   let busy = $state(false);
 
   let note = $state('');
-  let rating = $state(5);
-  let onTime = $state(true);
-  let asAgreed = $state(true);
+  let rating = $state(0);
+  let onTime = $state(false);
+  let asAgreed = $state(false);
   let comment = $state('');
 
   const me = $derived(usersStore.currentUser?.original_action_hash);
@@ -93,8 +109,21 @@
   const hash = () => exchange!.agreement_hash;
   const accept = () => act('Agreement accepted', () => runEffect(exchangesStore.respond(hash(), true, note)));
   const decline = () => act('Agreement declined', () => runEffect(exchangesStore.respond(hash(), false, note)));
+  const counter = async () => {
+    if (!exchange) return;
+    const a = exchange.agreement;
+    await act('Declined; make your counter-proposal', () =>
+      runEffect(exchangesStore.respond(hash(), false, 'Countered with a new proposal'))
+    );
+    goto(
+      `/exchanges/propose?interest=${encodeHashToBase64(a.interest)}` +
+        `&listing=${encodeHashToBase64(a.listing)}&type=${a.listing_type}`
+    );
+  };
   const complete = () => act('Marked as done', () => runEffect(exchangesStore.complete(hash())));
   const cancel = () => act('Agreement cancelled', () => runEffect(exchangesStore.cancel(hash(), note)));
+  const withdraw = () =>
+    act('Proposal withdrawn', () => runEffect(exchangesStore.cancel(hash(), 'Withdrawn by the proposer')));
   const review = () =>
     act('Review recorded', () =>
       runEffect(
@@ -162,7 +191,7 @@
       <div class="flex flex-wrap items-center justify-between gap-2">
         <h1 class="h2"><a class="anchor" href={listingHref}>{listingTitle || '...'}</a></h1>
         <span class="badge {exchangeStatusVariant(exchange.status)}">
-          {EXCHANGE_STATUS_LABEL[exchange.status]}
+          {statusLabel(exchange)}
         </span>
       </div>
       <p class="text-surface-500">
@@ -194,7 +223,12 @@
     {#if a.terms || a.delivery_timeframe}
       <div class="card space-y-2 p-4">
         {#if a.delivery_timeframe}<p><span class="font-semibold">When:</span> {a.delivery_timeframe}</p>{/if}
-        {#if a.terms}<p class="whitespace-pre-line">{a.terms}</p>{/if}
+        {#if a.terms}
+          <p class="text-xs uppercase tracking-wide text-surface-500">
+            {exchange.status === 'Proposed' || exchange.status === 'Declined' ? 'Proposal' : 'Agreement'}
+          </p>
+          <p class="whitespace-pre-line">{a.terms}</p>
+        {/if}
       </div>
     {/if}
 
@@ -205,7 +239,7 @@
       </div>
     {:else if exchange.status === 'Cancelled' && exchange.cancellation}
       <div class="alert variant-soft-surface">
-        <p>Cancelled on {formatWhen(exchange.cancellation.created_at)}.</p>
+        <p>{exchange.response ? 'Cancelled' : 'Withdrawn'} on {formatWhen(exchange.cancellation.created_at)}.</p>
         {#if exchange.cancellation.note}<p class="text-sm">{exchange.cancellation.note}</p>{/if}
       </div>
     {/if}
@@ -214,13 +248,18 @@
       <div class="card space-y-3 p-4">
         {#if exchange.status === 'Proposed'}
           {#if iWroteIt}
-            <p>Waiting for {other?.name ?? 'them'} to accept or decline.</p>
+            <p>Waiting for {other?.name ?? 'them'} to accept, counter or decline.</p>
+            <button class="variant-ghost-surface btn btn-sm" onclick={withdraw} disabled={busy}>
+              Withdraw proposal
+            </button>
           {:else}
-            <p>{other?.name ?? 'They'} wrote this up. Accept it, or decline with a note.</p>
+            <p>{other?.name ?? 'They'} sent this proposal. Accept it to form the agreement, counter with your own, or decline.</p>
             <textarea class="textarea" rows="2" bind:value={note} placeholder="A note, if declining"></textarea>
             <div class="flex flex-wrap gap-2">
-              <button class="variant-filled-primary btn" onclick={accept} disabled={busy}>Accept</button>
+              <button class="variant-soft-primary btn" onclick={discuss} disabled={busy || !other}>Discuss</button>
+              <button class="variant-filled-secondary btn" onclick={counter} disabled={busy}>Counter</button>
               <button class="variant-ghost-surface btn" onclick={decline} disabled={busy}>Decline</button>
+              <button class="variant-filled-primary btn" onclick={accept} disabled={busy}>Accept and form agreement</button>
             </div>
           {/if}
         {:else if exchange.status === 'Agreed' || exchange.status === 'ProviderDelivered'}
@@ -248,20 +287,35 @@
           {#if myReview}
             <p>Thanks for your review. Waiting for {other?.name ?? 'them'} to review.</p>
           {:else}
-            <p>Both parts are done. How did it go?</p>
-            <label class="label">
-              <span>Rating</span>
-              <select class="select" bind:value={rating}>
-                {#each [5, 4, 3, 2, 1, 0] as n (n)}<option value={n}>{n} of 5</option>{/each}
-              </select>
+            <p>Both parts are done. How was your exchange with {other?.name ?? 'them'}?</p>
+            <div class="flex items-center gap-1" role="radiogroup" aria-label="Rating">
+              {#each [1, 2, 3, 4, 5] as n (n)}
+                <button
+                  type="button"
+                  class="btn-icon btn-icon-sm {n <= rating ? 'variant-filled-warning' : 'variant-ghost-surface'}"
+                  onclick={() => (rating = n)}
+                  aria-label={`${n} of 5`}
+                  aria-pressed={n <= rating}
+                >{n}</button>
+              {/each}
+            </div>
+            <div class="space-y-2 py-2">
+              <label class="flex items-center gap-2"><input class="checkbox" type="checkbox" bind:checked={onTime} /> Delivered on time</label>
+              <label class="flex items-center gap-2"><input class="checkbox" type="checkbox" bind:checked={asAgreed} /> Matched what we agreed</label>
+            </div>
+            <label class="label pt-2">
+              <span>Comment <span class="text-xs text-surface-500">max 200</span></span>
+              <textarea class="textarea" rows="3" maxlength="200" bind:value={comment} placeholder="A few words about the exchange"></textarea>
+              <span class="text-xs text-surface-500">{comment.length}/200</span>
             </label>
-            <label class="flex items-center gap-2"><input class="checkbox" type="checkbox" bind:checked={onTime} /> On time</label>
-            <label class="flex items-center gap-2"><input class="checkbox" type="checkbox" bind:checked={asAgreed} /> As agreed</label>
-            <textarea class="textarea" rows="3" bind:value={comment} placeholder="Anything worth saying"></textarea>
-            <button class="variant-filled-primary btn" onclick={review} disabled={busy}>Send review</button>
+            {#if rating > 0 && rating <= 2}
+              <p class="text-sm text-warning-600">A low rating is recorded against the exchange. Stewarding, where this opens a resolution, arrives in a later release.</p>
+            {/if}
+            <button class="variant-filled-warning btn" onclick={review} disabled={busy || rating === 0}>Submit review</button>
           {/if}
         {:else if exchange.status === 'Reviewed'}
-          <p>Completed and reviewed by both of you.</p>
+          {@const done = Math.max(exchange.provider_done?.created_at ?? 0, exchange.receiver_done?.created_at ?? 0)}
+          <p>Completed {formatWhen(done)} and reviewed by both of you.</p>
         {/if}
       </div>
     {/if}

--- a/ui/src/routes/(public)/exchanges/propose/+page.svelte
+++ b/ui/src/routes/(public)/exchanges/propose/+page.svelte
@@ -4,46 +4,93 @@
   import { decodeHashFromBase64, encodeHashToBase64, type ActionHash } from '@holochain/client';
   import { getToastStore } from '@skeletonlabs/skeleton';
   import exchangesStore from '$lib/stores/exchanges.store.svelte';
+  import usersStore from '$lib/stores/users.store.svelte';
   import offersStore from '$lib/stores/offers.store.svelte';
   import requestsStore from '$lib/stores/requests.store.svelte';
   import serviceTypesStore from '$lib/stores/serviceTypes.store.svelte';
   import mediumsOfExchangeStore from '$lib/stores/mediums_of_exchange.store.svelte';
   import { runEffect } from '$lib/utils/effect';
   import { useConnectionGuard } from '$lib/composables/connection/useConnectionGuard';
-  import type { ExchangeTerm, ListingType, ResourceKind } from '$lib/types/holochain';
+  import { termLabel, type ExchangeRole } from '$lib/utils/exchange-ui';
+  import type { ExchangeTerm, ListingType } from '$lib/types/holochain';
+  import type { UIOffer, UIRequest, UIUser } from '$lib/types/ui';
 
   const toastStore = getToastStore();
+
+  const TIMEFRAMES = ['Within a few days', 'Within 2 weeks', 'Within a month', 'Flexible'];
+
+  type Medium = { name: string; currency: boolean };
 
   const params = $derived.by(() => {
     const q = page.url.searchParams;
     try {
-      const listingType = q.get('type') as ListingType | null;
+      const t = q.get('type');
       return {
         interest: q.get('interest') ? decodeHashFromBase64(q.get('interest')!) : null,
         listing: q.get('listing') ? decodeHashFromBase64(q.get('listing')!) : null,
-        listingType: listingType === 'Offer' || listingType === 'Request' ? listingType : null
+        listingType: (t === 'Offer' || t === 'Request' ? t : null) as ListingType | null
       };
     } catch {
       return { interest: null, listing: null, listingType: null };
     }
   });
 
-  let title = $state('');
-  let serviceName = $state('');
-  let mediumNames = $state<string[]>([]);
+  let listing = $state<UIOffer | UIRequest | null>(null);
+  let creator = $state<UIUser | null>(null);
+  let services = $state<string[]>([]);
+  let giverOffers = $state<string[]>([]);
+  let mediums = $state<Medium[]>([]);
   let loadError = $state<string | null>(null);
   let busy = $state(false);
 
-  let hours = $state<number | null>(null);
+  let service = $state('');
   let medium = $state('');
-  let reciprocalKind = $state<ResourceKind>('Tbd');
-  let reciprocalResource = $state('');
-  let reciprocalAmount = $state<number | null>(null);
+  let hours = $state<number | undefined>(undefined);
+  let returnService = $state('');
+  let amount = $state<number | undefined>(undefined);
   let terms = $state('');
-  let timeframe = $state('');
+  let timeframe = $state('Within 2 weeks');
 
-  const valid = $derived(
-    !!params.interest && !!params.listing && !!params.listingType && timeframe.trim().length > 0
+  const me = $derived(usersStore.currentUser?.original_action_hash);
+  const iAmAuthor = $derived(
+    !!listing?.creator && !!me && listing.creator.toString() === me.toString()
+  );
+  // An offer's author provides; a request's author receives.
+  const myRole = $derived<ExchangeRole>(
+    (params.listingType === 'Offer') === iAmAuthor ? 'provider' : 'receiver'
+  );
+  const isCurrency = $derived(mediums.find((m) => m.name === medium)?.currency ?? false);
+  const otherName = $derived(creator?.name ?? 'them');
+
+  const primary = $derived<ExchangeTerm>({
+    direction: 'Provide',
+    resource_conforms_to: service,
+    resource_kind: 'Service',
+    quantity: hours ? { value: hours, unit: 'hours' } : null
+  });
+  const reciprocal = $derived<ExchangeTerm>(
+    isCurrency
+      ? {
+          direction: 'Receive',
+          resource_conforms_to: medium,
+          resource_kind: 'Currency',
+          quantity: amount != null ? { value: amount, unit: medium } : null
+        }
+      : medium === 'Service Exchange'
+        ? { direction: 'Receive', resource_conforms_to: returnService === '__other__' ? 'A service, see terms' : returnService, resource_kind: 'Service', quantity: null }
+        : medium === 'Free/Pay it Forward'
+          ? { direction: 'Receive', resource_conforms_to: '', resource_kind: 'Gift', quantity: null }
+          : { direction: 'Receive', resource_conforms_to: '', resource_kind: 'Tbd', quantity: null }
+  );
+
+  const canSubmit = $derived(
+    !!params.interest &&
+      !!params.listing &&
+      !!service &&
+      !!medium &&
+      terms.trim().length > 0 &&
+      !(medium === 'Service Exchange' && !returnService) &&
+      !(isCurrency && amount == null)
   );
 
   function fail(e: unknown) {
@@ -53,18 +100,10 @@
     });
   }
 
-  async function nameOf(kind: 'service' | 'medium', hash: ActionHash): Promise<string | null> {
-    const item =
-      kind === 'service'
-        ? await runEffect(serviceTypesStore.getServiceType(hash))
-        : await runEffect(mediumsOfExchangeStore.getMediumOfExchange(hash));
-    return item?.name ?? null;
-  }
-
   $effect(() => {
-    const { listing, listingType } = params;
-    if (!listing || !listingType) {
-      loadError = 'This page needs a listing and an interest to write up.';
+    const { listing: hash, listingType } = params;
+    if (!hash || !listingType) {
+      loadError = 'This page needs a listing and an interest to propose against.';
       return;
     }
     (async () => {
@@ -72,59 +111,54 @@
         await runEffect(useConnectionGuard());
         const item =
           listingType === 'Offer'
-            ? await runEffect(offersStore.getOffer(listing))
-            : await runEffect(requestsStore.getRequest(listing));
+            ? await runEffect(offersStore.getOffer(hash))
+            : await runEffect(requestsStore.getRequest(hash));
         if (!item) {
           loadError = 'That listing could not be found.';
           return;
         }
-        title = item.title;
-        const firstService = item.service_type_hashes?.[0];
-        serviceName = (firstService && (await nameOf('service', firstService))) || item.title;
+        listing = item;
+        if (item.creator) creator = await runEffect(usersStore.getUserByActionHash(item.creator));
         const names = await Promise.all(
-          (item.medium_of_exchange_hashes ?? []).map((h) => nameOf('medium', h))
+          (item.service_type_hashes ?? []).map(async (h: ActionHash) => {
+            const st = await runEffect(serviceTypesStore.getServiceType(h));
+            return st?.name ?? null;
+          })
         );
-        mediumNames = names.filter((n): n is string => !!n);
-        medium = mediumNames[0] ?? '';
+        services = names.filter((n): n is string => !!n);
+        service = services[0] ?? item.title;
+        const found = await Promise.all(
+          (item.medium_of_exchange_hashes ?? []).map(async (h: ActionHash) => {
+            const m = await runEffect(mediumsOfExchangeStore.getMediumOfExchange(h));
+            return m ? { name: m.name, currency: m.exchange_type === 'currency' } : null;
+          })
+        );
+        mediums = found.filter((m): m is Medium => !!m);
+        medium = mediums[0]?.name ?? '';
+        // Under Service Exchange the return service is chosen from what the
+        // reciprocal giver actually offers: the receiver of the primary.
+        const interests = await runEffect(exchangesStore.getInterestsForListing(hash));
+        const theInterest = interests.find(
+          (i) => params.interest && i.interest_hash.toString() === params.interest.toString()
+        );
+        const authorHash = item.creator;
+        const memberHash = theInterest?.user;
+        const authorProvides = listingType === 'Offer';
+        const giver = authorProvides ? memberHash : authorHash;
+        if (giver) {
+          const offers = await runEffect(offersStore.getUserActiveOffers(giver));
+          giverOffers = [...new Set(offers.map((o) => o.title))];
+        }
       } catch (e) {
         loadError = e instanceof Error ? e.message : String(e);
       }
     })();
   });
 
-  // Terms are written from the provider's side: they provide the primary and
-  // receive the reciprocal.
-  function buildTerms(): { primary: ExchangeTerm; reciprocal: ExchangeTerm } {
-    const primary: ExchangeTerm = {
-      direction: 'Provide',
-      resource_conforms_to: serviceName,
-      resource_kind: 'Service',
-      quantity: hours ? { value: hours, unit: 'hours' } : null
-    };
-    const reciprocal: ExchangeTerm = {
-      direction: 'Receive',
-      resource_conforms_to:
-        reciprocalKind === 'Currency'
-          ? medium
-          : reciprocalKind === 'Service'
-            ? reciprocalResource
-            : '',
-      resource_kind: reciprocalKind,
-      quantity:
-        reciprocalKind === 'Currency' && reciprocalAmount
-          ? { value: reciprocalAmount, unit: medium }
-          : reciprocalKind === 'Service' && reciprocalAmount
-            ? { value: reciprocalAmount, unit: 'hours' }
-            : null
-    };
-    return { primary, reciprocal };
-  }
-
   async function submit() {
-    if (!valid) return;
+    if (!canSubmit) return;
     busy = true;
     try {
-      const { primary, reciprocal } = buildTerms();
       const exchange = await runEffect(
         exchangesStore.createAgreement({
           listing: params.listing!,
@@ -134,10 +168,10 @@
           reciprocal,
           medium,
           terms: terms.trim(),
-          delivery_timeframe: timeframe.trim()
+          delivery_timeframe: timeframe
         })
       );
-      toastStore.trigger({ message: 'Agreement written up', background: 'variant-filled-success' });
+      toastStore.trigger({ message: 'Proposal sent', background: 'variant-filled-success' });
       goto(`/exchanges/${encodeHashToBase64(exchange.agreement_hash)}`);
     } catch (e) {
       fail(e);
@@ -148,7 +182,7 @@
 </script>
 
 <svelte:head>
-  <title>Write up the agreement</title>
+  <title>Make a proposal</title>
 </svelte:head>
 
 <section class="container mx-auto max-w-2xl space-y-6 p-4">
@@ -156,76 +190,122 @@
 
   {#if loadError}
     <div class="alert variant-filled-error">{loadError}</div>
+  {:else if !listing}
+    <p class="text-surface-500">Loading the listing...</p>
   {:else}
     <header class="space-y-1">
-      <h1 class="h2">Write up the agreement</h1>
+      <h1 class="h2">Make a proposal</h1>
       <p class="text-surface-500">
-        For <span class="font-semibold">{title || '...'}</span>. The other party accepts or
-        declines what you write here; nothing is binding until they do.
+        For <span class="font-semibold">{listing.title}</span>, with {otherName}. They accept,
+        counter or decline what you send; nothing is binding until they accept.
       </p>
     </header>
 
-    <div class="card space-y-4 p-4">
-      <p class="text-xs uppercase tracking-wide text-surface-500">What is provided</p>
-      <p class="font-semibold">{serviceName || '...'}</p>
-      <label class="label">
-        <span>How much, in hours (optional)</span>
-        <input class="input" type="number" min="0" step="0.5" bind:value={hours} />
-      </label>
+    <div class="card space-y-2 p-4">
+      <p class="text-xs uppercase tracking-wide text-surface-500">The {params.listingType?.toLowerCase()} as listed</p>
+      <p class="font-semibold">{listing.title}</p>
+      {#if listing.description}<p class="line-clamp-3 text-sm text-surface-500">{listing.description}</p>{/if}
+      <p class="text-sm">
+        {#if services.length}Service: {services.join(', ')}.{/if}
+        {#if mediums.length}Medium of exchange: {mediums.map((m) => m.name).join(', ')}.{/if}
+      </p>
+    </div>
+
+    <div class="alert variant-soft-primary text-sm">
+      Every exchange is reciprocal, and the medium of exchange is the frame it happens under, not
+      itself a thing you give. Under Service Exchange you name a second service in return; under
+      Let's Discuss you make your opening proposition in the terms; under Free/Pay it Forward
+      nothing flows back.
     </div>
 
     <div class="card space-y-4 p-4">
-      <p class="text-xs uppercase tracking-wide text-surface-500">What is given in return</p>
       <label class="label">
-        <span>Kind</span>
-        <select class="select" bind:value={reciprocalKind}>
-          <option value="Tbd">To be agreed later</option>
-          <option value="Gift">Gift, nothing owed</option>
-          <option value="Currency">A payment</option>
-          <option value="Service">A service in return</option>
-        </select>
+        <span>Service</span>
+        {#if services.length > 1}
+          <select class="select" bind:value={service}>
+            {#each services as s (s)}<option value={s}>{s}</option>{/each}
+          </select>
+        {:else}
+          <input class="input" type="text" bind:value={service} />
+        {/if}
       </label>
-      {#if reciprocalKind === 'Currency'}
+      <div class="grid gap-4 sm:grid-cols-2">
         <label class="label">
-          <span>Medium</span>
-          {#if mediumNames.length > 0}
+          <span>Medium of exchange</span>
+          {#if mediums.length > 0}
             <select class="select" bind:value={medium}>
-              {#each mediumNames as name (name)}<option value={name}>{name}</option>{/each}
+              {#each mediums as m (m.name)}<option value={m.name}>{m.name}</option>{/each}
             </select>
           {:else}
-            <input class="input" type="text" bind:value={medium} placeholder="e.g. GBP, time credits" />
+            <input class="input" type="text" bind:value={medium} placeholder="As agreed" />
           {/if}
         </label>
         <label class="label">
-          <span>Amount</span>
-          <input class="input" type="number" min="0" step="0.01" bind:value={reciprocalAmount} />
+          <span>{myRole === 'provider' ? 'Hours offered' : 'Hours requested'}</span>
+          <input class="input" type="number" min="0" step="0.5" bind:value={hours} placeholder="e.g. 3" />
         </label>
-      {:else if reciprocalKind === 'Service'}
+      </div>
+
+      {#if isCurrency}
         <label class="label">
-          <span>What service</span>
-          <input class="input" type="text" bind:value={reciprocalResource} />
+          <span>Amount in {medium}</span>
+          <input class="input" type="number" min="0" step="0.5" bind:value={amount} placeholder="e.g. 50" />
         </label>
+      {:else if medium === 'Service Exchange'}
         <label class="label">
-          <span>How much, in hours (optional)</span>
-          <input class="input" type="number" min="0" step="0.5" bind:value={reciprocalAmount} />
+          <span>Return service</span>
+          {#if giverOffers.length > 0}
+            <select class="select" bind:value={returnService}>
+              <option value="" disabled>Choose one of {myRole === 'provider' ? `${otherName}'s` : 'your'} offers</option>
+              {#each giverOffers as title (title)}<option value={title}>{title}</option>{/each}
+              <option value="__other__">Something else, named in the terms</option>
+            </select>
+          {:else}
+            <input class="input" type="text" bind:value={returnService} placeholder="e.g. UI design, copy editing" />
+          {/if}
+          <span class="text-xs text-surface-500">
+            {#if giverOffers.length > 0}
+              What {myRole === 'provider' ? otherName : 'you'} already offer{myRole === 'provider' ? 's' : ''}; pick one, or name something else in the terms.
+            {:else}
+              {myRole === 'provider' ? otherName : 'You'} {myRole === 'provider' ? 'has' : 'have'} no active offer yet; name the return service and settle the details in the terms.
+            {/if}
+          </span>
         </label>
+      {:else if medium === "Let's Discuss"}
+        <p class="text-sm text-surface-500">Nothing is named as the reciprocal here; make your opening proposition in the terms.</p>
+      {:else if medium === 'Free/Pay it Forward'}
+        <p class="text-sm text-surface-500">This is a gift. Nothing is expected in return.</p>
       {/if}
+
+      <label class="label">
+        <span>Your proposal <span class="text-xs text-surface-500">{medium === "Let's Discuss" ? 'your opening proposition' : 'what exactly is being exchanged'}, max 300</span></span>
+        <textarea class="textarea" rows="4" maxlength="300" bind:value={terms}></textarea>
+        <span class="text-xs text-surface-500">{terms.length}/300</span>
+      </label>
+
+      <label class="label">
+        <span>Delivery timeframe</span>
+        <select class="select" bind:value={timeframe}>
+          {#each TIMEFRAMES as t (t)}<option value={t}>{t}</option>{/each}
+        </select>
+      </label>
     </div>
 
-    <div class="card space-y-4 p-4">
-      <label class="label">
-        <span>When</span>
-        <input class="input" type="text" bind:value={timeframe} placeholder="e.g. Saturday morning, or by the end of March" />
-      </label>
-      <label class="label">
-        <span>Anything else you have agreed (optional)</span>
-        <textarea class="textarea" rows="4" bind:value={terms}></textarea>
-      </label>
+    <div class="card space-y-2 p-4">
+      <p class="text-xs uppercase tracking-wide text-surface-500">Preview</p>
+      <p>
+        <span class="badge variant-soft-surface">{medium || '...'}</span>
+      </p>
+      <p class="text-sm">
+        You give <span class="font-semibold">{termLabel(myRole === 'provider' ? primary : reciprocal) || '...'}</span>
+        and receive <span class="font-semibold">{termLabel(myRole === 'provider' ? reciprocal : primary) || '...'}</span>
+      </p>
     </div>
 
-    <div class="flex justify-end">
-      <button class="variant-filled-primary btn" onclick={submit} disabled={!valid || busy}>
-        Send for acceptance
+    <div class="flex justify-end gap-2">
+      <button class="variant-ghost-surface btn" onclick={() => history.back()}>Cancel</button>
+      <button class="variant-filled-primary btn" onclick={submit} disabled={!canSubmit || busy}>
+        Send proposal
       </button>
     </div>
   {/if}

--- a/ui/src/routes/(public)/exchanges/propose/+page.svelte
+++ b/ui/src/routes/(public)/exchanges/propose/+page.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import { goto } from '$app/navigation';
+  import { decodeHashFromBase64, encodeHashToBase64, type ActionHash } from '@holochain/client';
+  import { getToastStore } from '@skeletonlabs/skeleton';
+  import exchangesStore from '$lib/stores/exchanges.store.svelte';
+  import offersStore from '$lib/stores/offers.store.svelte';
+  import requestsStore from '$lib/stores/requests.store.svelte';
+  import serviceTypesStore from '$lib/stores/serviceTypes.store.svelte';
+  import mediumsOfExchangeStore from '$lib/stores/mediums_of_exchange.store.svelte';
+  import { runEffect } from '$lib/utils/effect';
+  import { useConnectionGuard } from '$lib/composables/connection/useConnectionGuard';
+  import type { ExchangeTerm, ListingType, ResourceKind } from '$lib/types/holochain';
+
+  const toastStore = getToastStore();
+
+  const params = $derived.by(() => {
+    const q = page.url.searchParams;
+    try {
+      const listingType = q.get('type') as ListingType | null;
+      return {
+        interest: q.get('interest') ? decodeHashFromBase64(q.get('interest')!) : null,
+        listing: q.get('listing') ? decodeHashFromBase64(q.get('listing')!) : null,
+        listingType: listingType === 'Offer' || listingType === 'Request' ? listingType : null
+      };
+    } catch {
+      return { interest: null, listing: null, listingType: null };
+    }
+  });
+
+  let title = $state('');
+  let serviceName = $state('');
+  let mediumNames = $state<string[]>([]);
+  let loadError = $state<string | null>(null);
+  let busy = $state(false);
+
+  let hours = $state<number | null>(null);
+  let medium = $state('');
+  let reciprocalKind = $state<ResourceKind>('Tbd');
+  let reciprocalResource = $state('');
+  let reciprocalAmount = $state<number | null>(null);
+  let terms = $state('');
+  let timeframe = $state('');
+
+  const valid = $derived(
+    !!params.interest && !!params.listing && !!params.listingType && timeframe.trim().length > 0
+  );
+
+  function fail(e: unknown) {
+    toastStore.trigger({
+      message: e instanceof Error ? e.message : String(e),
+      background: 'variant-filled-error'
+    });
+  }
+
+  async function nameOf(kind: 'service' | 'medium', hash: ActionHash): Promise<string | null> {
+    const item =
+      kind === 'service'
+        ? await runEffect(serviceTypesStore.getServiceType(hash))
+        : await runEffect(mediumsOfExchangeStore.getMediumOfExchange(hash));
+    return item?.name ?? null;
+  }
+
+  $effect(() => {
+    const { listing, listingType } = params;
+    if (!listing || !listingType) {
+      loadError = 'This page needs a listing and an interest to write up.';
+      return;
+    }
+    (async () => {
+      try {
+        await runEffect(useConnectionGuard());
+        const item =
+          listingType === 'Offer'
+            ? await runEffect(offersStore.getOffer(listing))
+            : await runEffect(requestsStore.getRequest(listing));
+        if (!item) {
+          loadError = 'That listing could not be found.';
+          return;
+        }
+        title = item.title;
+        const firstService = item.service_type_hashes?.[0];
+        serviceName = (firstService && (await nameOf('service', firstService))) || item.title;
+        const names = await Promise.all(
+          (item.medium_of_exchange_hashes ?? []).map((h) => nameOf('medium', h))
+        );
+        mediumNames = names.filter((n): n is string => !!n);
+        medium = mediumNames[0] ?? '';
+      } catch (e) {
+        loadError = e instanceof Error ? e.message : String(e);
+      }
+    })();
+  });
+
+  // Terms are written from the provider's side: they provide the primary and
+  // receive the reciprocal.
+  function buildTerms(): { primary: ExchangeTerm; reciprocal: ExchangeTerm } {
+    const primary: ExchangeTerm = {
+      direction: 'Provide',
+      resource_conforms_to: serviceName,
+      resource_kind: 'Service',
+      quantity: hours ? { value: hours, unit: 'hours' } : null
+    };
+    const reciprocal: ExchangeTerm = {
+      direction: 'Receive',
+      resource_conforms_to:
+        reciprocalKind === 'Currency'
+          ? medium
+          : reciprocalKind === 'Service'
+            ? reciprocalResource
+            : '',
+      resource_kind: reciprocalKind,
+      quantity:
+        reciprocalKind === 'Currency' && reciprocalAmount
+          ? { value: reciprocalAmount, unit: medium }
+          : reciprocalKind === 'Service' && reciprocalAmount
+            ? { value: reciprocalAmount, unit: 'hours' }
+            : null
+    };
+    return { primary, reciprocal };
+  }
+
+  async function submit() {
+    if (!valid) return;
+    busy = true;
+    try {
+      const { primary, reciprocal } = buildTerms();
+      const exchange = await runEffect(
+        exchangesStore.createAgreement({
+          listing: params.listing!,
+          listing_type: params.listingType!,
+          interest: params.interest!,
+          primary,
+          reciprocal,
+          medium,
+          terms: terms.trim(),
+          delivery_timeframe: timeframe.trim()
+        })
+      );
+      toastStore.trigger({ message: 'Agreement written up', background: 'variant-filled-success' });
+      goto(`/exchanges/${encodeHashToBase64(exchange.agreement_hash)}`);
+    } catch (e) {
+      fail(e);
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Write up the agreement</title>
+</svelte:head>
+
+<section class="container mx-auto max-w-2xl space-y-6 p-4">
+  <button class="variant-soft btn btn-sm" onclick={() => history.back()}>Back</button>
+
+  {#if loadError}
+    <div class="alert variant-filled-error">{loadError}</div>
+  {:else}
+    <header class="space-y-1">
+      <h1 class="h2">Write up the agreement</h1>
+      <p class="text-surface-500">
+        For <span class="font-semibold">{title || '...'}</span>. The other party accepts or
+        declines what you write here; nothing is binding until they do.
+      </p>
+    </header>
+
+    <div class="card space-y-4 p-4">
+      <p class="text-xs uppercase tracking-wide text-surface-500">What is provided</p>
+      <p class="font-semibold">{serviceName || '...'}</p>
+      <label class="label">
+        <span>How much, in hours (optional)</span>
+        <input class="input" type="number" min="0" step="0.5" bind:value={hours} />
+      </label>
+    </div>
+
+    <div class="card space-y-4 p-4">
+      <p class="text-xs uppercase tracking-wide text-surface-500">What is given in return</p>
+      <label class="label">
+        <span>Kind</span>
+        <select class="select" bind:value={reciprocalKind}>
+          <option value="Tbd">To be agreed later</option>
+          <option value="Gift">Gift, nothing owed</option>
+          <option value="Currency">A payment</option>
+          <option value="Service">A service in return</option>
+        </select>
+      </label>
+      {#if reciprocalKind === 'Currency'}
+        <label class="label">
+          <span>Medium</span>
+          {#if mediumNames.length > 0}
+            <select class="select" bind:value={medium}>
+              {#each mediumNames as name (name)}<option value={name}>{name}</option>{/each}
+            </select>
+          {:else}
+            <input class="input" type="text" bind:value={medium} placeholder="e.g. GBP, time credits" />
+          {/if}
+        </label>
+        <label class="label">
+          <span>Amount</span>
+          <input class="input" type="number" min="0" step="0.01" bind:value={reciprocalAmount} />
+        </label>
+      {:else if reciprocalKind === 'Service'}
+        <label class="label">
+          <span>What service</span>
+          <input class="input" type="text" bind:value={reciprocalResource} />
+        </label>
+        <label class="label">
+          <span>How much, in hours (optional)</span>
+          <input class="input" type="number" min="0" step="0.5" bind:value={reciprocalAmount} />
+        </label>
+      {/if}
+    </div>
+
+    <div class="card space-y-4 p-4">
+      <label class="label">
+        <span>When</span>
+        <input class="input" type="text" bind:value={timeframe} placeholder="e.g. Saturday morning, or by the end of March" />
+      </label>
+      <label class="label">
+        <span>Anything else you have agreed (optional)</span>
+        <textarea class="textarea" rows="4" bind:value={terms}></textarea>
+      </label>
+    </div>
+
+    <div class="flex justify-end">
+      <button class="variant-filled-primary btn" onclick={submit} disabled={!valid || busy}>
+        Send for acceptance
+      </button>
+    </div>
+  {/if}
+</section>

--- a/ui/src/routes/(public)/exchanges/propose/+page.svelte
+++ b/ui/src/routes/(public)/exchanges/propose/+page.svelte
@@ -90,6 +90,7 @@
       !!medium &&
       terms.trim().length > 0 &&
       !(medium === 'Service Exchange' && !returnService) &&
+      !(medium === 'Service Exchange' && giverOffers.length === 0) &&
       !(isCurrency && amount == null)
   );
 
@@ -214,24 +215,21 @@
     <div class="alert variant-soft-primary text-sm">
       Every exchange is reciprocal, and the medium of exchange is the frame it happens under, not
       itself a thing you give. Under Service Exchange you name a second service in return; under
-      Let's Discuss you make your opening proposition in the terms; under Free/Pay it Forward
-      nothing flows back.
+      Free/Pay it Forward nothing flows back.
     </div>
 
     <div class="card space-y-4 p-4">
-      <label class="label">
-        <span>Service</span>
-        {#if services.length > 1}
+      {#if services.length > 1}
+        <label class="label">
+          <span>Service <span class="text-xs text-surface-500">which of the listed services this covers</span></span>
           <select class="select" bind:value={service}>
             {#each services as s (s)}<option value={s}>{s}</option>{/each}
           </select>
-        {:else}
-          <input class="input" type="text" bind:value={service} />
-        {/if}
-      </label>
+        </label>
+      {/if}
       <div class="grid gap-4 sm:grid-cols-2">
         <label class="label">
-          <span>Medium of exchange</span>
+          <span>Requested medium of exchange</span>
           {#if mediums.length > 0}
             <select class="select" bind:value={medium}>
               {#each mediums as m (m.name)}<option value={m.name}>{m.name}</option>{/each}
@@ -253,7 +251,7 @@
         </label>
       {:else if medium === 'Service Exchange'}
         <label class="label">
-          <span>Return service</span>
+          <span>Chosen service offer for proposal</span>
           {#if giverOffers.length > 0}
             <select class="select" bind:value={returnService}>
               <option value="" disabled>Choose one of {myRole === 'provider' ? `${otherName}'s` : 'your'} offers</option>
@@ -261,9 +259,9 @@
             </select>
           {:else}
             <p class="alert variant-soft-warning text-sm">
-              A Service Exchange names a service on both sides, and {myRole === 'provider' ? otherName : 'you'}
-              {myRole === 'provider' ? 'has' : 'have'} no active offer to name. Agree what it will be between you,
-              post it as an offer, and it can be named here. To settle it as you go instead, use Let's Discuss.
+              A Service Exchange names a real offer on both sides, and {myRole === 'provider' ? otherName : 'you'}
+              {myRole === 'provider' ? 'has' : 'have'} no active offer to name. Agree what it will be between you
+              and post it as an offer first; this proposal cannot be sent until one exists.
             </p>
           {/if}
           {#if giverOffers.length > 0}
@@ -272,16 +270,20 @@
             </span>
           {/if}
         </label>
-      {:else if medium === "Let's Discuss"}
-        <p class="text-sm text-surface-500">Nothing is named as the reciprocal here; make your opening proposition in the terms.</p>
       {:else if medium === 'Free/Pay it Forward'}
         <p class="text-sm text-surface-500">This is a gift. Nothing is expected in return.</p>
       {/if}
 
       <label class="label">
-        <span>Your proposal <span class="text-xs text-surface-500">{medium === "Let's Discuss" ? 'your opening proposition' : 'what exactly is being exchanged'}, max 300</span></span>
-        <textarea class="textarea" rows="4" maxlength="300" bind:value={terms}></textarea>
-        <span class="text-xs text-surface-500">{terms.length}/300</span>
+        <span>Your proposal <span class="text-xs text-surface-500">what exactly is being exchanged, max 300</span></span>
+        <textarea
+          class="textarea"
+          rows="4"
+          maxlength="300"
+          bind:value={terms}
+          placeholder="Conditions of the exchange: quantities, timing, expectations. Not a private message."
+        ></textarea>
+        <span class="text-xs text-surface-500">{terms.length}/300 &middot; published to the whole network, permanently</span>
       </label>
 
       <label class="label">

--- a/ui/src/routes/(public)/exchanges/propose/+page.svelte
+++ b/ui/src/routes/(public)/exchanges/propose/+page.svelte
@@ -77,7 +77,7 @@
           quantity: amount != null ? { value: amount, unit: medium } : null
         }
       : medium === 'Service Exchange'
-        ? { direction: 'Receive', resource_conforms_to: returnService === '__other__' ? 'A service, see terms' : returnService, resource_kind: 'Service', quantity: null }
+        ? { direction: 'Receive', resource_conforms_to: returnService, resource_kind: 'Service', quantity: null }
         : medium === 'Free/Pay it Forward'
           ? { direction: 'Receive', resource_conforms_to: '', resource_kind: 'Gift', quantity: null }
           : { direction: 'Receive', resource_conforms_to: '', resource_kind: 'Tbd', quantity: null }
@@ -258,18 +258,19 @@
             <select class="select" bind:value={returnService}>
               <option value="" disabled>Choose one of {myRole === 'provider' ? `${otherName}'s` : 'your'} offers</option>
               {#each giverOffers as title (title)}<option value={title}>{title}</option>{/each}
-              <option value="__other__">Something else, named in the terms</option>
             </select>
           {:else}
-            <input class="input" type="text" bind:value={returnService} placeholder="e.g. UI design, copy editing" />
+            <p class="alert variant-soft-warning text-sm">
+              A Service Exchange names a service on both sides, and {myRole === 'provider' ? otherName : 'you'}
+              {myRole === 'provider' ? 'has' : 'have'} no active offer to name. Agree what it will be between you,
+              post it as an offer, and it can be named here. To settle it as you go instead, use Let's Discuss.
+            </p>
           {/if}
-          <span class="text-xs text-surface-500">
-            {#if giverOffers.length > 0}
-              What {myRole === 'provider' ? otherName : 'you'} already offer{myRole === 'provider' ? 's' : ''}; pick one, or name something else in the terms.
-            {:else}
-              {myRole === 'provider' ? otherName : 'You'} {myRole === 'provider' ? 'has' : 'have'} no active offer yet; name the return service and settle the details in the terms.
-            {/if}
-          </span>
+          {#if giverOffers.length > 0}
+            <span class="text-xs text-surface-500">
+              What {myRole === 'provider' ? otherName : 'you'} already offer{myRole === 'provider' ? 's' : ''}.
+            </span>
+          {/if}
         </label>
       {:else if medium === "Let's Discuss"}
         <p class="text-sm text-surface-500">Nothing is named as the reciprocal here; make your opening proposition in the terms.</p>

--- a/ui/src/routes/(public)/offers/[id]/+page.svelte
+++ b/ui/src/routes/(public)/offers/[id]/+page.svelte
@@ -16,6 +16,7 @@
   import { useConnectionGuard } from '$lib/composables/connection/useConnectionGuard';
   import { useAdminStatusGuard } from '$lib/composables/connection/useAdminStatusGuard.svelte';
   import ContactButton from '$lib/components/shared/listings/ContactButton.svelte';
+  import ListingInterest from '$lib/components/exchanges/ListingInterest.svelte';
   import MarkdownRenderer from '$lib/components/shared/MarkdownRenderer.svelte';
   import { stripMarkdown } from '$lib/utils/markdown';
 
@@ -526,6 +527,14 @@
           </div>
         </div>
       {/if}
+    {/if}
+
+    {#if offer}
+      <ListingInterest
+        listingHash={offer.original_action_hash}
+        listingType="Offer"
+        isCreator={!!(offer.creator && usersStore.currentUser?.original_action_hash && offer.creator.toString() === usersStore.currentUser.original_action_hash.toString())}
+      />
     {/if}
 
     <!-- Contact Information -->

--- a/ui/src/routes/(public)/offers/[id]/+page.svelte
+++ b/ui/src/routes/(public)/offers/[id]/+page.svelte
@@ -15,7 +15,6 @@
   import { runEffect } from '$lib/utils/effect';
   import { useConnectionGuard } from '$lib/composables/connection/useConnectionGuard';
   import { useAdminStatusGuard } from '$lib/composables/connection/useAdminStatusGuard.svelte';
-  import ContactButton from '$lib/components/shared/listings/ContactButton.svelte';
   import ListingInterest from '$lib/components/exchanges/ListingInterest.svelte';
   import MarkdownRenderer from '$lib/components/shared/MarkdownRenderer.svelte';
   import { stripMarkdown } from '$lib/utils/markdown';
@@ -529,16 +528,17 @@
       {/if}
     {/if}
 
+    <!-- Interest and contact -->
     {#if offer}
       <ListingInterest
         listingHash={offer.original_action_hash}
         listingType="Offer"
+        listingTitle={offer.title}
+        {creator}
+        {organization}
         isCreator={!!(offer.creator && usersStore.currentUser?.original_action_hash && offer.creator.toString() === usersStore.currentUser.original_action_hash.toString())}
       />
     {/if}
-
-    <!-- Contact Information -->
-    <ContactButton user={creator} {organization} listingType="offer" listingTitle={offer?.title} />
 
     <!-- Metadata Footer -->
     <div class="text-center text-sm text-surface-500 dark:text-surface-400">

--- a/ui/src/routes/(public)/offers/[id]/+page.svelte
+++ b/ui/src/routes/(public)/offers/[id]/+page.svelte
@@ -480,9 +480,9 @@
                       {/if}
                     </div>
                     <div>
-                      <p class="font-semibold">{creator.name}</p>
+                      <p class="font-semibold">Name: {creator.name}</p>
                       {#if creator.nickname}
-                        <p class="text-surface-600-300-token text-sm">@{creator.nickname}</p>
+                        <p class="text-surface-600-300-token text-sm">Nickname/Handle: {creator.nickname}</p>
                       {/if}
                     </div>
                   </div>

--- a/ui/src/routes/(public)/requests/[id]/+page.svelte
+++ b/ui/src/routes/(public)/requests/[id]/+page.svelte
@@ -16,6 +16,7 @@
   import { useConnectionGuard } from '$lib/composables/connection/useConnectionGuard';
   import { useAdminStatusGuard } from '$lib/composables/connection/useAdminStatusGuard.svelte';
   import ContactButton from '$lib/components/shared/listings/ContactButton.svelte';
+  import ListingInterest from '$lib/components/exchanges/ListingInterest.svelte';
   import MarkdownRenderer from '$lib/components/shared/MarkdownRenderer.svelte';
   import { stripMarkdown } from '$lib/utils/markdown';
 
@@ -553,6 +554,14 @@
           </div>
         </div>
       {/if}
+    {/if}
+
+    {#if request}
+      <ListingInterest
+        listingHash={request.original_action_hash}
+        listingType="Request"
+        isCreator={!!(request.creator && usersStore.currentUser?.original_action_hash && request.creator.toString() === usersStore.currentUser.original_action_hash.toString())}
+      />
     {/if}
 
     <!-- Contact Information -->

--- a/ui/src/routes/(public)/requests/[id]/+page.svelte
+++ b/ui/src/routes/(public)/requests/[id]/+page.svelte
@@ -507,9 +507,9 @@
                       {/if}
                     </div>
                     <div>
-                      <p class="font-semibold">{creator.name}</p>
+                      <p class="font-semibold">Name: {creator.name}</p>
                       {#if creator.nickname}
-                        <p class="text-surface-600-300-token text-sm">@{creator.nickname}</p>
+                        <p class="text-surface-600-300-token text-sm">Nickname/Handle: {creator.nickname}</p>
                       {/if}
                     </div>
                   </div>

--- a/ui/src/routes/(public)/requests/[id]/+page.svelte
+++ b/ui/src/routes/(public)/requests/[id]/+page.svelte
@@ -15,7 +15,6 @@
   import { runEffect } from '$lib/utils/effect';
   import { useConnectionGuard } from '$lib/composables/connection/useConnectionGuard';
   import { useAdminStatusGuard } from '$lib/composables/connection/useAdminStatusGuard.svelte';
-  import ContactButton from '$lib/components/shared/listings/ContactButton.svelte';
   import ListingInterest from '$lib/components/exchanges/ListingInterest.svelte';
   import MarkdownRenderer from '$lib/components/shared/MarkdownRenderer.svelte';
   import { stripMarkdown } from '$lib/utils/markdown';
@@ -556,21 +555,17 @@
       {/if}
     {/if}
 
+    <!-- Interest and contact -->
     {#if request}
       <ListingInterest
         listingHash={request.original_action_hash}
         listingType="Request"
+        listingTitle={request.title}
+        {creator}
+        {organization}
         isCreator={!!(request.creator && usersStore.currentUser?.original_action_hash && request.creator.toString() === usersStore.currentUser.original_action_hash.toString())}
       />
     {/if}
-
-    <!-- Contact Information -->
-    <ContactButton
-      user={creator}
-      {organization}
-      listingType="request"
-      listingTitle={request?.title}
-    />
 
     <!-- Metadata Footer -->
     <div class="text-center text-sm text-surface-500 dark:text-surface-400">

--- a/ui/tests/e2e/specs/09-exchanges.spec.ts
+++ b/ui/tests/e2e/specs/09-exchanges.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { encodeHashToBase64, type AppWebsocket, type Record as HcRecord } from '@holochain/client';
+import { gotoApp, createTestClient, ensureAcceptedUser, callZome } from '../utils/e2e-helpers.js';
+
+// ============================================================================
+// 09 — EXCHANGES
+//
+// One agent per run, so this covers what one member sees: their empty
+// dashboard, and the author's side of the interest block on a listing they
+// own. The two-party handshake, proposal, acceptance, completion and review
+// is exercised by the exchanges sweettest and walked by hand on two agents.
+// ============================================================================
+
+test.describe.serial('09 — exchanges', () => {
+  let client: AppWebsocket;
+
+  test.beforeAll(async () => {
+    client = await createTestClient();
+    await ensureAcceptedUser(client);
+  });
+
+  test.afterAll(async () => {
+    await client.client.close();
+  });
+
+  test('my exchanges renders its three groups and the empty state', async ({ page }) => {
+    await gotoApp(page, '/exchanges');
+
+    await expect(page.getByRole('heading', { name: 'My Exchanges', exact: true })).toBeVisible({
+      timeout: 15_000
+    });
+    for (const group of ['Proposals', 'Active', 'Completed']) {
+      await expect(page.getByRole('tab', { name: new RegExp(group) })).toBeVisible();
+    }
+    await expect(page.getByText('No active exchanges yet.')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('link', { name: 'Browse listings to start one' })).toBeVisible();
+  });
+
+  test('the author of a listing sees who is interested, not the interest button', async ({
+    page
+  }) => {
+    // The offers spec archives or removes what it makes, so make one here.
+    const created = (await callZome(client, 'offers', 'create_offer', {
+      offer: {
+        title: 'E2E Exchange Listing',
+        description: 'A listing whose author looks for interested members.',
+        time_preference: 'NoPreference',
+        time_zone: 'Europe/London',
+        interaction_type: 'Virtual',
+        links: []
+      },
+      organization: null,
+      service_type_hashes: [],
+      medium_of_exchange_hashes: []
+    })) as HcRecord;
+    const hash = encodeHashToBase64(created.signed_action.hashed.hash);
+    await gotoApp(page, `/offers/${hash}`);
+
+    await expect(page.getByRole('heading', { name: 'Interested members' })).toBeVisible({
+      timeout: 15_000
+    });
+    await expect(page.getByText('No one has registered interest yet.')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Interested in this offer/ })).toHaveCount(0);
+  });
+});

--- a/ui/tests/unit/stores/exchanges.store.test.ts
+++ b/ui/tests/unit/stores/exchanges.store.test.ts
@@ -48,6 +48,10 @@ const model = (over: Partial<ExchangeReadModel> = {}): ExchangeReadModel => ({
   ...over
 });
 
+// What the next read returns; tests swap these instead of reassigning readonly fields.
+let nextExchange: () => ExchangeReadModel = () => model();
+let nextList: () => E.Effect<ExchangeReadModel[], ExchangeError> = () => E.succeed([model()]);
+
 function mockService(over: Partial<ExchangesService> = {}): ExchangesService {
   return {
     createInterest: vi.fn(() => E.succeed(record(interest, hash(20)))),
@@ -59,8 +63,8 @@ function mockService(over: Partial<ExchangesService> = {}): ExchangesService {
     completeAgreement: vi.fn(() => E.succeed(record({ agreement: hash(10) }, hash(12)))),
     reviewAgreement: vi.fn(() => E.succeed(record({ agreement: hash(10), rating: 5, on_time: true, as_agreed: true, comment: '' }, hash(13)))),
     cancelAgreement: vi.fn(() => E.succeed(record({ agreement: hash(10), note: '' }, hash(14)))),
-    getExchange: vi.fn(() => E.succeed(model())),
-    getMyExchanges: vi.fn(() => E.succeed([model()])),
+    getExchange: vi.fn(() => E.succeed(nextExchange())),
+    getMyExchanges: vi.fn(() => nextList()),
     getExchangesForListing: vi.fn(() => E.succeed([model()])),
     ...over
   };
@@ -75,6 +79,8 @@ describe('exchanges store', () => {
   let store: ExchangesStore;
 
   beforeEach(async () => {
+    nextExchange = () => model();
+    nextList = () => E.succeed([model()]);
     service = mockService();
     store = await storeWith(service);
   });
@@ -93,7 +99,7 @@ describe('exchanges store', () => {
       response: record({ agreement: hash(10), accepted: true, note: 'yes' }, hash(11)),
       provider_completion: record({ agreement: hash(10) }, hash(12), 1_700_000_100_000)
     });
-    service.getExchange = vi.fn(() => E.succeed(provided));
+    nextExchange = () => provided;
     const ex = await E.runPromise(store.getExchange(hash(10)));
     expect(ex.agreement_hash).toEqual(hash(10));
     expect(ex.agreement.medium).toBe('Free/Pay it Forward');
@@ -107,7 +113,7 @@ describe('exchanges store', () => {
   it('reads the exchange back after a write and keeps one entry per agreement', async () => {
     await E.runPromise(store.loadMyExchanges());
     expect(store.exchanges).toHaveLength(1);
-    service.getExchange = vi.fn(() => E.succeed(model({ status: 'Agreed', response: record({ agreement: hash(10), accepted: true, note: '' }, hash(11)) })));
+    nextExchange = () => model({ status: 'Agreed', response: record({ agreement: hash(10), accepted: true, note: '' }, hash(11)) });
     const ex = await E.runPromise(store.respond(hash(10), true, ''));
     expect(service.respondToAgreement).toHaveBeenCalledWith(hash(10), true, '');
     expect(ex.status).toBe('Agreed');
@@ -122,7 +128,7 @@ describe('exchanges store', () => {
   });
 
   it('records a service failure and clears loading', async () => {
-    service.getMyExchanges = vi.fn(() => E.fail(ExchangeError.create('conductor away')));
+    nextList = () => E.fail(ExchangeError.create('conductor away'));
     await expect(E.runPromise(store.loadMyExchanges())).rejects.toThrow();
     expect(store.error).toContain('conductor away');
     expect(store.loading).toBe(false);

--- a/ui/tests/unit/stores/exchanges.store.test.ts
+++ b/ui/tests/unit/stores/exchanges.store.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Effect as E, Layer } from 'effect';
+import { encode } from '@msgpack/msgpack';
+import type { Record as HcRecord } from '@holochain/client';
+import { createExchangesStore, type ExchangesStore } from '$lib/stores/exchanges.store.svelte';
+import { ExchangesServiceTag, type ExchangesService } from '$lib/services/zomes/exchanges.service';
+import { ExchangeError } from '$lib/errors/exchanges.errors';
+import type { AgreementInDHT, ExchangeReadModel, InterestInDHT } from '$lib/types/holochain';
+
+const hash = (n: number) => new Uint8Array([n, n, n, n]);
+
+const record = (entry: object, actionHash: Uint8Array, atMs = 1_700_000_000_000): HcRecord =>
+  ({
+    signed_action: {
+      hashed: {
+        hash: actionHash,
+        content: { timestamp: atMs * 1000, author: hash(9) }
+      }
+    },
+    entry: { Present: { entry: encode(entry) } }
+  }) as unknown as HcRecord;
+
+const agreement: AgreementInDHT = {
+  listing: hash(1),
+  listing_type: 'Offer',
+  interest: hash(2),
+  counterparty: hash(3),
+  provider: hash(4),
+  receiver: hash(3),
+  primary: { direction: 'Provide', resource_conforms_to: 'Gardening', resource_kind: 'Service', quantity: { value: 2, unit: 'h' } },
+  reciprocal: { direction: 'Receive', resource_conforms_to: '', resource_kind: 'Gift', quantity: null },
+  medium: 'Free/Pay it Forward',
+  terms: 'Saturday, bring gloves',
+  delivery_timeframe: 'Within 2 weeks'
+};
+
+const interest: InterestInDHT = { listing: hash(1), listing_type: 'Offer', user: hash(3) };
+
+const model = (over: Partial<ExchangeReadModel> = {}): ExchangeReadModel => ({
+  agreement: record(agreement, hash(10)),
+  response: null,
+  provider_completion: null,
+  receiver_completion: null,
+  provider_review: null,
+  receiver_review: null,
+  cancellation: null,
+  status: 'Proposed',
+  ...over
+});
+
+function mockService(over: Partial<ExchangesService> = {}): ExchangesService {
+  return {
+    createInterest: vi.fn(() => E.succeed(record(interest, hash(20)))),
+    withdrawInterest: vi.fn(() => E.succeed(hash(20))),
+    getInterestsForListing: vi.fn(() => E.succeed([record(interest, hash(20))])),
+    getMyInterests: vi.fn(() => E.succeed([])),
+    createAgreement: vi.fn(() => E.succeed(record(agreement, hash(10)))),
+    respondToAgreement: vi.fn(() => E.succeed(record({ agreement: hash(10), accepted: true, note: '' }, hash(11)))),
+    completeAgreement: vi.fn(() => E.succeed(record({ agreement: hash(10) }, hash(12)))),
+    reviewAgreement: vi.fn(() => E.succeed(record({ agreement: hash(10), rating: 5, on_time: true, as_agreed: true, comment: '' }, hash(13)))),
+    cancelAgreement: vi.fn(() => E.succeed(record({ agreement: hash(10), note: '' }, hash(14)))),
+    getExchange: vi.fn(() => E.succeed(model())),
+    getMyExchanges: vi.fn(() => E.succeed([model()])),
+    getExchangesForListing: vi.fn(() => E.succeed([model()])),
+    ...over
+  };
+}
+
+async function storeWith(service: ExchangesService): Promise<ExchangesStore> {
+  return E.runPromise(E.provide(createExchangesStore(), Layer.succeed(ExchangesServiceTag, service)));
+}
+
+describe('exchanges store', () => {
+  let service: ExchangesService;
+  let store: ExchangesStore;
+
+  beforeEach(async () => {
+    service = mockService();
+    store = await storeWith(service);
+  });
+
+  it('decodes an interest with its hash, member and time', async () => {
+    const [i] = await E.runPromise(store.getInterestsForListing(hash(1)));
+    expect(i.interest_hash).toEqual(hash(20));
+    expect(i.user).toEqual(hash(3));
+    expect(i.listing_type).toBe('Offer');
+    expect(i.created_at).toBe(1_700_000_000_000);
+  });
+
+  it('decodes an exchange by role and carries the derived status', async () => {
+    const provided = model({
+      status: 'ProviderDelivered',
+      response: record({ agreement: hash(10), accepted: true, note: 'yes' }, hash(11)),
+      provider_completion: record({ agreement: hash(10) }, hash(12), 1_700_000_100_000)
+    });
+    service.getExchange = vi.fn(() => E.succeed(provided));
+    const ex = await E.runPromise(store.getExchange(hash(10)));
+    expect(ex.agreement_hash).toEqual(hash(10));
+    expect(ex.agreement.medium).toBe('Free/Pay it Forward');
+    expect(ex.status).toBe('ProviderDelivered');
+    expect(ex.response?.accepted).toBe(true);
+    expect(ex.provider_done?.created_at).toBe(1_700_000_100_000);
+    expect(ex.receiver_done).toBeUndefined();
+    expect(ex.provider_review).toBeUndefined();
+  });
+
+  it('reads the exchange back after a write and keeps one entry per agreement', async () => {
+    await E.runPromise(store.loadMyExchanges());
+    expect(store.exchanges).toHaveLength(1);
+    service.getExchange = vi.fn(() => E.succeed(model({ status: 'Agreed', response: record({ agreement: hash(10), accepted: true, note: '' }, hash(11)) })));
+    const ex = await E.runPromise(store.respond(hash(10), true, ''));
+    expect(service.respondToAgreement).toHaveBeenCalledWith(hash(10), true, '');
+    expect(ex.status).toBe('Agreed');
+    expect(store.exchanges).toHaveLength(1);
+    expect(store.exchanges[0].status).toBe('Agreed');
+  });
+
+  it('replaces the list on load rather than appending', async () => {
+    await E.runPromise(store.loadMyExchanges());
+    await E.runPromise(store.loadMyExchanges());
+    expect(store.exchanges).toHaveLength(1);
+  });
+
+  it('records a service failure and clears loading', async () => {
+    service.getMyExchanges = vi.fn(() => E.fail(ExchangeError.create('conductor away')));
+    await expect(E.runPromise(store.loadMyExchanges())).rejects.toThrow();
+    expect(store.error).toContain('conductor away');
+    expect(store.loading).toBe(false);
+  });
+
+  it('passes the review fields through to the zome', async () => {
+    await E.runPromise(store.review(hash(10), { rating: 4, on_time: true, as_agreed: false, comment: 'fine' }));
+    expect(service.reviewAgreement).toHaveBeenCalledWith(hash(10), { rating: 4, on_time: true, as_agreed: false, comment: 'fine' });
+  });
+});

--- a/ui/tests/unit/utils/formatUserName.test.ts
+++ b/ui/tests/unit/utils/formatUserName.test.ts
@@ -27,8 +27,8 @@ describe('formatUserName', () => {
     expect(formatUserName('Dr. Smith')).toBe('Dr. Smith');
   });
 
-  it('preserves dots in initials like "J. R. R. Tolkien"', () => {
-    expect(formatUserName('J. R. R. Tolkien')).toBe('J. R. R. Tolkien');
+  it('preserves dots in initials like "Arthur C. Clarke"', () => {
+    expect(formatUserName('Arthur C. Clarke')).toBe('Arthur C. Clarke');
   });
 
   it('strips only the trailing sentinel when initials are also present', () => {

--- a/workdir/dna.yaml
+++ b/workdir/dna.yaml
@@ -29,6 +29,10 @@ integrity:
       hash: ~
       path: "../target/wasm32-unknown-unknown/release/mediums_of_exchange_integrity.wasm"
       dependencies: ~
+    - name: exchanges_integrity
+      hash: ~
+      path: "../target/wasm32-unknown-unknown/release/exchanges_integrity.wasm"
+      dependencies: ~
 coordinator:
   zomes:
     - name: users_organizations
@@ -65,3 +69,8 @@ coordinator:
       path: "../target/wasm32-unknown-unknown/release/mediums_of_exchange.wasm"
       dependencies:
         - name: mediums_of_exchange_integrity
+    - name: exchanges
+      hash: ~
+      path: "../target/wasm32-unknown-unknown/release/exchanges.wasm"
+      dependencies:
+        - name: exchanges_integrity


### PR DESCRIPTION
Impl #248

## The exchange record

An exchange is recorded as six append-only entries: Interest, Agreement, Response, Completion, Review and Cancellation. Its state is derived from which of them exist and is never stored. That is the whole model; the design note at `documentation/architecture/EXCHANGE_RECORD.md` sets out the frame check, the entry model, the derived states, the integrity rules, and section 14 makes the case for this landing in alpha.1 rather than waiting on hREA.

This precedes and maps onto the hREA-first design in `documentation/requirements/post-mvp/exchange-process.md`. Each entry has an hREA counterpart (section 9 of the note), so when #90 lands the record migrates rather than being replaced. The crate and DNA wiring, the cross-zome calls and the review shape are lifted from the exchanges zome removed in the bulletin-board pivot (ab462063); the entry model and the derived state are new.

```mermaid
stateDiagram-v2
    direction LR
    [*] --> Proposed : Interest, then Agreement
    Proposed --> Agreed : Response, accepted
    Proposed --> Declined : Response, declined
    Proposed --> Withdrawn : Cancellation
    Agreed --> ProviderDelivered : Completion by provider
    Agreed --> Agreed : Completion by receiver first
    Agreed --> Cancelled : Cancellation
    ProviderDelivered --> Complete : Completion by receiver
    ProviderDelivered --> Cancelled : Cancellation
    Complete --> Reviewed : Review by both
    Declined --> [*]
    Withdrawn --> [*]
    Cancelled --> [*]
    Reviewed --> [*]
```

Every arrow is one append-only entry; no state is stored. Withdrawn and Cancelled are the same `Cancellation` entry, told apart by whether a `Response` exists. Counter is a `Response` declined followed by a new `Agreement` on the same `Interest`. Whose turn it is falls out of the same reading: the counterparty at Proposed, whoever has not completed at Agreed, the receiver at ProviderDelivered, whoever has not reviewed at Complete.

## Reading order

1. `documentation/architecture/EXCHANGE_RECORD.md`, sections 1 to 7, for the model and the rules.
2. `dnas/requests_and_offers/zomes/integrity/exchanges/src/lib.rs`: every op is routed; every referenced hash must be a Create, checked with `must_get_valid_record`; updates and link deletes are refused; an Interest may be deleted by its author and nothing else may.
3. `dnas/requests_and_offers/zomes/coordinator/exchanges/src/exchange.rs`: every client hash resolves to its Create with the propagating variant before any guard reads it; the read model splits completions and reviews by provider and receiver so readers reason in roles.
4. `tests/sweettest/tests/exchanges.rs`: the lifecycle as one story with status read from the other conductor at each step, a decline, a cancellation, and seven refusals, one of them a rating above five refused by validation.
5. The UI, from `ui/src/lib/components/exchanges/ListingInterest.svelte` outward.

## What a member sees

The screens are the design system's exchange flow, ported: My Exchanges with proposals, active and completed; the proposal builder with the listing beside it and the reciprocal driven by the medium of exchange; review proposal with decline, counter and accept; the active exchange with both commitments and the status-driven action bar; the design's review form.

Until messaging carries first contact, registering interest is the knock. On a listing, one button registers interest and opens the author's contact details in the same gesture; it then becomes send a proposal, withdraw interest and view contact information. The listing's author sees who is interested and can send the proposal from their side. That block takes over from `ContactButton` on both listing pages; the component itself is unchanged.

A proposal withdrawn before anyone answers it reads as withdrawn among proposals, not cancelled among active. Counter declines with a note and opens the builder on the same interest, which is what append-only means for a counter.

My Exchanges says whose turn each exchange is, derived from its record at every status; each group counts how many are yours and the page opens on the first with one; within a group there are filters for side, origin and turn, and latest or oldest first.

## Design review

The product owner's comments on the exchange screens in the design system (threads `exchanges`, `exchange-proposal`, `exchange-detail`, `exchange-confirm`, `exchange-review`, `exchange-complete`) are addressed here and in the design system, which was brought level with this build tonight: hours as the unit, who proposed and the counterparty named instead of a second "you", review starting unchecked with room before the comment and no "Later", Discuss before Counter, Decline and Accept, the hREA captions removed, dates on delivery and completion, the proposer's paragraph labelled Proposal and then Agreement. Named for later: reminders (alpha.2 notifications), flagging to stewards (alpha.3), and the listing pages' own labels.

## Tested

- Sweettest: the exchanges binary four of four. Full suite on the final commit: every binary green apart from the two failures `dev` carries and #236 fixes.
- Store unit test, six cases: decoding by role, refetch after write keeping one entry per agreement, list replacement on load, failure landing in `error` with `loading` cleared, review fields reaching the zome unchanged.
- E2E `09-exchanges`: My Exchanges renders its three groups and empty state; a listing's author sees the interested-members form on a listing the spec creates through the zome. Two of two.
- Walked by hand on two agents, on an offer and on a request, so both role assignments: interest, proposal from either side, accept, both completions in either order, both reviews, plus decline, counter and withdraw.

## Found on the way

- #238: the sweettest reads a DNA packed from a second manifest the app does not ship. Both manifests are edited here so the harness runs; the fix belongs in `DNA_PATH`.
- `08-hrea`'s proposals-list guard failed on the first full e2e run here with `HreaError: Attempted to call a zome function that doesn't exist`. The cause was #223: the `hrea.dna` on this machine was a May download of `happ-0.4.0-beta` in the old multi-zome layout, the asset has since been republished under the same tag in the consolidated single-zome layout, and `download-hrea` never refreshes an existing file. With a fresh download the guard passes and the e2e suite is 52 of 52. Nothing in this PR touches hREA; noted on #223 with the two hashes.

## Also fixed on the way, outside the exchange record

These landed on the branch after the review of 9 September and are not exchange work. They are listed here so the release notes do not have to be reconstructed from the commit log.

- **Action timestamps were microseconds, rendered as year 58666.** Five stores (`offers`, `requests`, `organizations`, `serviceTypes`, `users`) wrote the raw Holochain action timestamp into `created_at` and `updated_at`; offers additionally mixed in milliseconds on update. All now convert at construction, the convention `record-helpers.ts` documents and the exchanges store already followed. Listing, profile and admin dates were wrong on `dev` before this.
- **Names and nicknames are labelled** instead of carrying an `@` prefix, and `formatUserName`'s doc example was swapped to match.
- **Anita's review of the propose screen** is applied, alongside the design-system pass described above.
- **The two `exchanges.md` documentation links** now point at `architecture/EXCHANGE_RECORD.md`. They were the only dead links among the nine zome entries. This closes the first box of #251.

## Not in this PR

- Messaging: interest surfaces on the listing until the knock has an inbox to land in.
- Countersigning: same states, same hREA mapping, a fast path for when both are online; the decision sits at #190.
- Stewarding: "disputed" is alpha.3; a low review rating is recorded and nothing opens.
- `PublicationStageControl`'s member-default model, which is a design question for Anita and unrelated to this zome.
