### PR TITLE
feat(administration): two-steward concurrence for indefinite suspension

### DIFF
--- a/dnas/requests_and_offers/zomes/coordinator/administration/src/concurrence.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/administration/src/concurrence.rs
@@ -1,0 +1,306 @@
+use std::str::FromStr;
+
+use administration_integrity::*;
+use chrono::Duration;
+use concurrence::*;
+use hdk::prelude::*;
+use status::*;
+use utils::{
+  errors::{AdministrationError, CommonError},
+  find_original_action_hash, EntityActionHash, EntityAgent, OriginalActionHash,
+  PreviousActionHash,
+};
+
+use crate::administration::{check_if_agent_is_administrator, check_if_entity_is_administrator};
+use crate::permissions::{check_if_agent_has_permission, AgentPermission, PERMISSION_STEWARD};
+use crate::status::{get_latest_status_record_for_entity, UpdateEntityActionHash};
+
+/// Input for putting a motion.
+///
+/// Both subject identities are supplied by the caller, following the convention the
+/// stewarding design sets for flags: whatever renders the control already knows whose
+/// content it is showing, so it passes the identity along with the reference.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MoveInput {
+  pub kind: String,
+  pub entity: String,
+  pub subject_agent: AgentPubKey,
+  pub subject_entity_hash: ActionHash,
+  pub flavour: Option<String>,
+  pub duration_days: Option<i64>,
+  pub reason: String,
+}
+
+/// The single administrative domain. Every caller in this zome passes it.
+const ENTITY_NETWORK: &str = "network";
+
+fn my_pubkey() -> ExternResult<AgentPubKey> {
+  Ok(agent_info()?.agent_initial_pubkey)
+}
+
+/// Refuses any caller who does not hold the steward permission.
+///
+/// Deliberately does not accept an administrator instead. An administrator who stewards
+/// holds the permission explicitly and appears in the public roster.
+fn require_steward() -> ExternResult<()> {
+  if !check_if_agent_has_permission(AgentPermission {
+    permission: PERMISSION_STEWARD.to_string(),
+    agent_pubkey: my_pubkey()?,
+  })? {
+    return Err(AdministrationError::Unauthorized.into());
+  }
+  Ok(())
+}
+
+fn is_admin(agent_pubkey: AgentPubKey) -> ExternResult<bool> {
+  check_if_agent_is_administrator(EntityAgent {
+    entity: ENTITY_NETWORK.to_string(),
+    agent_pubkey,
+  })
+}
+
+/// Refuses a pairing that would let one role act alone against an administrator.
+///
+/// An administrator holds authority over the network itself, so an act against one
+/// requires at least one administrator among the two signatories. Two stewards alone
+/// cannot unseat the people who appointed them; an administrator with a steward can, and
+/// so can two administrators, which is what keeps an administrator answerable to their
+/// peers rather than unassailable.
+///
+/// A network with a single administrator cannot reach them at all, because there is
+/// nobody to pair with. That is a real limit rather than an oversight, and the answer is
+/// a new network rather than a weaker rule.
+///
+/// Neither signatory may be the subject. That rule is unconditional and enforced above,
+/// for motions about members and administrators alike.
+///
+/// The progenitor is out of reach of this or any other in-network act: that key is a DNA
+/// property, so replacing it means a new DNA.
+fn require_pairing_for_subject(
+  motion: &Motion,
+  mover: &AgentPubKey,
+  concurrer: &AgentPubKey,
+) -> ExternResult<()> {
+  // Administrator membership is scoped to the network, not to the entity type whose
+  // status the motion changes. Passing `motion.entity` here would look in
+  // `"users.administrators"`, which is always empty, and the rule would never fire.
+  let subject_is_admin = check_if_entity_is_administrator(EntityActionHash {
+    entity: ENTITY_NETWORK.to_string(),
+    entity_original_action_hash: OriginalActionHash(motion.subject_entity_hash.clone()),
+  })?;
+
+  if !subject_is_admin {
+    return Ok(());
+  }
+
+  let mover_is_admin = is_admin(mover.clone())?;
+  let concurrer_is_admin = is_admin(concurrer.clone())?;
+
+  if !mover_is_admin && !concurrer_is_admin {
+    return Err(CommonError::InvalidData(
+      "a motion about an administrator needs an administrator among its signatories"
+        .to_string(),
+    )
+    .into());
+  }
+
+  Ok(())
+}
+
+fn record_at(hash: ActionHash, what: &str) -> ExternResult<Record> {
+  get(hash, GetOptions::default())?.ok_or_else(|| CommonError::RecordNotFound(what.to_string()).into())
+}
+
+fn motion_at(hash: &ActionHash) -> ExternResult<(Record, Motion)> {
+  let record = record_at(hash.clone(), "motion")?;
+  let motion = record
+    .entry()
+    .to_app_option::<Motion>()
+    .map_err(|_| CommonError::InvalidData("motion".to_string()))?
+    .ok_or_else(|| CommonError::EntryNotFound("motion".to_string()))?;
+  Ok((record, motion))
+}
+
+fn links_from(base: ActionHash, link_type: LinkTypes) -> ExternResult<Vec<Link>> {
+  let filter = link_type
+    .try_into_filter()
+    .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+  get_links(LinkQuery::new(base, filter), GetStrategy::Network)
+}
+
+/// Puts a motion. The caller must hold the steward permission.
+///
+/// Committing a motion changes nobody's status. It is inert until a second steward
+/// concurs, and that holding is the mechanism.
+#[hdk_extern]
+pub fn put_motion(input: MoveInput) -> ExternResult<Record> {
+  require_steward()?;
+
+  if input.subject_agent == my_pubkey()? {
+    return Err(
+      CommonError::InvalidData("you cannot put a motion about yourself".to_string()).into(),
+    );
+  }
+
+  let subject = find_original_action_hash(input.subject_entity_hash)?;
+
+  let motion = Motion {
+    kind: input.kind,
+    entity: input.entity,
+    subject_agent: input.subject_agent,
+    subject_entity_hash: subject.0.clone(),
+    flavour: input.flavour,
+    duration_days: input.duration_days,
+    reason: input.reason,
+  };
+
+  let hash = create_entry(&EntryTypes::Motion(motion))?;
+  create_link(subject.0, hash.clone(), LinkTypes::SubjectMotions, ())?;
+  record_at(hash, "motion")
+}
+
+/// Concurs with a motion, which is what makes it take effect.
+///
+/// The caller must hold the steward permission, must not be the motion's author, and the
+/// motion must not already carry a concurrence.
+///
+/// All writes in a zome call commit to the source chain together, so if the status
+/// transition fails the concurrence is not recorded either. That is what keeps the two
+/// halves of the act from separating.
+#[hdk_extern]
+pub fn concur(motion_hash: ActionHash) -> ExternResult<Record> {
+  require_steward()?;
+
+  let motion_hash = find_original_action_hash(motion_hash)?.0;
+  let (motion_record, motion) = motion_at(&motion_hash)?;
+
+  let me = my_pubkey()?;
+
+  if motion_record.action().author() == &me {
+    return Err(
+      CommonError::InvalidData("you cannot concur with your own motion".to_string()).into(),
+    );
+  }
+
+  // A steward who is a party to the act may neither move it nor carry it. Plural
+  // authority means two people, and neither of them the person it bears on.
+  if motion.subject_agent == me {
+    return Err(
+      CommonError::InvalidData("you cannot concur with a motion about yourself".to_string())
+        .into(),
+    );
+  }
+
+  require_pairing_for_subject(&motion, motion_record.action().author(), &me)?;
+
+  if !links_from(motion_hash.clone(), LinkTypes::MotionConcurrences)?.is_empty() {
+    return Err(
+      CommonError::InvalidData("this motion already has a concurrence".to_string()).into(),
+    );
+  }
+
+  let hash = create_entry(&EntryTypes::Concurrence(Concurrence {
+    motion: motion_hash.clone(),
+  }))?;
+  create_link(
+    motion_hash,
+    hash.clone(),
+    LinkTypes::MotionConcurrences,
+    (),
+  )?;
+
+  apply(&motion)?;
+
+  record_at(hash, "concurrence")
+}
+
+/// Applies a concurred motion.
+///
+/// Calls `update_entity_status` directly rather than the `suspend_entity_*` wrappers,
+/// because those end in `Ok(update_entity_status(...).is_ok())` and collapse an
+/// authorisation failure, a missing status and a transient network read into the same
+/// `false`. A steward needs to know which of those happened.
+///
+/// A closure motion has no effect yet: the case entry it would close is not built.
+fn apply(motion: &Motion) -> ExternResult<()> {
+  let kind = MotionKind::from_str(&motion.kind)
+    .map_err(|e| wasm_error!(WasmErrorInner::Guest(e)))?;
+
+  if kind == MotionKind::Closure {
+    return Ok(());
+  }
+
+  let entity_input = EntityActionHash {
+    entity: motion.entity.clone(),
+    entity_original_action_hash: OriginalActionHash(motion.subject_entity_hash.clone()),
+  };
+
+  let latest = get_latest_status_record_for_entity(entity_input)?
+    .ok_or_else(|| CommonError::RecordNotFound("status".to_string()))?;
+  let previous = latest.action_address().clone();
+  let original = find_original_action_hash(previous.clone())?;
+
+  let flavour = motion
+    .flavour
+    .as_deref()
+    .ok_or_else(|| CommonError::InvalidData("suspension flavour".to_string()))
+    .and_then(|f| {
+      SuspensionFlavour::from_str(f).map_err(|_| CommonError::InvalidData("suspension flavour".to_string()))
+    })?;
+
+  let new_status = match flavour {
+    SuspensionFlavour::Indefinite => Status::suspend(motion.reason.as_str(), None),
+    SuspensionFlavour::Temporary => {
+      let days = motion
+        .duration_days
+        .ok_or_else(|| CommonError::InvalidData("suspension duration".to_string()))?;
+      let now = &sys_time()?;
+      Status::suspend(motion.reason.as_str(), Some((Duration::days(days), now)))
+    }
+  };
+
+  crate::status::update_entity_status(UpdateEntityActionHash {
+    entity: motion.entity.clone(),
+    entity_original_action_hash: OriginalActionHash(motion.subject_entity_hash.clone()),
+    status_original_action_hash: original,
+    status_previous_action_hash: PreviousActionHash(previous),
+    new_status,
+  })?;
+
+  Ok(())
+}
+
+/// Returns every motion put against the given subject.
+#[hdk_extern]
+pub fn get_motions_for_subject(subject: ActionHash) -> ExternResult<Vec<Record>> {
+  let subject = find_original_action_hash(subject)?;
+  let links = links_from(subject.0, LinkTypes::SubjectMotions)?;
+
+  links
+    .into_iter()
+    .filter_map(|link| link.target.into_action_hash())
+    .map(|hash| record_at(hash, "motion"))
+    .collect()
+}
+
+/// Returns the concurrence for a motion, if it has one.
+///
+/// A motion carrying no concurrence is still pending. The state is derived from the
+/// records rather than stored on the motion, so nothing has to be kept in step.
+#[hdk_extern]
+pub fn get_concurrence_for_motion(motion_hash: ActionHash) -> ExternResult<Option<Record>> {
+  let motion_hash = find_original_action_hash(motion_hash)?.0;
+  let links = links_from(motion_hash, LinkTypes::MotionConcurrences)?;
+
+  match links.first() {
+    None => Ok(None),
+    Some(link) => {
+      let hash = link
+        .target
+        .clone()
+        .into_action_hash()
+        .ok_or_else(|| CommonError::ActionHashNotFound("concurrence".to_string()))?;
+      Ok(Some(record_at(hash, "concurrence")?))
+    }
+  }
+}

