### PR TITLE
fix(ui): serve symlinked node_modules so the e2e suite runs from a worktree

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,6 +1,21 @@
 import { purgeCss } from 'vite-plugin-tailwind-purgecss';
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig, type PluginOption } from 'vite';
+import { defineConfig, searchForWorkspaceRoot, type PluginOption } from 'vite';
+import { existsSync, realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// In a git worktree, `node_modules` is a symlink to the main checkout's copy.
+// Vite resolves symlinks to their real path before checking `server.fs.allow`,
+// so the SvelteKit client runtime is refused with "outside of Vite serving
+// allow list" and the app never boots. The page then hangs on the connection
+// gate with no JavaScript behind it.
+// Allowing the real path of whatever `node_modules` points at fixes worktrees
+// and is a no-op in a normal checkout, where the real path is already inside.
+const workspaceRoot = searchForWorkspaceRoot(process.cwd());
+const linkedNodeModules = ['node_modules', '../node_modules']
+  .map((p) => resolve(p))
+  .filter((p) => existsSync(p))
+  .map((p) => realpathSync(p));
 
 export default defineConfig({
   plugins: [sveltekit(), purgeCss()] as PluginOption[],
@@ -10,5 +25,8 @@ export default defineConfig({
     outDir: 'build'
   },
   base: './',
-  envDir: '../' // Look for .env files in the parent directory (project root)
+  envDir: '../', // Look for .env files in the parent directory (project root)
+  server: {
+    fs: { allow: [workspaceRoot, ...linkedNodeModules] }
+  }
 });


### PR DESCRIPTION
> **SoushAI analysis.** Drafted by Soushi's AI assistant, reviewed and posted by @Soushi888.

## Intent

**The end-to-end suite cannot run from a git worktree, and the failure is silent.** Found while verifying #175: every page hangs on "Connecting to Holochain Network" and the tests report missing elements rather than a dead app.

The cause is not Holochain. In a worktree, `node_modules` is a symlink to the main checkout's copy. Vite resolves symlinks to their real path *before* checking `server.fs.allow`, so it refuses to serve SvelteKit's own client runtime:

```
The request url ".../requests-and-offers/node_modules/@sveltejs/kit/src/runtime/client/entry.js"
is outside of Vite serving allow list.
```

No JavaScript loads, so the app never boots and never connects. What the browser shows is the static shell.

## Changes

`ui/vite.config.ts` gains a `server.fs.allow` list built from the real path of whatever `node_modules` actually points at, plus the workspace root:

```ts
const workspaceRoot = searchForWorkspaceRoot(process.cwd());
const linkedNodeModules = ['node_modules', '../node_modules']
  .map((p) => resolve(p))
  .filter((p) => existsSync(p))
  .map((p) => realpathSync(p));
```

It is computed, not hardcoded, so it carries no machine-specific path and is a no-op in a normal checkout where the real path already sits inside the root.

## Decisions

| Option | Rejected because |
|--------|-----------------|
| `resolve.preserveSymlinks: true` | Fixes the symptom by changing module resolution for the whole build, which is a much larger blast radius than a dev-server serving rule. |
| Give each worktree a real `bun install` | 1.2 GB per worktree, and it fixes nobody else's machine. The repo currently has seven worktrees. |
| Hardcode the parent path in `fs.allow` | Machine-specific and would break for anyone whose checkout lives elsewhere. |

`server.fs` affects only the dev server, so the production build is untouched.

## How to test

```bash
# From any git worktree of this repo:
cd ui && bun test:e2e:smoke
```

Before this change every route fails on the connection gate. After it, verified on `test/e2e-smoke-tests` with the #175 smoke layer:

```
✓ / mounts (3.2s)                ✓ /organizations mounts (2.4s)
✓ /service-types mounts (2.7s)   ✓ /users mounts (2.3s)
✓ /offers mounts (2.3s)          ✓ /admin mounts (2.4s)
✓ /requests mounts (2.2s)        ✓ /admin/hrea-test mounts (2.5s)
8 passed (1.2m)
```

The full journey suite is running against the same config.

## Documentation

No documentation change. `ui/tests/e2e/README.md` documents how to run the suite, not how the dev server resolves modules, and this makes the documented commands work rather than changing them.

## Related

Found while verifying #175. Related #222, which would have caught this the first time a worktree ran in CI.

**Worth knowing, and not fixed here.** The suite's first test, `00-onboarding` › `app loads and connects to conductor`, passed in 326ms against an app that had neither loaded nor connected. Its assertions are "a failure banner is hidden", which is true when the element does not exist, and "the URL has a port". Neither can fail while the app is dead, which is why this went unnoticed. That deserves its own fix, along with the e2e helper `waitForConnection`, which swallows its own timeout in a bare `catch {}` and so cannot distinguish an instant connection from no connection at all.