--- a/dnas/requests_and_offers/zomes/coordinator/administration/src/lib.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/administration/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod administration;
+pub mod concurrence;
 pub mod permissions;
 pub mod status;
 

--- a/dnas/requests_and_offers/zomes/coordinator/administration/src/lib.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/administration/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod administration;
+pub mod permissions;
 pub mod status;
 
 use administration_integrity::*;

--- a/dnas/requests_and_offers/zomes/coordinator/administration/src/permissions.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/administration/src/permissions.rs
@@ -1,0 +1,153 @@
+use administration_integrity::*;
+use hdk::prelude::*;
+use utils::{
+  errors::AdministrationError,
+  EntityAgent, OriginalActionHash,
+};
+
+use crate::administration::check_if_agent_is_administrator;
+
+/// The steward permission: supporting members, handling flags, and acting on cases.
+/// Distinct from administration, which configures and deploys the network.
+pub const PERMISSION_STEWARD: &str = "steward";
+
+/// Input for granting or revoking a named permission.
+///
+/// Mirrors `EntityActionHashAgents`: the holder is identified by both their user entity
+/// (for the roster index) and their agent key (for the membership query), because the
+/// two link directions have different bases.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PermissionActionHashAgents {
+  pub permission: String,
+  pub holder_original_action_hash: OriginalActionHash,
+  pub agent_pubkeys: Vec<AgentPubKey>,
+}
+
+/// Input for querying whether an agent holds a named permission.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AgentPermission {
+  pub permission: String,
+  pub agent_pubkey: AgentPubKey,
+}
+
+/// Returns the path entry hash for a named permission.
+fn permission_path_hash(permission: &str) -> ExternResult<EntryHash> {
+  Path::from(format!("permission.{}", permission)).path_entry_hash()
+}
+
+/// Returns every `AllPermissionHolders` link anchored to the `"permission.{name}"` path.
+///
+/// Each link target is the original action hash of a holder's user entity. This is the
+/// public roster query: the steward role is deliberately visible.
+#[hdk_extern]
+pub fn get_all_permission_holders_links(permission: String) -> ExternResult<Vec<Link>> {
+  let path_hash = permission_path_hash(&permission)?;
+  let link_type_filter = LinkTypes::AllPermissionHolders
+    .try_into_filter()
+    .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+  let links = get_links(
+    LinkQuery::new(path_hash, link_type_filter),
+    GetStrategy::Network,
+  )?;
+  Ok(links)
+}
+
+/// Grants a named permission to one or more agents.
+///
+/// The caller must be an administrator. Granting is a single-signature act: the authority
+/// gradient belongs on irreversible acts, not on role membership, and a grant is reversible
+/// by [`revoke_permission`].
+#[hdk_extern]
+pub fn grant_permission(input: PermissionActionHashAgents) -> ExternResult<bool> {
+  if !check_if_agent_is_administrator(EntityAgent {
+    entity: "network".to_string(),
+    agent_pubkey: agent_info()?.agent_initial_pubkey,
+  })? {
+    return Err(AdministrationError::Unauthorized.into());
+  }
+
+  let path_hash = permission_path_hash(&input.permission)?;
+
+  create_link(
+    path_hash.clone(),
+    input.holder_original_action_hash.0.clone(),
+    LinkTypes::AllPermissionHolders,
+    (),
+  )?;
+
+  for agent_pubkey in input.agent_pubkeys {
+    create_link(
+      agent_pubkey,
+      path_hash.clone(),
+      LinkTypes::AgentPermissions,
+      (),
+    )?;
+  }
+
+  Ok(true)
+}
+
+/// Revokes a named permission from one or more agents.
+///
+/// The caller must be an administrator. There is no last-holder guard: a network may hold
+/// zero stewards. The plural acts that require two stewards simply become impossible, since
+/// there is nobody to concur.
+#[hdk_extern]
+pub fn revoke_permission(input: PermissionActionHashAgents) -> ExternResult<bool> {
+  if !check_if_agent_is_administrator(EntityAgent {
+    entity: "network".to_string(),
+    agent_pubkey: agent_info()?.agent_initial_pubkey,
+  })? {
+    return Err(AdministrationError::Unauthorized.into());
+  }
+
+  let path_hash = permission_path_hash(&input.permission)?;
+
+  let holder_links = get_all_permission_holders_links(input.permission.clone())?;
+  for link in holder_links
+    .iter()
+    .filter(|link| link.target == input.holder_original_action_hash.0.clone().into())
+  {
+    delete_link(link.create_link_hash.clone(), GetOptions::default())?;
+  }
+
+  for agent_pubkey in input.agent_pubkeys {
+    let link_type_filter = LinkTypes::AgentPermissions
+      .try_into_filter()
+      .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+    let links = get_links(
+      LinkQuery::new(agent_pubkey, link_type_filter),
+      GetStrategy::Network,
+    )?;
+
+    for link in links
+      .iter()
+      .filter(|link| link.target == path_hash.clone().into())
+    {
+      delete_link(link.create_link_hash.clone(), GetOptions::default())?;
+    }
+  }
+
+  Ok(true)
+}
+
+/// Returns `true` if the agent holds the named permission.
+///
+/// Queries from the agent public key as the link base, which avoids loading the full holder
+/// list. Does not fall back to the administrator check: an administrator who stewards holds
+/// the permission explicitly and appears in the public roster, because authority nobody can
+/// identify is authority nobody can question.
+#[hdk_extern]
+pub fn check_if_agent_has_permission(input: AgentPermission) -> ExternResult<bool> {
+  let path_hash = permission_path_hash(&input.permission)?;
+
+  let link_type_filter = LinkTypes::AgentPermissions
+    .try_into_filter()
+    .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+  let links = get_links(
+    LinkQuery::new(input.agent_pubkey, link_type_filter),
+    GetStrategy::Network,
+  )?;
+
+  Ok(links.iter().any(|link| link.target == path_hash.clone().into()))
+}

--- a/dnas/requests_and_offers/zomes/coordinator/administration/src/status.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/administration/src/status.rs
@@ -315,10 +315,25 @@ pub struct UpdateEntityActionHash {
 /// if `input.new_status.status_type == "accepted"`.
 #[hdk_extern]
 pub fn update_entity_status(input: UpdateEntityActionHash) -> ExternResult<Record> {
-  if !check_if_agent_is_administrator(EntityAgent {
-    agent_pubkey: agent_info()?.agent_initial_pubkey.clone(),
+  let caller = agent_info()?.agent_initial_pubkey;
+
+  let is_admin = check_if_agent_is_administrator(EntityAgent {
+    agent_pubkey: caller.clone(),
     entity: input.entity.clone(),
-  })? {
+  })?;
+
+  // Stewards may change a member's status because suspension is a stewarding act, not an
+  // administrative one. Administration configures the network; stewarding supports the
+  // people in it. Without this a concurred suspension would record its decision and then
+  // fail to apply it.
+  let is_steward = crate::permissions::check_if_agent_has_permission(
+    crate::permissions::AgentPermission {
+      permission: crate::permissions::PERMISSION_STEWARD.to_string(),
+      agent_pubkey: caller,
+    },
+  )?;
+
+  if !is_admin && !is_steward {
     return Err(AdministrationError::Unauthorized.into());
   }
 

--- a/dnas/requests_and_offers/zomes/integrity/administration/src/concurrence.rs
+++ b/dnas/requests_and_offers/zomes/integrity/administration/src/concurrence.rs
@@ -1,0 +1,205 @@
+use std::str::FromStr;
+
+use hdi::prelude::*;
+
+/// Canonical set of motion kinds used to validate `Motion.kind` strings.
+///
+/// Stored as a plain `String` on the entry for schema stability, following the same
+/// convention as `StatusType`; this enum is used only for parsing and validation.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum MotionKind {
+  Suspension,
+  Closure,
+}
+
+impl FromStr for MotionKind {
+  type Err = String;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s {
+      "suspension" => Ok(Self::Suspension),
+      "closure" => Ok(Self::Closure),
+      _ => Err(format!("Invalid motion kind: {}", s)),
+    }
+  }
+}
+
+/// The two shapes a suspension can take. Temporary carries a length; indefinite does not,
+/// because re-admission is a separate process rather than a countdown.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum SuspensionFlavour {
+  Temporary,
+  Indefinite,
+}
+
+impl FromStr for SuspensionFlavour {
+  type Err = String;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s {
+      "temporary" => Ok(Self::Temporary),
+      "indefinite" => Ok(Self::Indefinite),
+      _ => Err(format!("Invalid suspension flavour: {}", s)),
+    }
+  }
+}
+
+/// An HDK entry representing an act put forward for a second signatory to concur with
+/// before it takes effect.
+///
+/// Named `Motion` rather than `Proposal` because that word is taken three times over in
+/// this codebase: the exchange record, hREA's ValueFlows types, and the design system's
+/// member-facing labels. The stewarding design calls it a proposal in prose; the same
+/// deconfliction the membrane design applied to capability and warrant applies here.
+///
+/// A motion is inert. Committing one changes nobody's status; it holds the intent
+/// awaiting a concurrence, and that holding is the mechanism.
+///
+/// It carries the intent rather than a built `Status`, because the concurring signatory
+/// is agreeing to a specific length, and the clock starts at concurrence rather than when
+/// the motion was made.
+///
+/// The subject is carried as **both** identities, following the same convention the
+/// stewarding design sets for flags. `subject_agent` is the peer identity: stewarding
+/// keys on `AgentPubKey` because names are editable and not unique, and the rule that a
+/// steward may not act on a case they are party to is a comparison against it.
+/// `subject_entity_hash` is the entity reference the status functions take. They serve
+/// two different layers rather than storing one fact twice.
+///
+/// ## Fields
+/// - `kind` - one of the canonical strings defined in [`MotionKind`].
+/// - `entity` - the entity scope the subject belongs to, e.g. `"users"`.
+/// - `subject_agent` - the peer the act bears on.
+/// - `subject_entity_hash` - the original action hash of that peer's entity.
+/// - `flavour` - required for `"suspension"`; `None` for `"closure"`.
+/// - `duration_days` - required for a temporary suspension; `None` otherwise.
+/// - `reason` - required, and carried onto the resulting `Status`.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct Motion {
+  pub kind: String,
+  pub entity: String,
+  pub subject_agent: AgentPubKey,
+  pub subject_entity_hash: ActionHash,
+  pub flavour: Option<String>,
+  pub duration_days: Option<i64>,
+  pub reason: String,
+}
+
+/// An HDK entry recording that a second signatory agreed to a motion.
+///
+/// The signatory is the entry's author, taken from the action header rather than stored
+/// in the entry. The rule that the moving signatory may not concur cannot be enforced
+/// here, because reading the motion's author is a DHT read and validation callbacks
+/// cannot perform one; the coordinator holds that guard.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct Concurrence {
+  pub motion: ActionHash,
+}
+
+/// Validates that a `Motion` entry conforms to the zome's business rules.
+///
+/// Enforces seven rules:
+/// 1. `kind` must match a known [`MotionKind`] discriminant string.
+/// 2. `entity` and `reason` must not be empty.
+/// 3. A suspension must carry a `flavour`; a closure must not.
+/// 4. Any `flavour` must match a known [`SuspensionFlavour`] discriminant string.
+/// 5. A temporary suspension must carry a positive `duration_days`.
+/// 6. An indefinite suspension must not carry `duration_days`.
+/// 7. A closure must carry neither.
+///
+/// The preset lengths named in the stewarding design are deliberately not enforced here.
+/// They are a fairness norm the community may revise, and baking them into the integrity
+/// zome would make changing them a DNA change.
+pub fn validate_motion(motion: Motion) -> ExternResult<ValidateCallbackResult> {
+  let kind = match MotionKind::from_str(&motion.kind) {
+    Ok(kind) => kind,
+    Err(_) => {
+      return Ok(ValidateCallbackResult::Invalid(format!(
+        "Invalid motion kind: {}",
+        motion.kind
+      )))
+    }
+  };
+
+  if motion.entity.trim().is_empty() {
+    return Ok(ValidateCallbackResult::Invalid(String::from(
+      "Motion must name an entity scope",
+    )));
+  }
+
+  if motion.reason.trim().is_empty() {
+    return Ok(ValidateCallbackResult::Invalid(String::from(
+      "Motion must have a reason",
+    )));
+  }
+
+  match kind {
+    MotionKind::Closure => {
+      if motion.flavour.is_some() {
+        return Ok(ValidateCallbackResult::Invalid(String::from(
+          "Closure motion must not have a suspension flavour",
+        )));
+      }
+      if motion.duration_days.is_some() {
+        return Ok(ValidateCallbackResult::Invalid(String::from(
+          "Closure motion must not have a duration",
+        )));
+      }
+    }
+    MotionKind::Suspension => {
+      let flavour = match &motion.flavour {
+        None => {
+          return Ok(ValidateCallbackResult::Invalid(String::from(
+            "Suspension motion must have a flavour",
+          )))
+        }
+        Some(flavour) => match SuspensionFlavour::from_str(flavour) {
+          Ok(flavour) => flavour,
+          Err(_) => {
+            return Ok(ValidateCallbackResult::Invalid(format!(
+              "Invalid suspension flavour: {}",
+              flavour
+            )))
+          }
+        },
+      };
+
+      match flavour {
+        SuspensionFlavour::Temporary => match motion.duration_days {
+          None => {
+            return Ok(ValidateCallbackResult::Invalid(String::from(
+              "Temporary suspension motion must have a duration",
+            )))
+          }
+          Some(days) if days < 1 => {
+            return Ok(ValidateCallbackResult::Invalid(String::from(
+              "Temporary suspension duration must be at least one day",
+            )))
+          }
+          Some(_) => (),
+        },
+        SuspensionFlavour::Indefinite => {
+          if motion.duration_days.is_some() {
+            return Ok(ValidateCallbackResult::Invalid(String::from(
+              "Indefinite suspension motion must not have a duration",
+            )));
+          }
+        }
+      }
+    }
+  }
+
+  Ok(ValidateCallbackResult::Valid)
+}
+
+/// Validates a `Concurrence` entry.
+///
+/// The entry carries only a pointer, so there is nothing checkable from it alone. The
+/// substantive rules - that the author is not the mover, that the motion exists, and that
+/// it has not already been concurred with - all require DHT reads and are enforced by the
+/// coordinator.
+pub fn validate_concurrence(_concurrence: Concurrence) -> ExternResult<ValidateCallbackResult> {
+  Ok(ValidateCallbackResult::Valid)
+}

--- a/dnas/requests_and_offers/zomes/integrity/administration/src/lib.rs
+++ b/dnas/requests_and_offers/zomes/integrity/administration/src/lib.rs
@@ -1,6 +1,8 @@
 use hdi::prelude::*;
+use concurrence::*;
 use status::*;
 
+pub mod concurrence;
 pub mod status;
 mod tests;
 
@@ -15,6 +17,12 @@ mod tests;
 pub enum EntryTypes {
   /// A moderation/lifecycle status entry for a network entity.
   Status(Status),
+
+  /// An act put forward for a second signatory. Inert until concurred with.
+  Motion(Motion),
+
+  /// A second signatory's agreement to a motion.
+  Concurrence(Concurrence),
 }
 
 /// Registry of all link types defined in this integrity zome.
@@ -58,6 +66,13 @@ pub enum LinkTypes {
   /// Index link from an agent's public key to a `"permission.{name}"` path entry hash.
   /// Enables the membership query: "does this agent hold this named permission?"
   AgentPermissions,
+
+  /// Index link from a subject's original action hash to a motion put against it.
+  SubjectMotions,
+
+  /// Index link from a motion's action hash to the concurrence that carried it.
+  /// A motion with no such link is still pending; the state derives from the records.
+  MotionConcurrences,
 }
 
 #[hdk_extern]
@@ -160,9 +175,13 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
     FlatOp::StoreEntry(store_entry) => match store_entry {
       OpEntry::CreateEntry { app_entry, .. } => match app_entry {
         EntryTypes::Status(status) => validate_status(status),
+        EntryTypes::Motion(motion) => validate_motion(motion),
+        EntryTypes::Concurrence(concurrence) => validate_concurrence(concurrence),
       },
       OpEntry::UpdateEntry { app_entry, .. } => match app_entry {
         EntryTypes::Status(status) => validate_status(status),
+        EntryTypes::Motion(motion) => validate_motion(motion),
+        EntryTypes::Concurrence(concurrence) => validate_concurrence(concurrence),
       },
       _ => Ok(ValidateCallbackResult::Valid),
     },

--- a/dnas/requests_and_offers/zomes/integrity/administration/src/lib.rs
+++ b/dnas/requests_and_offers/zomes/integrity/administration/src/lib.rs
@@ -47,6 +47,17 @@ pub enum LinkTypes {
   /// Index link from the `"{entity}.status.accepted"` path entry hash to an entity's original
   /// action hash. Enables listing all currently accepted entities of a given type.
   AcceptedEntity,
+
+  // New variants are appended, never inserted. Link type discriminants are positional,
+  // so inserting one renumbers every variant after it and orphans existing links.
+  /// Index link from a `"permission.{name}"` path entry hash to an agent's public key.
+  /// Enables listing every holder of a named permission, which the public steward
+  /// roster is rendered from.
+  AllPermissionHolders,
+
+  /// Index link from an agent's public key to a `"permission.{name}"` path entry hash.
+  /// Enables the membership query: "does this agent hold this named permission?"
+  AgentPermissions,
 }
 
 #[hdk_extern]

--- a/tests/sweettest/Cargo.toml
+++ b/tests/sweettest/Cargo.toml
@@ -40,6 +40,10 @@ name = "administration_progenitor"
 path = "tests/administration/progenitor.rs"
 
 [[test]]
+name = "administration_concurrence"
+path = "tests/administration/concurrence.rs"
+
+[[test]]
 name = "administration_permission_management"
 path = "tests/administration/permission_management.rs"
 

--- a/tests/sweettest/Cargo.toml
+++ b/tests/sweettest/Cargo.toml
@@ -40,6 +40,10 @@ name = "administration_progenitor"
 path = "tests/administration/progenitor.rs"
 
 [[test]]
+name = "administration_permission_management"
+path = "tests/administration/permission_management.rs"
+
+[[test]]
 name = "administration_status_management"
 path = "tests/administration/status_management.rs"
 

--- a/tests/sweettest/src/common/conductors.rs
+++ b/tests/sweettest/src/common/conductors.rs
@@ -192,6 +192,58 @@ pub async fn accept_entity(
         .await;
 }
 
+/// Spin up four conductors where Alice's `AgentPubKey` is embedded as the
+/// progenitor in the DNA properties.
+///
+/// Use this for tests of an act requiring two distinct signatories, neither of
+/// whom may be the person it bears on, plus someone holding neither role.
+///
+/// Returns `(conductors, cell_alice, cell_bob, cell_carol, cell_dave)`.
+pub async fn setup_four_agents_with_alice_as_progenitor() -> (
+    SweetConductorBatch,
+    SweetCell,
+    SweetCell,
+    SweetCell,
+    SweetCell,
+) {
+    let mut conductors =
+        SweetConductorBatch::from_config_rendezvous(4, SweetConductorConfig::standard()).await;
+
+    let alice_key = SweetAgents::one(conductors[0].keystore()).await;
+    let alice_key_str = alice_key.to_string();
+
+    let dna = build_dna(alice_key_str).await;
+
+    let alice_app = conductors[0]
+        .setup_app_for_agent("requests_and_offers", alice_key, &[dna.clone()])
+        .await
+        .expect("Failed to install app for Alice");
+
+    let bob_app = conductors[1]
+        .setup_app("requests_and_offers", &[dna.clone()])
+        .await
+        .expect("Failed to install app for Bob");
+
+    let carol_app = conductors[2]
+        .setup_app("requests_and_offers", &[dna.clone()])
+        .await
+        .expect("Failed to install app for Carol");
+
+    let dave_app = conductors[3]
+        .setup_app("requests_and_offers", &[dna])
+        .await
+        .expect("Failed to install app for Dave");
+
+    conductors.exchange_peer_info().await;
+
+    let (cell_alice,) = alice_app.into_tuple();
+    let (cell_bob,) = bob_app.into_tuple();
+    let (cell_carol,) = carol_app.into_tuple();
+    let (cell_dave,) = dave_app.into_tuple();
+
+    (conductors, cell_alice, cell_bob, cell_carol, cell_dave)
+}
+
 /// Spin up two conductors where Alice's `AgentPubKey` is embedded as the
 /// progenitor in the DNA properties.
 ///

--- a/tests/sweettest/tests/administration/concurrence.rs
+++ b/tests/sweettest/tests/administration/concurrence.rs
@@ -1,0 +1,507 @@
+//! Concurrence tests.
+//!
+//! Covers the inert motion, the refusals that make plural authority mean two people,
+//! the status transition a concurrence carries, and the constrained pairing required
+//! when the subject is an administrator.
+
+use holochain::prelude::*;
+use holochain::sweettest::*;
+use requests_and_offers_sweettest::common::*;
+
+const PERMISSION_STEWARD: &str = "steward";
+
+/// Creates a user for each agent and returns their user action hashes.
+async fn create_users(
+    conductors: &SweetConductorBatch,
+    cells: [&SweetCell; 4],
+    names: [&str; 4],
+) -> Vec<ActionHash> {
+    for (i, cell) in cells.iter().enumerate() {
+        let _: Record = conductors[i]
+            .call(
+                &cell.zome("users_organizations"),
+                "create_user",
+                sample_user(names[i]),
+            )
+            .await;
+    }
+
+    await_consistency_s(20, cells).await.unwrap();
+
+    let mut hashes = Vec::new();
+    for (i, cell) in cells.iter().enumerate() {
+        let links: Vec<Link> = conductors[i]
+            .call(
+                &cell.zome("users_organizations"),
+                "get_agent_user",
+                cell.agent_pubkey().clone(),
+            )
+            .await;
+        hashes.push(links[0].target.clone().into_action_hash().unwrap());
+    }
+    hashes
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn two_stewards_carry_a_suspension() {
+    let (conductors, alice, bob, carol, dave) =
+        setup_four_agents_with_alice_as_progenitor().await;
+
+    let hashes = create_users(
+        &conductors,
+        [&alice, &bob, &carol, &dave],
+        ["Alice", "Bob", "Carol", "Dave"],
+    )
+    .await;
+    let (alice_user, bob_user, dave_user) =
+        (hashes[0].clone(), hashes[1].clone(), hashes[3].clone());
+
+    // Alice becomes network administrator.
+    let _: bool = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "add_administrator",
+            EntityActionHashAgents {
+                entity: ENTITY_NETWORK.to_string(),
+                entity_original_action_hash: alice_user.clone(),
+                agent_pubkeys: vec![alice.agent_pubkey().clone()],
+            },
+        )
+        .await;
+
+    // Members must be accepted before there is anything to suspend.
+    for hash in [&hashes[1], &hashes[2], &hashes[3]] {
+        accept_entity(&conductors[0], &alice, ENTITY_USERS, hash.clone()).await;
+    }
+
+    await_consistency_s(20, [&alice, &bob, &carol, &dave])
+        .await
+        .unwrap();
+
+    // Bob and Carol become stewards.
+    for (hash, cell) in [(&hashes[1], &bob), (&hashes[2], &carol)] {
+        let _: bool = conductors[0]
+            .call(
+                &alice.zome("administration"),
+                "grant_permission",
+                serde_json::json!({
+                    "permission": PERMISSION_STEWARD,
+                    "holder_original_action_hash": hash,
+                    "agent_pubkeys": [cell.agent_pubkey()]
+                }),
+            )
+            .await;
+    }
+
+    await_consistency_s(20, [&alice, &bob, &carol, &dave])
+        .await
+        .unwrap();
+
+    let motion_input = serde_json::json!({
+        "kind": "suspension",
+        "entity": ENTITY_USERS,
+        "subject_agent": dave.agent_pubkey(),
+        "subject_entity_hash": dave_user,
+        "flavour": "temporary",
+        "duration_days": 30,
+        "reason": "Repeated commercial solicitation after a guidance finding"
+    });
+
+    // Dave holds no permission, so he cannot put a motion at all.
+    let dave_motion = conductors[3]
+        .call_fallible::<_, Record>(
+            &dave.zome("administration"),
+            "put_motion",
+            motion_input.clone(),
+        )
+        .await;
+    assert!(dave_motion.is_err(), "A non-steward should not put a motion");
+
+    // Bob moves the suspension.
+    let motion: Record = conductors[1]
+        .call(&bob.zome("administration"), "put_motion", motion_input)
+        .await;
+    let motion_hash = motion.signed_action.hashed.hash.clone();
+
+    await_consistency_s(20, [&alice, &bob, &carol, &dave])
+        .await
+        .unwrap();
+
+    // The motion is inert: Dave is still accepted, and nothing carries it yet.
+    let dave_status: Option<Status> = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "get_latest_status_for_entity",
+            serde_json::json!({
+                "entity": ENTITY_USERS,
+                "entity_original_action_hash": dave_user
+            }),
+        )
+        .await;
+    assert_eq!(
+        dave_status.unwrap().status_type,
+        "accepted",
+        "A motion alone should not change anyone's status"
+    );
+
+    let pending: Option<Record> = conductors[2]
+        .call(
+            &carol.zome("administration"),
+            "get_concurrence_for_motion",
+            motion_hash.clone(),
+        )
+        .await;
+    assert!(pending.is_none(), "The motion should be awaiting a second steward");
+
+    // Bob cannot carry his own motion.
+    let self_concur = conductors[1]
+        .call_fallible::<_, Record>(
+            &bob.zome("administration"),
+            "concur",
+            motion_hash.clone(),
+        )
+        .await;
+    assert!(
+        self_concur.is_err(),
+        "The moving steward should not be the concurring one"
+    );
+
+    // Alice administers but does not steward, so she cannot concur either.
+    let admin_concur = conductors[0]
+        .call_fallible::<_, Record>(
+            &alice.zome("administration"),
+            "concur",
+            motion_hash.clone(),
+        )
+        .await;
+    assert!(
+        admin_concur.is_err(),
+        "An administrator without the steward permission should not concur"
+    );
+
+    // Dave is the subject, and in any case holds no permission.
+    let subject_concur = conductors[3]
+        .call_fallible::<_, Record>(
+            &dave.zome("administration"),
+            "concur",
+            motion_hash.clone(),
+        )
+        .await;
+    assert!(subject_concur.is_err(), "The subject should not concur");
+
+    // Carol carries it.
+    let _: Record = conductors[2]
+        .call(&carol.zome("administration"), "concur", motion_hash.clone())
+        .await;
+
+    await_consistency_s(20, [&alice, &bob, &carol, &dave])
+        .await
+        .unwrap();
+
+    // The suspension is applied, read from a third conductor.
+    let dave_after: Option<Status> = conductors[1]
+        .call(
+            &bob.zome("administration"),
+            "get_latest_status_for_entity",
+            serde_json::json!({
+                "entity": ENTITY_USERS,
+                "entity_original_action_hash": dave_user
+            }),
+        )
+        .await;
+    let dave_after = dave_after.expect("Dave should have a status");
+    assert_eq!(
+        dave_after.status_type, "suspended temporarily",
+        "The concurrence should carry the suspension"
+    );
+    assert!(
+        dave_after.suspended_until.is_some(),
+        "A temporary suspension computes its end date at concurrence"
+    );
+
+    // A second concurrence is refused, so the act cannot be applied twice.
+    let second = conductors[1]
+        .call_fallible::<_, Record>(&bob.zome("administration"), "concur", motion_hash)
+        .await;
+    assert!(
+        second.is_err(),
+        "A motion should carry only one concurrence"
+    );
+
+    // Bob and Carol are two stewards, so a motion about a member needed no administrator.
+    let _ = (bob_user,);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_motion_about_an_administrator_needs_an_administrator() {
+    let (conductors, alice, bob, carol, dave) =
+        setup_four_agents_with_alice_as_progenitor().await;
+
+    let hashes = create_users(
+        &conductors,
+        [&alice, &bob, &carol, &dave],
+        ["Alice", "Bob", "Carol", "Dave"],
+    )
+    .await;
+    let (alice_user, dave_user) = (hashes[0].clone(), hashes[3].clone());
+
+    // Alice becomes administrator first so she can accept the others.
+    let _: bool = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "add_administrator",
+            EntityActionHashAgents {
+                entity: ENTITY_NETWORK.to_string(),
+                entity_original_action_hash: alice_user.clone(),
+                agent_pubkeys: vec![alice.agent_pubkey().clone()],
+            },
+        )
+        .await;
+
+    for hash in [&hashes[1], &hashes[2], &hashes[3]] {
+        accept_entity(&conductors[0], &alice, ENTITY_USERS, hash.clone()).await;
+    }
+
+    await_consistency_s(20, [&alice, &bob, &carol, &dave])
+        .await
+        .unwrap();
+
+    // Dave is an administrator too; Bob and Carol are stewards.
+    for (hash, cell) in [(&hashes[3], &dave)] {
+        let _: bool = conductors[0]
+            .call(
+                &alice.zome("administration"),
+                "add_administrator",
+                EntityActionHashAgents {
+                    entity: ENTITY_NETWORK.to_string(),
+                    entity_original_action_hash: hash.clone(),
+                    agent_pubkeys: vec![cell.agent_pubkey().clone()],
+                },
+            )
+            .await;
+    }
+
+    for (hash, cell) in [(&hashes[1], &bob), (&hashes[2], &carol)] {
+        let _: bool = conductors[0]
+            .call(
+                &alice.zome("administration"),
+                "grant_permission",
+                serde_json::json!({
+                    "permission": PERMISSION_STEWARD,
+                    "holder_original_action_hash": hash,
+                    "agent_pubkeys": [cell.agent_pubkey()]
+                }),
+            )
+            .await;
+    }
+
+    // Alice also stewards, so she can move and concur in her own right.
+    let _: bool = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "grant_permission",
+            serde_json::json!({
+                "permission": PERMISSION_STEWARD,
+                "holder_original_action_hash": alice_user,
+                "agent_pubkeys": [alice.agent_pubkey()]
+            }),
+        )
+        .await;
+
+    await_consistency_s(20, [&alice, &bob, &carol, &dave])
+        .await
+        .unwrap();
+
+    // Dave's status original, fixed for the life of the chain; the previous hash
+    // rotates with every update but this does not.
+    let dave_status_record: Option<Record> = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "get_latest_status_record_for_entity",
+            serde_json::json!({
+                "entity": ENTITY_USERS,
+                "entity_original_action_hash": dave_user
+            }),
+        )
+        .await;
+    let dave_status_original = dave_status_record
+        .expect("Dave should have a status")
+        .signed_action
+        .hashed
+        .hash
+        .clone();
+
+    // The pairing rule turns on this being true. Assert it directly rather than
+    // inferring it from the rule's behaviour.
+    let dave_is_admin: bool = conductors[1]
+        .call(
+            &bob.zome("administration"),
+            "check_if_entity_is_administrator",
+            serde_json::json!({
+                "entity": ENTITY_NETWORK,
+                "entity_original_action_hash": dave_user
+            }),
+        )
+        .await;
+    assert!(dave_is_admin, "Dave should be an administrator");
+
+    let motion_input = serde_json::json!({
+        "kind": "suspension",
+        "entity": ENTITY_USERS,
+        "subject_agent": dave.agent_pubkey(),
+        "subject_entity_hash": dave_user,
+        "flavour": "indefinite",
+        "duration_days": serde_json::Value::Null,
+        "reason": "Administrative authority used against the community agreement"
+    });
+
+    // Bob moves it. Carol is the other steward, so two stewards alone cannot carry it.
+    let motion: Record = conductors[1]
+        .call(
+            &bob.zome("administration"),
+            "put_motion",
+            motion_input.clone(),
+        )
+        .await;
+    let motion_hash = motion.signed_action.hashed.hash.clone();
+
+    await_consistency_s(20, [&alice, &bob, &carol, &dave])
+        .await
+        .unwrap();
+
+    let two_stewards = conductors[2]
+        .call_fallible::<_, Record>(
+            &carol.zome("administration"),
+            "concur",
+            motion_hash.clone(),
+        )
+        .await;
+    assert!(
+        two_stewards.is_err(),
+        "Two stewards should not carry a motion about an administrator"
+    );
+
+    // Alice holds both roles, so she is the administrator half of the pairing.
+    let _: Record = conductors[0]
+        .call(&alice.zome("administration"), "concur", motion_hash)
+        .await;
+
+    await_consistency_s(20, [&alice, &bob, &carol, &dave])
+        .await
+        .unwrap();
+
+    let dave_after: Option<Status> = conductors[2]
+        .call(
+            &carol.zome("administration"),
+            "get_latest_status_for_entity",
+            serde_json::json!({
+                "entity": ENTITY_USERS,
+                "entity_original_action_hash": dave_user
+            }),
+        )
+        .await;
+    let dave_after = dave_after.expect("Dave should have a status");
+    assert_eq!(
+        dave_after.status_type, "suspended indefinitely",
+        "An administrator with a steward should carry it"
+    );
+    assert!(
+        dave_after.suspended_until.is_none(),
+        "An indefinite suspension carries no end date"
+    );
+
+    // Return Dave to accepted so the next motion acts on a clean subject. Nothing in
+    // the zome refuses a motion against an already-suspended member; whether it should
+    // is a design question this test deliberately does not exercise.
+    let suspended_record: Option<Record> = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "get_latest_status_record_for_entity",
+            serde_json::json!({
+                "entity": ENTITY_USERS,
+                "entity_original_action_hash": dave_user
+            }),
+        )
+        .await;
+    let suspended_hash = suspended_record.unwrap().signed_action.hashed.hash.clone();
+
+    let _: bool = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "unsuspend_entity",
+            serde_json::json!({
+                "entity": ENTITY_USERS,
+                "entity_original_action_hash": dave_user,
+                "status_original_action_hash": dave_status_original,
+                "status_previous_action_hash": suspended_hash
+            }),
+        )
+        .await;
+
+    await_consistency_s(20, [&alice, &bob, &carol, &dave])
+        .await
+        .unwrap();
+
+    // Two administrators can act on a third without a steward. An administrator is
+    // answerable to their peers rather than unassailable.
+    let _: bool = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "add_administrator",
+            EntityActionHashAgents {
+                entity: ENTITY_NETWORK.to_string(),
+                entity_original_action_hash: hashes[2].clone(),
+                agent_pubkeys: vec![carol.agent_pubkey().clone()],
+            },
+        )
+        .await;
+
+    await_consistency_s(20, [&alice, &bob, &carol, &dave])
+        .await
+        .unwrap();
+
+    let second_motion: Record = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "put_motion",
+            serde_json::json!({
+                "kind": "suspension",
+                "entity": ENTITY_USERS,
+                "subject_agent": dave.agent_pubkey(),
+                "subject_entity_hash": dave_user,
+                "flavour": "temporary",
+                "duration_days": 7,
+                "reason": "Second motion, carried by two administrators"
+            }),
+        )
+        .await;
+    let second_hash = second_motion.signed_action.hashed.hash.clone();
+
+    await_consistency_s(20, [&alice, &bob, &carol, &dave])
+        .await
+        .unwrap();
+
+    let _: Record = conductors[2]
+        .call(&carol.zome("administration"), "concur", second_hash)
+        .await;
+
+    await_consistency_s(20, [&alice, &bob, &carol, &dave])
+        .await
+        .unwrap();
+
+    let dave_finally: Option<Status> = conductors[1]
+        .call(
+            &bob.zome("administration"),
+            "get_latest_status_for_entity",
+            serde_json::json!({
+                "entity": ENTITY_USERS,
+                "entity_original_action_hash": dave_user
+            }),
+        )
+        .await;
+    assert_eq!(
+        dave_finally.unwrap().status_type,
+        "suspended temporarily",
+        "Two administrators should carry a motion about a third"
+    );
+}

--- a/tests/sweettest/tests/administration/permission_management.rs
+++ b/tests/sweettest/tests/administration/permission_management.rs
@@ -1,0 +1,164 @@
+//! Named permission tests.
+//! Covers grant, revoke, the admin gate, and the deliberate absence of a
+//! last-holder guard.
+
+use holochain::prelude::*;
+use holochain::sweettest::*;
+use requests_and_offers_sweettest::common::*;
+
+// The coordinator crate cannot be imported here (it targets WASM), so the
+// permission name is repeated as a literal. It is `PERMISSION_STEWARD` in
+// `permissions.rs`.
+const PERMISSION_STEWARD: &str = "steward";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn grant_and_revoke_steward_permission() {
+    let (conductors, alice, bob) = setup_two_agents_with_alice_as_progenitor().await;
+
+    // Create users for both agents.
+    let _: Record = conductors[0]
+        .call(&alice.zome("users_organizations"), "create_user", sample_user("Alice"))
+        .await;
+    let _: Record = conductors[1]
+        .call(&bob.zome("users_organizations"), "create_user", sample_user("Bob"))
+        .await;
+
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    let alice_links: Vec<Link> = conductors[0]
+        .call(&alice.zome("users_organizations"), "get_agent_user", alice.agent_pubkey().clone())
+        .await;
+    let bob_links: Vec<Link> = conductors[1]
+        .call(&bob.zome("users_organizations"), "get_agent_user", bob.agent_pubkey().clone())
+        .await;
+
+    let alice_user_hash = alice_links[0].target.clone().into_action_hash().unwrap();
+    let bob_user_hash = bob_links[0].target.clone().into_action_hash().unwrap();
+
+    // Alice becomes network administrator.
+    let _: bool = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "add_administrator",
+            EntityActionHashAgents {
+                entity: ENTITY_NETWORK.to_string(),
+                entity_original_action_hash: alice_user_hash.clone(),
+                agent_pubkeys: vec![alice.agent_pubkey().clone()],
+            },
+        )
+        .await;
+
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    // Bob is not an administrator, so he cannot grant himself the permission.
+    let self_grant = conductors[1]
+        .call_fallible::<_, bool>(
+            &bob.zome("administration"),
+            "grant_permission",
+            serde_json::json!({
+                "permission": PERMISSION_STEWARD,
+                "holder_original_action_hash": bob_user_hash,
+                "agent_pubkeys": [bob.agent_pubkey()]
+            }),
+        )
+        .await;
+    assert!(self_grant.is_err(), "Non-admin should not grant a permission");
+
+    // Alice grants Bob the steward permission.
+    let _: bool = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "grant_permission",
+            serde_json::json!({
+                "permission": PERMISSION_STEWARD,
+                "holder_original_action_hash": bob_user_hash,
+                "agent_pubkeys": [bob.agent_pubkey()]
+            }),
+        )
+        .await;
+
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    // The roster is read from the other conductor, so this asserts the links
+    // gossiped rather than merely existing where they were written.
+    let roster: Vec<Link> = conductors[1]
+        .call(
+            &bob.zome("administration"),
+            "get_all_permission_holders_links",
+            PERMISSION_STEWARD,
+        )
+        .await;
+    assert_eq!(roster.len(), 1, "Roster should hold exactly one steward");
+    assert_eq!(
+        roster[0].target.clone().into_action_hash().unwrap(),
+        bob_user_hash,
+        "Roster entry should target Bob's user entity, not his agent key"
+    );
+
+    // The agent-keyed query uses a different link base, so it is a separate
+    // assertion rather than a restatement of the roster.
+    let bob_is_steward: bool = conductors[1]
+        .call(
+            &bob.zome("administration"),
+            "check_if_agent_has_permission",
+            serde_json::json!({
+                "permission": PERMISSION_STEWARD,
+                "agent_pubkey": bob.agent_pubkey()
+            }),
+        )
+        .await;
+    assert!(bob_is_steward, "Bob should hold the steward permission");
+
+    // Alice administers but does not steward. The check must not fall back to
+    // the administrator link.
+    let alice_is_steward: bool = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "check_if_agent_has_permission",
+            serde_json::json!({
+                "permission": PERMISSION_STEWARD,
+                "agent_pubkey": alice.agent_pubkey()
+            }),
+        )
+        .await;
+    assert!(
+        !alice_is_steward,
+        "An administrator should not implicitly hold the steward permission"
+    );
+
+    // Revoking the only holder is permitted: there is no last-holder guard.
+    let _: bool = conductors[0]
+        .call(
+            &alice.zome("administration"),
+            "revoke_permission",
+            serde_json::json!({
+                "permission": PERMISSION_STEWARD,
+                "holder_original_action_hash": bob_user_hash,
+                "agent_pubkeys": [bob.agent_pubkey()]
+            }),
+        )
+        .await;
+
+    await_consistency_s(15, [&alice, &bob]).await.unwrap();
+
+    let roster_after: Vec<Link> = conductors[1]
+        .call(
+            &bob.zome("administration"),
+            "get_all_permission_holders_links",
+            PERMISSION_STEWARD,
+        )
+        .await;
+    assert!(roster_after.is_empty(), "Roster should be empty after revocation");
+
+    let bob_still_steward: bool = conductors[1]
+        .call(
+            &bob.zome("administration"),
+            "check_if_agent_has_permission",
+            serde_json::json!({
+                "permission": PERMISSION_STEWARD,
+                "agent_pubkey": bob.agent_pubkey()
+            }),
+        )
+        .await;
+    assert!(!bob_still_steward, "Bob should not hold the permission after revocation");
+}


### PR DESCRIPTION
Draft for alpha 3. Design in STEWARDING_MANAGEMENT.md section 5.

A motion to suspend indefinitely takes a second steward's concurrence before it acts. A motion about an administrator needs an administrator to concur, so stewards alone cannot move against the progenitor and the progenitor alone cannot move against a steward.

Integrity and coordinator in concurrence.rs. Two Sweettests across three conductors, both passing. Sits on the named-permissions branch, which is held until the hdk 0.7 upgrade (#192).